### PR TITLE
fix(proto): message definition marshaler byte order

### DIFF
--- a/proto/marshaler.go
+++ b/proto/marshaler.go
@@ -63,7 +63,7 @@ func (m *MessageDefinition) MarshalBinary() ([]byte, error) {
 	b = append(b, m.Architecture)
 
 	globalMesgNum := make([]byte, 2)
-	binary.LittleEndian.PutUint16(globalMesgNum, uint16(m.MesgNum))
+	byteorder.Select(m.Architecture).PutUint16(globalMesgNum, uint16(m.MesgNum))
 	b = append(b, globalMesgNum...)
 
 	b = append(b, byte(len(m.FieldDefinitions)))


### PR DESCRIPTION
When marshaling message number, it should choose which byte order to use instead of using little endian.

Decoder code block as a reference:
https://github.com/muktihari/fit/blob/d78e0791daaa1f48adec2f5e46139719084c148f/decoder/decoder.go#L401