### PR TITLE
refactor: reduce memory allocs and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,24 @@
 [![CodeCov](https://codecov.io/gh/muktihari/fit/branch/master/graph/badge.svg)](https://codecov.io/gh/muktihari/fit)
 [![Go Report Card](https://goreportcard.com/badge/github.com/muktihari/fit)](https://goreportcard.com/report/github.com/muktihari/fit)
 
-The Flexible and Interoperable Data Transfer (FIT) protocol is a protocol developed by Garmin for storing and sharing data originating from sports, fitness, and health devices. 
-When recording an activity using devices such as cycling computer, smartwatch, and more, chances are the resulting file is often in FIT format (*.fit). 
-The FIT file is a binary file format known for its compact size, making it the preferred choice for manufacturers to be used in their embedded devices. 
+The Flexible and Interoperable Data Transfer (FIT) protocol is a protocol developed by Garmin for storing and sharing data originating from sports, fitness, and health devices.
+When recording an activity using devices such as cycling computer, smartwatch, and similiar devices, chances are the resulting file is often in FIT file format (\*.fit).
+The FIT file is a binary file format known for its compact size, making it the preferred choice for manufacturers to use in their embedded devices.
 However, despite having gained widespread adoption, Garmin has not yet released an official SDK for Go, this is where this SDK comes in to bridge the gap, enabling Go developers to be able to interact with FIT file format.
-
-This SDK is designed with efficiency in mind, but it places a higher priority on clarity, simplicity and extensibility.
 
 More about FIT: [developer.garmin.com/fit](https://developer.garmin.com/fit)
 
+This SDK is designed with efficiency in mind, but it places a higher priority on clarity, simplicity and extensibility.
+
 ## Usage
+
 Please see [Usage](/docs/usage.md).
 
 ## Generate Custom FIT SDK
+
 Please see [Generate Custom FIT SDK](/docs/generating_code.md#Generate-Custom-FIT-SDK)
 
 ## Contributing
+
 Please see [CONTRIBUTING.md](/CONTRIBUTING.md).
 Thank you, [contributors](https://github.com/muktihari/fit/graphs/contributors)!

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2023 The Fit SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package cmd provides CLIs to work with fit files.
+package cmd

--- a/cmd/fitconv/Makefile
+++ b/cmd/fitconv/Makefile
@@ -4,19 +4,19 @@ build:
 	go build -gcflags="-m=2" main.go
 
 run:
-	go build main.go
+	go build main.go -path $(path)
 	./main
 
 pprof:
 	go build main.go
-	./main -opt $(lastword $(MAKECMDGOALS))
-	go tool pprof -http=:8080 $(lastword $(MAKECMDGOALS)).pprof
+	./main -path $(path) -opt $(opt)
+	go tool pprof -http=:8080 $(opt).pprof
 
 trace:
 	go build main.go
-	./main -opt $(lastword $(MAKECMDGOALS))
-	go tool trace $(lastword $(MAKECMDGOALS)).out
+	./main -path $(path) -opt $(opt)
+	go tool trace $(opt).out
 	
 took:
 	go build main.go
-	./main -opt took
+	./main -path $(path) -opt took

--- a/cmd/fitconv/csv/converter.go
+++ b/cmd/fitconv/csv/converter.go
@@ -130,8 +130,13 @@ func (c *Conv) writeMesgDef(mesgDef proto.MessageDefinition) {
 	c.once.Do(func() { c.printHeader() })
 
 	c.buf.WriteString("Definition,")
-	c.buf.WriteString(strconv.Itoa(int(mesgDef.LocalMesgNum)) + ",")
-	c.buf.WriteString(mesgDef.MesgNum.String() + ",")
+	c.buf.WriteString(strconv.Itoa(int(proto.LocalMesgNum(mesgDef.Header))) + ",")
+	mesgName := mesgDef.MesgNum.String()
+	if mesgName == strconv.FormatInt(int64(mesgDef.MesgNum), 10) {
+		mesgName = factory.NameUnknown
+	}
+	c.buf.WriteString(mesgName)
+	c.buf.WriteRune(',')
 
 	for i := range mesgDef.FieldDefinitions {
 		fieldDef := mesgDef.FieldDefinitions[i]
@@ -186,8 +191,13 @@ func (c *Conv) writeMesg(mesg proto.Message) {
 	}
 
 	c.buf.WriteString("Data,")
-	c.buf.WriteString(strconv.Itoa(int(mesg.LocalNum)) + ",")
-	c.buf.WriteString(mesg.Num.String() + ",")
+	c.buf.WriteString(strconv.Itoa(int(proto.LocalMesgNum(mesg.Header))) + ",")
+	mesgName := mesg.Num.String()
+	if mesgName == strconv.FormatInt(int64(mesg.Num), 10) {
+		mesgName = factory.NameUnknown
+	}
+	c.buf.WriteString(mesgName)
+	c.buf.WriteRune(',')
 
 	for i := range mesg.Fields {
 		field := &mesg.Fields[i]
@@ -205,7 +215,7 @@ func (c *Conv) writeMesg(mesg proto.Message) {
 			c.buf.WriteByte(',')
 
 			c.buf.WriteByte('"')
-			for i := 0; i < len(vals); i++ {
+			for i := range vals {
 				value := vals[i]
 				if !c.debugUseRawValue {
 					value = scaleoffset.ApplyAny(vals[i], field.Scale, field.Offset)
@@ -263,7 +273,7 @@ func sliceAny(val any) (vals []any, isSlice bool) {
 	isSlice = true
 	switch vs := val.(type) {
 	case []int8:
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Sint8.Invalid() {
 				continue
 			}
@@ -271,7 +281,7 @@ func sliceAny(val any) (vals []any, isSlice bool) {
 		}
 		return
 	case []uint8:
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Uint8.Invalid() {
 				continue
 			}
@@ -279,7 +289,7 @@ func sliceAny(val any) (vals []any, isSlice bool) {
 		}
 		return
 	case []int16:
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Sint16.Invalid() {
 				continue
 			}
@@ -287,7 +297,7 @@ func sliceAny(val any) (vals []any, isSlice bool) {
 		}
 		return
 	case []uint16:
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Uint16.Invalid() {
 				continue
 			}
@@ -295,7 +305,7 @@ func sliceAny(val any) (vals []any, isSlice bool) {
 		}
 		return
 	case []int32:
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Sint32.Invalid() {
 				continue
 			}
@@ -303,7 +313,7 @@ func sliceAny(val any) (vals []any, isSlice bool) {
 		}
 		return
 	case []uint32:
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Uint32.Invalid() {
 				continue
 			}
@@ -311,7 +321,7 @@ func sliceAny(val any) (vals []any, isSlice bool) {
 		}
 		return
 	case []float32:
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if math.IsNaN(float64(vs[i])) {
 				continue
 			}
@@ -319,7 +329,7 @@ func sliceAny(val any) (vals []any, isSlice bool) {
 		}
 		return
 	case []float64:
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if math.IsNaN(float64(vs[i])) {
 				continue
 			}

--- a/cmd/fitconv/main.go
+++ b/cmd/fitconv/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bufio"
-	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -78,13 +77,14 @@ func main() {
 
 	bw := bufferedwriter.NewSize(cf, 1000<<10)
 	csvconv := csv.NewConverter(bw)
+
 	dec := decoder.New(bufio.NewReaderSize(ff, 1000<<10),
 		decoder.WithMesgDefListener(csvconv),
 		decoder.WithMesgListener(csvconv),
 		decoder.WithBroadcastOnly(),
 	)
 
-	_, err = dec.Decode(context.Background())
+	_, err = dec.Decode()
 	if err != nil {
 		fmt.Printf("decode failed: %v\n", err)
 		return

--- a/cmd/fitprint/main.go
+++ b/cmd/fitprint/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -52,7 +51,7 @@ func main() {
 		decoder.WithIgnoreChecksum(),
 	)
 
-	_, err = dec.Decode(context.Background())
+	_, err = dec.Decode()
 	if err != nil {
 		fatalf("could not decode: %v\n", err)
 	}
@@ -96,7 +95,7 @@ func (p *printer) Wait() {
 func (p *printer) OnMesg(mesg proto.Message) { p.eventch <- mesg }
 
 func (p *printer) writeMesg(mesg proto.Message) {
-	fmt.Fprintf(p.w, "%s:\n", mesg.Name)
+	fmt.Fprintf(p.w, "%s:\n", mesg.Num.String())
 	for i := range mesg.Fields {
 		fmt.Fprintf(p.w, "    %s: %v\n", mesg.Fields[i].Name, formatValue(&mesg.Fields[i]))
 	}

--- a/decoder/accumulator.go
+++ b/decoder/accumulator.go
@@ -17,7 +17,7 @@ func NewAccumulator() *Accumulator {
 }
 
 func (a *Accumulator) Collect(mesgNum typedef.MesgNum, destFieldNum byte, value int64) {
-	for i := 0; i < len(a.AccumulatedValues); i++ {
+	for i := range a.AccumulatedValues {
 		field := &a.AccumulatedValues[i]
 		if field.MesgNum == mesgNum && field.DestFieldNum == destFieldNum {
 			field.Value = value
@@ -34,7 +34,7 @@ func (a *Accumulator) Collect(mesgNum typedef.MesgNum, destFieldNum byte, value 
 }
 
 func (a *Accumulator) Accumulate(mesgNum typedef.MesgNum, destFieldNum byte, value int64, bits byte) int64 {
-	for i := 0; i < len(a.AccumulatedValues); i++ {
+	for i := range a.AccumulatedValues {
 		av := &a.AccumulatedValues[i]
 		if av.MesgNum == mesgNum && av.DestFieldNum == destFieldNum {
 			return av.Accumulate(value, bits)

--- a/decoder/doc.go
+++ b/decoder/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2023 The Fit SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package decoder provides a handler to decode fit files.
+//
+// Decoder supports decoding chained fit files for all fit protocol versions.
+package decoder

--- a/encoder/doc.go
+++ b/encoder/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2023 The Fit SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package encoder provides a handler to encode data into fit file binary form.
+//
+// Encoder supports encoding multiple data into a single chained fit file.
+package encoder

--- a/encoder/validator.go
+++ b/encoder/validator.go
@@ -77,7 +77,7 @@ type messageValidator struct {
 }
 
 func (v *messageValidator) Validate(mesg *proto.Message) error {
-	mesg.Header = MesgNormalHeaderMask // reset default
+	mesg.Header = proto.MesgNormalHeaderMask // reset default
 
 	fields := make([]proto.Field, 0, len(mesg.Fields))
 	for i := range mesg.Fields {
@@ -250,7 +250,7 @@ func hasValidValue(val any) bool {
 		return val != basetype.Uint64.Invalid()
 	case []int8:
 		invalidcounter := 0
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Sint8.Invalid() {
 				invalidcounter++
 			}
@@ -258,7 +258,7 @@ func hasValidValue(val any) bool {
 		return invalidcounter != len(vs)
 	case []uint8:
 		invalidcounter := 0
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Uint8.Invalid() {
 				invalidcounter++
 			}
@@ -266,7 +266,7 @@ func hasValidValue(val any) bool {
 		return invalidcounter != len(vs)
 	case []int16:
 		invalidcounter := 0
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Sint16.Invalid() {
 				invalidcounter++
 			}
@@ -274,7 +274,7 @@ func hasValidValue(val any) bool {
 		return invalidcounter != len(vs)
 	case []uint16:
 		invalidcounter := 0
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Uint16.Invalid() {
 				invalidcounter++
 			}
@@ -282,7 +282,7 @@ func hasValidValue(val any) bool {
 		return invalidcounter != len(vs)
 	case []int32:
 		invalidcounter := 0
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Sint32.Invalid() {
 				invalidcounter++
 			}
@@ -290,7 +290,7 @@ func hasValidValue(val any) bool {
 		return invalidcounter != len(vs)
 	case []uint32:
 		invalidcounter := 0
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Uint32.Invalid() {
 				invalidcounter++
 			}
@@ -298,7 +298,7 @@ func hasValidValue(val any) bool {
 		return invalidcounter != len(vs)
 	case []float32:
 		invalidcounter := 0
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if math.IsNaN(float64(vs[i])) {
 				invalidcounter++
 			}
@@ -306,7 +306,7 @@ func hasValidValue(val any) bool {
 		return invalidcounter != len(vs)
 	case []float64:
 		invalidcounter := 0
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if math.IsNaN(vs[i]) {
 				invalidcounter++
 			}
@@ -314,7 +314,7 @@ func hasValidValue(val any) bool {
 		return invalidcounter != len(vs)
 	case []int64:
 		invalidcounter := 0
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Sint64.Invalid() {
 				invalidcounter++
 			}
@@ -322,7 +322,7 @@ func hasValidValue(val any) bool {
 		return invalidcounter != len(vs)
 	case []uint64:
 		invalidcounter := 0
-		for i := 0; i < len(vs); i++ {
+		for i := range vs {
 			if vs[i] == basetype.Uint64.Invalid() {
 				invalidcounter++
 			}

--- a/factory/factory_gen.go
+++ b/factory/factory_gen.go
@@ -46,7 +46,7 @@ func (f *Factory) CreateMesg(num typedef.MesgNum) proto.Message {
 		return createUnknownMesg(num)
 	}
 
-	if f.mesgs[num].Name == "" {
+	if f.mesgs[num].Num != num {
 		return createUnknownMesg(num)
 	}
 
@@ -60,7 +60,7 @@ func (f *Factory) CreateMesgOnly(num typedef.MesgNum) proto.Message {
 		return createUnknownMesg(num)
 	}
 
-	if f.mesgs[num].Name == "" {
+	if f.mesgs[num].Num != num {
 		return createUnknownMesg(num)
 	}
 
@@ -72,7 +72,7 @@ func (f *Factory) CreateMesgOnly(num typedef.MesgNum) proto.Message {
 }
 
 func createUnknownMesg(num typedef.MesgNum) proto.Message {
-	return proto.Message{Name: NameUnknown, Num: num}
+	return proto.Message{Num: num}
 }
 
 // CreateField creates new field based on defined messages in the factory. If not found, it returns new field with "unknown" name.
@@ -84,7 +84,7 @@ func (f *Factory) CreateField(mesgNum typedef.MesgNum, num byte) proto.Field {
 		return createUnknownField(mesgNum, num)
 	}
 
-	if f.mesgs[mesgNum].Name == "" {
+	if f.mesgs[mesgNum].Num != mesgNum {
 		return createUnknownField(mesgNum, num)
 	}
 
@@ -122,8 +122,7 @@ func (f *Factory) RegisterMesg(mesg proto.Message) error {
 func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 	return []proto.Message{
 		typedef.MesgNumFileId: {
-			Name: "file_id",
-			Num:  typedef.MesgNumFileId,
+			Num: typedef.MesgNumFileId, /* file_id */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -250,8 +249,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumFileCreator: {
-			Name: "file_creator",
-			Num:  typedef.MesgNumFileCreator,
+			Num: typedef.MesgNumFileCreator, /* file_creator */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -287,8 +285,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumTimestampCorrelation: {
-			Name: "timestamp_correlation",
-			Num:  typedef.MesgNumTimestampCorrelation,
+			Num: typedef.MesgNumTimestampCorrelation, /* timestamp_correlation */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -399,8 +396,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSoftware: {
-			Name: "software",
-			Num:  typedef.MesgNumSoftware,
+			Num: typedef.MesgNumSoftware, /* software */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -451,8 +447,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSlaveDevice: {
-			Name: "slave_device",
-			Num:  typedef.MesgNumSlaveDevice,
+			Num: typedef.MesgNumSlaveDevice, /* slave_device */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -504,8 +499,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumCapabilities: {
-			Name: "capabilities",
-			Num:  typedef.MesgNumCapabilities,
+			Num: typedef.MesgNumCapabilities, /* capabilities */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -571,8 +565,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumFileCapabilities: {
-			Name: "file_capabilities",
-			Num:  typedef.MesgNumFileCapabilities,
+			Num: typedef.MesgNumFileCapabilities, /* file_capabilities */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -668,8 +661,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumMesgCapabilities: {
-			Name: "mesg_capabilities",
-			Num:  typedef.MesgNumMesgCapabilities,
+			Num: typedef.MesgNumMesgCapabilities, /* mesg_capabilities */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -769,8 +761,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumFieldCapabilities: {
-			Name: "field_capabilities",
-			Num:  typedef.MesgNumFieldCapabilities,
+			Num: typedef.MesgNumFieldCapabilities, /* field_capabilities */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -851,8 +842,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumDeviceSettings: {
-			Name: "device_settings",
-			Num:  typedef.MesgNumDeviceSettings,
+			Num: typedef.MesgNumDeviceSettings, /* device_settings */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -1218,8 +1208,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumUserProfile: {
-			Name: "user_profile",
-			Num:  typedef.MesgNumUserProfile,
+			Num: typedef.MesgNumUserProfile, /* user_profile */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -1660,8 +1649,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumHrmProfile: {
-			Name: "hrm_profile",
-			Num:  typedef.MesgNumHrmProfile,
+			Num: typedef.MesgNumHrmProfile, /* hrm_profile */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -1742,8 +1730,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSdmProfile: {
-			Name: "sdm_profile",
-			Num:  typedef.MesgNumSdmProfile,
+			Num: typedef.MesgNumSdmProfile, /* sdm_profile */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -1869,8 +1856,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumBikeProfile: {
-			Name: "bike_profile",
-			Num:  typedef.MesgNumBikeProfile,
+			Num: typedef.MesgNumBikeProfile, /* bike_profile */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -2356,8 +2342,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumConnectivity: {
-			Name: "connectivity",
-			Num:  typedef.MesgNumConnectivity,
+			Num: typedef.MesgNumConnectivity, /* connectivity */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -2558,8 +2543,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumWatchfaceSettings: {
-			Name: "watchface_settings",
-			Num:  typedef.MesgNumWatchfaceSettings,
+			Num: typedef.MesgNumWatchfaceSettings, /* watchface_settings */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -2623,8 +2607,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumOhrSettings: {
-			Name: "ohr_settings",
-			Num:  typedef.MesgNumOhrSettings,
+			Num: typedef.MesgNumOhrSettings, /* ohr_settings */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -2660,8 +2643,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumTimeInZone: {
-			Name: "time_in_zone",
-			Num:  typedef.MesgNumTimeInZone,
+			Num: typedef.MesgNumTimeInZone, /* time_in_zone */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -2922,8 +2904,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumZonesTarget: {
-			Name: "zones_target",
-			Num:  typedef.MesgNumZonesTarget,
+			Num: typedef.MesgNumZonesTarget, /* zones_target */
 			Fields: []proto.Field{
 				1: {
 					FieldBase: &proto.FieldBase{
@@ -3004,8 +2985,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSport: {
-			Name: "sport",
-			Num:  typedef.MesgNumSport,
+			Num: typedef.MesgNumSport, /* sport */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -3056,8 +3036,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumHrZone: {
-			Name: "hr_zone",
-			Num:  typedef.MesgNumHrZone,
+			Num: typedef.MesgNumHrZone, /* hr_zone */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -3108,8 +3087,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSpeedZone: {
-			Name: "speed_zone",
-			Num:  typedef.MesgNumSpeedZone,
+			Num: typedef.MesgNumSpeedZone, /* speed_zone */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -3160,8 +3138,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumCadenceZone: {
-			Name: "cadence_zone",
-			Num:  typedef.MesgNumCadenceZone,
+			Num: typedef.MesgNumCadenceZone, /* cadence_zone */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -3212,8 +3189,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumPowerZone: {
-			Name: "power_zone",
-			Num:  typedef.MesgNumPowerZone,
+			Num: typedef.MesgNumPowerZone, /* power_zone */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -3264,8 +3240,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumMetZone: {
-			Name: "met_zone",
-			Num:  typedef.MesgNumMetZone,
+			Num: typedef.MesgNumMetZone, /* met_zone */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -3331,8 +3306,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumDiveSettings: {
-			Name: "dive_settings",
-			Num:  typedef.MesgNumDiveSettings,
+			Num: typedef.MesgNumDiveSettings, /* dive_settings */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -3876,8 +3850,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumDiveAlarm: {
-			Name: "dive_alarm",
-			Num:  typedef.MesgNumDiveAlarm,
+			Num: typedef.MesgNumDiveAlarm, /* dive_alarm */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -4078,8 +4051,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumDiveApneaAlarm: {
-			Name: "dive_apnea_alarm",
-			Num:  typedef.MesgNumDiveApneaAlarm,
+			Num: typedef.MesgNumDiveApneaAlarm, /* dive_apnea_alarm */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -4280,8 +4252,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumDiveGas: {
-			Name: "dive_gas",
-			Num:  typedef.MesgNumDiveGas,
+			Num: typedef.MesgNumDiveGas, /* dive_gas */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -4362,8 +4333,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumGoal: {
-			Name: "goal",
-			Num:  typedef.MesgNumGoal,
+			Num: typedef.MesgNumGoal, /* goal */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -4564,8 +4534,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumActivity: {
-			Name: "activity",
-			Num:  typedef.MesgNumActivity,
+			Num: typedef.MesgNumActivity, /* activity */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -4691,8 +4660,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSession: {
-			Name: "session",
-			Num:  typedef.MesgNumSession,
+			Num: typedef.MesgNumSession, /* session */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -7055,8 +7023,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumLap: {
-			Name: "lap",
-			Num:  typedef.MesgNumLap,
+			Num: typedef.MesgNumLap, /* lap */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -8952,8 +8919,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumLength: {
-			Name: "length",
-			Num:  typedef.MesgNumLength,
+			Num: typedef.MesgNumLength, /* length */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -9293,8 +9259,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumRecord: {
-			Name: "record",
-			Num:  typedef.MesgNumRecord,
+			Num: typedef.MesgNumRecord, /* record */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -10573,8 +10538,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumEvent: {
-			Name: "event",
-			Num:  typedef.MesgNumEvent,
+			Num: typedef.MesgNumEvent, /* event */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -11027,8 +10991,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumDeviceInfo: {
-			Name: "device_info",
-			Num:  typedef.MesgNumDeviceInfo,
+			Num: typedef.MesgNumDeviceInfo, /* device_info */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -11360,8 +11323,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumDeviceAuxBatteryInfo: {
-			Name: "device_aux_battery_info",
-			Num:  typedef.MesgNumDeviceAuxBatteryInfo,
+			Num: typedef.MesgNumDeviceAuxBatteryInfo, /* device_aux_battery_info */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -11442,8 +11404,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumTrainingFile: {
-			Name: "training_file",
-			Num:  typedef.MesgNumTrainingFile,
+			Num: typedef.MesgNumTrainingFile, /* training_file */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -11555,8 +11516,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumWeatherConditions: {
-			Name: "weather_conditions",
-			Num:  typedef.MesgNumWeatherConditions,
+			Num: typedef.MesgNumWeatherConditions, /* weather_conditions */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -11802,8 +11762,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumWeatherAlert: {
-			Name: "weather_alert",
-			Num:  typedef.MesgNumWeatherAlert,
+			Num: typedef.MesgNumWeatherAlert, /* weather_alert */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -11899,8 +11858,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumGpsMetadata: {
-			Name: "gps_metadata",
-			Num:  typedef.MesgNumGpsMetadata,
+			Num: typedef.MesgNumGpsMetadata, /* gps_metadata */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -12041,8 +11999,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumCameraEvent: {
-			Name: "camera_event",
-			Num:  typedef.MesgNumCameraEvent,
+			Num: typedef.MesgNumCameraEvent, /* camera_event */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -12123,8 +12080,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumGyroscopeData: {
-			Name: "gyroscope_data",
-			Num:  typedef.MesgNumGyroscopeData,
+			Num: typedef.MesgNumGyroscopeData, /* gyroscope_data */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -12265,8 +12221,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumAccelerometerData: {
-			Name: "accelerometer_data",
-			Num:  typedef.MesgNumAccelerometerData,
+			Num: typedef.MesgNumAccelerometerData, /* accelerometer_data */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -12452,8 +12407,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumMagnetometerData: {
-			Name: "magnetometer_data",
-			Num:  typedef.MesgNumMagnetometerData,
+			Num: typedef.MesgNumMagnetometerData, /* magnetometer_data */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -12594,8 +12548,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumBarometerData: {
-			Name: "barometer_data",
-			Num:  typedef.MesgNumBarometerData,
+			Num: typedef.MesgNumBarometerData, /* barometer_data */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -12661,8 +12614,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumThreeDSensorCalibration: {
-			Name: "three_d_sensor_calibration",
-			Num:  typedef.MesgNumThreeDSensorCalibration,
+			Num: typedef.MesgNumThreeDSensorCalibration, /* three_d_sensor_calibration */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -12786,8 +12738,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumOneDSensorCalibration: {
-			Name: "one_d_sensor_calibration",
-			Num:  typedef.MesgNumOneDSensorCalibration,
+			Num: typedef.MesgNumOneDSensorCalibration, /* one_d_sensor_calibration */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -12890,8 +12841,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumVideoFrame: {
-			Name: "video_frame",
-			Num:  typedef.MesgNumVideoFrame,
+			Num: typedef.MesgNumVideoFrame, /* video_frame */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -12942,8 +12892,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumObdiiData: {
-			Name: "obdii_data",
-			Num:  typedef.MesgNumObdiiData,
+			Num: typedef.MesgNumObdiiData, /* obdii_data */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -13084,8 +13033,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumNmeaSentence: {
-			Name: "nmea_sentence",
-			Num:  typedef.MesgNumNmeaSentence,
+			Num: typedef.MesgNumNmeaSentence, /* nmea_sentence */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -13136,8 +13084,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumAviationAttitude: {
-			Name: "aviation_attitude",
-			Num:  typedef.MesgNumAviationAttitude,
+			Num: typedef.MesgNumAviationAttitude, /* aviation_attitude */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -13323,8 +13270,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumVideo: {
-			Name: "video",
-			Num:  typedef.MesgNumVideo,
+			Num: typedef.MesgNumVideo, /* video */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -13375,8 +13321,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumVideoTitle: {
-			Name: "video_title",
-			Num:  typedef.MesgNumVideoTitle,
+			Num: typedef.MesgNumVideoTitle, /* video_title */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -13427,8 +13372,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumVideoDescription: {
-			Name: "video_description",
-			Num:  typedef.MesgNumVideoDescription,
+			Num: typedef.MesgNumVideoDescription, /* video_description */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -13479,8 +13423,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumVideoClip: {
-			Name: "video_clip",
-			Num:  typedef.MesgNumVideoClip,
+			Num: typedef.MesgNumVideoClip, /* video_clip */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -13591,8 +13534,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSet: {
-			Name: "set",
-			Num:  typedef.MesgNumSet,
+			Num: typedef.MesgNumSet, /* set */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -13763,8 +13705,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumJump: {
-			Name: "jump",
-			Num:  typedef.MesgNumJump,
+			Num: typedef.MesgNumJump, /* jump */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -13922,8 +13863,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSplit: {
-			Name: "split",
-			Num:  typedef.MesgNumSplit,
+			Num: typedef.MesgNumSplit, /* split */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -14004,8 +13944,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumClimbPro: {
-			Name: "climb_pro",
-			Num:  typedef.MesgNumClimbPro,
+			Num: typedef.MesgNumClimbPro, /* climb_pro */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -14116,8 +14055,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumFieldDescription: {
-			Name: "field_description",
-			Num:  typedef.MesgNumFieldDescription,
+			Num: typedef.MesgNumFieldDescription, /* field_description */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -14333,8 +14271,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumDeveloperDataId: {
-			Name: "developer_data_id",
-			Num:  typedef.MesgNumDeveloperDataId,
+			Num: typedef.MesgNumDeveloperDataId, /* developer_data_id */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -14415,8 +14352,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumCourse: {
-			Name: "course",
-			Num:  typedef.MesgNumCourse,
+			Num: typedef.MesgNumCourse, /* course */
 			Fields: []proto.Field{
 				4: {
 					FieldBase: &proto.FieldBase{
@@ -14482,8 +14418,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumCoursePoint: {
-			Name: "course_point",
-			Num:  typedef.MesgNumCoursePoint,
+			Num: typedef.MesgNumCoursePoint, /* course_point */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -14609,8 +14544,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSegmentId: {
-			Name: "segment_id",
-			Num:  typedef.MesgNumSegmentId,
+			Num: typedef.MesgNumSegmentId, /* segment_id */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -14751,8 +14685,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSegmentLeaderboardEntry: {
-			Name: "segment_leaderboard_entry",
-			Num:  typedef.MesgNumSegmentLeaderboardEntry,
+			Num: typedef.MesgNumSegmentLeaderboardEntry, /* segment_leaderboard_entry */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -14863,8 +14796,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSegmentPoint: {
-			Name: "segment_point",
-			Num:  typedef.MesgNumSegmentPoint,
+			Num: typedef.MesgNumSegmentPoint, /* segment_point */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -14977,8 +14909,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSegmentLap: {
-			Name: "segment_lap",
-			Num:  typedef.MesgNumSegmentLap,
+			Num: typedef.MesgNumSegmentLap, /* segment_lap */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -16422,8 +16353,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSegmentFile: {
-			Name: "segment_file",
-			Num:  typedef.MesgNumSegmentFile,
+			Num: typedef.MesgNumSegmentFile, /* segment_file */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -16564,8 +16494,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumWorkout: {
-			Name: "workout",
-			Num:  typedef.MesgNumWorkout,
+			Num: typedef.MesgNumWorkout, /* workout */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -16691,8 +16620,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumWorkoutSession: {
-			Name: "workout_session",
-			Num:  typedef.MesgNumWorkoutSession,
+			Num: typedef.MesgNumWorkoutSession, /* workout_session */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -16803,8 +16731,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumWorkoutStep: {
-			Name: "workout_step",
-			Num:  typedef.MesgNumWorkoutStep,
+			Num: typedef.MesgNumWorkoutStep, /* workout_step */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -17348,8 +17275,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumExerciseTitle: {
-			Name: "exercise_title",
-			Num:  typedef.MesgNumExerciseTitle,
+			Num: typedef.MesgNumExerciseTitle, /* exercise_title */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -17415,8 +17341,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSchedule: {
-			Name: "schedule",
-			Num:  typedef.MesgNumSchedule,
+			Num: typedef.MesgNumSchedule, /* schedule */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -17543,8 +17468,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumTotals: {
-			Name: "totals",
-			Num:  typedef.MesgNumTotals,
+			Num: typedef.MesgNumTotals, /* totals */
 			Fields: []proto.Field{
 				254: {
 					FieldBase: &proto.FieldBase{
@@ -17700,8 +17624,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumWeightScale: {
-			Name: "weight_scale",
-			Num:  typedef.MesgNumWeightScale,
+			Num: typedef.MesgNumWeightScale, /* weight_scale */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -17917,8 +17840,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumBloodPressure: {
-			Name: "blood_pressure",
-			Num:  typedef.MesgNumBloodPressure,
+			Num: typedef.MesgNumBloodPressure, /* blood_pressure */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -18089,8 +18011,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumMonitoringInfo: {
-			Name: "monitoring_info",
-			Num:  typedef.MesgNumMonitoringInfo,
+			Num: typedef.MesgNumMonitoringInfo, /* monitoring_info */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -18186,8 +18107,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumMonitoring: {
-			Name: "monitoring",
-			Num:  typedef.MesgNumMonitoring,
+			Num: typedef.MesgNumMonitoring, /* monitoring */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -18646,8 +18566,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumMonitoringHrData: {
-			Name: "monitoring_hr_data",
-			Num:  typedef.MesgNumMonitoringHrData,
+			Num: typedef.MesgNumMonitoringHrData, /* monitoring_hr_data */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -18698,8 +18617,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSpo2Data: {
-			Name: "spo2_data",
-			Num:  typedef.MesgNumSpo2Data,
+			Num: typedef.MesgNumSpo2Data, /* spo2_data */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -18765,8 +18683,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumHr: {
-			Name: "hr",
-			Num:  typedef.MesgNumHr,
+			Num: typedef.MesgNumHr, /* hr */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -18875,8 +18792,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumStressLevel: {
-			Name: "stress_level",
-			Num:  typedef.MesgNumStressLevel,
+			Num: typedef.MesgNumStressLevel, /* stress_level */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -18912,8 +18828,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumMaxMetData: {
-			Name: "max_met_data",
-			Num:  typedef.MesgNumMaxMetData,
+			Num: typedef.MesgNumMaxMetData, /* max_met_data */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -19039,8 +18954,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumMemoGlob: {
-			Name: "memo_glob",
-			Num:  typedef.MesgNumMemoGlob,
+			Num: typedef.MesgNumMemoGlob, /* memo_glob */
 			Fields: []proto.Field{
 				250: {
 					FieldBase: &proto.FieldBase{
@@ -19136,8 +19050,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSleepLevel: {
-			Name: "sleep_level",
-			Num:  typedef.MesgNumSleepLevel,
+			Num: typedef.MesgNumSleepLevel, /* sleep_level */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -19173,8 +19086,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumAntChannelId: {
-			Name: "ant_channel_id",
-			Num:  typedef.MesgNumAntChannelId,
+			Num: typedef.MesgNumAntChannelId, /* ant_channel_id */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -19255,8 +19167,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumAntRx: {
-			Name: "ant_rx",
-			Num:  typedef.MesgNumAntRx,
+			Num: typedef.MesgNumAntRx, /* ant_rx */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -19362,8 +19273,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumAntTx: {
-			Name: "ant_tx",
-			Num:  typedef.MesgNumAntTx,
+			Num: typedef.MesgNumAntTx, /* ant_tx */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -19469,8 +19379,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumExdScreenConfiguration: {
-			Name: "exd_screen_configuration",
-			Num:  typedef.MesgNumExdScreenConfiguration,
+			Num: typedef.MesgNumExdScreenConfiguration, /* exd_screen_configuration */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -19536,8 +19445,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumExdDataFieldConfiguration: {
-			Name: "exd_data_field_configuration",
-			Num:  typedef.MesgNumExdDataFieldConfiguration,
+			Num: typedef.MesgNumExdDataFieldConfiguration, /* exd_data_field_configuration */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -19636,8 +19544,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumExdDataConceptConfiguration: {
-			Name: "exd_data_concept_configuration",
-			Num:  typedef.MesgNumExdDataConceptConfiguration,
+			Num: typedef.MesgNumExdDataConceptConfiguration, /* exd_data_concept_configuration */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -19811,8 +19718,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumDiveSummary: {
-			Name: "dive_summary",
-			Num:  typedef.MesgNumDiveSummary,
+			Num: typedef.MesgNumDiveSummary, /* dive_summary */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -20163,8 +20069,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumHrv: {
-			Name: "hrv",
-			Num:  typedef.MesgNumHrv,
+			Num: typedef.MesgNumHrv, /* hrv */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -20185,8 +20090,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumBeatIntervals: {
-			Name: "beat_intervals",
-			Num:  typedef.MesgNumBeatIntervals,
+			Num: typedef.MesgNumBeatIntervals, /* beat_intervals */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -20237,8 +20141,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumHrvStatusSummary: {
-			Name: "hrv_status_summary",
-			Num:  typedef.MesgNumHrvStatusSummary,
+			Num: typedef.MesgNumHrvStatusSummary, /* hrv_status_summary */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -20364,8 +20267,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumHrvValue: {
-			Name: "hrv_value",
-			Num:  typedef.MesgNumHrvValue,
+			Num: typedef.MesgNumHrvValue, /* hrv_value */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -20401,8 +20303,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumRespirationRate: {
-			Name: "respiration_rate",
-			Num:  typedef.MesgNumRespirationRate,
+			Num: typedef.MesgNumRespirationRate, /* respiration_rate */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -20438,8 +20339,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumTankUpdate: {
-			Name: "tank_update",
-			Num:  typedef.MesgNumTankUpdate,
+			Num: typedef.MesgNumTankUpdate, /* tank_update */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -20490,8 +20390,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumTankSummary: {
-			Name: "tank_summary",
-			Num:  typedef.MesgNumTankSummary,
+			Num: typedef.MesgNumTankSummary, /* tank_summary */
 			Fields: []proto.Field{
 				253: {
 					FieldBase: &proto.FieldBase{
@@ -20572,8 +20471,7 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			DeveloperFields: nil,
 		},
 		typedef.MesgNumSleepAssessment: {
-			Name: "sleep_assessment",
-			Num:  typedef.MesgNumSleepAssessment,
+			Num: typedef.MesgNumSleepAssessment, /* sleep_assessment */
 			Fields: []proto.Field{
 				0: {
 					FieldBase: &proto.FieldBase{
@@ -20788,6 +20686,6 @@ func predefinedMessages() []proto.Message { // Use slice to ensure O(1) lookup
 			},
 			DeveloperFields: nil,
 		},
-		{Name: "mfg_range_min", Num: 0xFF00}, {Name: "mfg_range_min", Num: 0xFFFE}, /* 0xFF00 - 0xFFFE reserved for manufacturer specific messages */
+		{Num: 0xFF00 /* mfg_range_min */}, {Num: 0xFFFE /* mfg_range_min */}, /* 0xFF00 - 0xFFFE reserved for manufacturer specific messages */
 	}
 }

--- a/internal/cmd/fitgen/factory/builder.go
+++ b/internal/cmd/fitgen/factory/builder.go
@@ -132,14 +132,13 @@ func (b *factoryBuilder) Build() ([]builder.Data, error) {
 	strbuf.WriteString("[]proto.Message{\n")
 	for _, message := range b.messages {
 		strbuf.WriteString(b.transformMesgnum(message.Name) + ": {\n") // indexed to create fixed-size slice.
-		strbuf.WriteString(fmt.Sprintf("Name: %q,\n", message.Name))
-		strbuf.WriteString(fmt.Sprintf("Num: %s,\n", b.transformMesgnum(message.Name)))
+		strbuf.WriteString(fmt.Sprintf("Num: %s, /* %s */\n", b.transformMesgnum(message.Name), message.Name))
 		strbuf.WriteString(fmt.Sprintf("Fields: %s,\n", b.makeFields(message)))
 		strbuf.WriteString("DeveloperFields: nil,\n") // default nil
 		strbuf.WriteString("},\n")
 	}
 
-	strbuf.WriteString(fmt.Sprintf("{Name: \"mfg_range_min\", Num: %s},{Name: \"mfg_range_min\", Num: %s} %s,\n",
+	strbuf.WriteString(fmt.Sprintf("{Num: %s /* mfg_range_min */},{Num: %s /* mfg_range_min */} %s,\n",
 		b.valueMapByTypeNameByValueName["mesg_num"]["mfg_range_min"].Value,
 		b.valueMapByTypeNameByValueName["mesg_num"]["mfg_range_max"].Value,
 		"/* 0xFF00 - 0xFFFE reserved for manufacturer specific messages */"))

--- a/internal/cmd/fitgen/factory/factory.tmpl
+++ b/internal/cmd/fitgen/factory/factory.tmpl
@@ -54,7 +54,7 @@ func (f *Factory) CreateMesg(num typedef.MesgNum) proto.Message {
 		return createUnknownMesg(num)
 	}
 	
-	if f.mesgs[num].Name == "" {
+	if f.mesgs[num].Num != num {
 		return createUnknownMesg(num)
 	}
 
@@ -67,7 +67,7 @@ func (f *Factory) CreateMesgOnly(num typedef.MesgNum) proto.Message {
 		return createUnknownMesg(num)
 	}
 
-	if f.mesgs[num].Name == "" {
+	if f.mesgs[num].Num != num {
 		return createUnknownMesg(num)
 	}
 
@@ -79,7 +79,7 @@ func (f *Factory) CreateMesgOnly(num typedef.MesgNum) proto.Message {
 }
 
 func createUnknownMesg(num typedef.MesgNum) proto.Message {
-	return proto.Message{Name: NameUnknown, Num: num}
+	return proto.Message{Num: num}
 }
 
 {{ template "create_field_doc" -}}
@@ -88,7 +88,7 @@ func (f *Factory) CreateField(mesgNum typedef.MesgNum, num byte) proto.Field {
 		return createUnknownField(mesgNum, num)
 	}
 
-	if f.mesgs[mesgNum].Name == "" {
+	if f.mesgs[mesgNum].Num != mesgNum {
 		return createUnknownField(mesgNum, num)
 	}
 

--- a/internal/cmd/fitgen/pkg/strutil/strutil.go
+++ b/internal/cmd/fitgen/pkg/strutil/strutil.go
@@ -81,7 +81,7 @@ func TrimRepeatedChar(s string, char rune) string {
 	}
 	var last byte
 	var strbuf = new(strings.Builder)
-	for i := 0; i < len(s); i++ {
+	for i := range s {
 		c := s[i]
 		if c != last || rune(c) != char {
 			last = c

--- a/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
+++ b/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
@@ -25,11 +25,11 @@ type {{ .Name }} struct {
 	{{ .Name }} {{ .Type }} {{ if .Comment }} // {{ .Comment }} {{ end }}
 	{{ end }}
 
-	{{ if and (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
+	{{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription")) }}
 	// Developer Fields are dynamic, can't be mapped as struct's fields. 
 	// [Added since protocol version 2.0]
 	DeveloperFields []proto.DeveloperField
-	{{ end }}
+	{{- end -}}
 }
 
 // New{{ .Name }} creates new {{ .Name }} struct based on given mesg. If mesg is nil or mesg.Num is not equal to {{ .Name }} mesg number, it will return nil.
@@ -44,7 +44,7 @@ func New{{ .Name }}(mesg proto.Message) *{{ .Name }} {
 		{{ end -}}
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}
@@ -56,7 +56,7 @@ func New{{ .Name }}(mesg proto.Message) *{{ .Name }} {
 			{{ .Name }}: {{ .AssignedValue }},
 		{{ end -}}
 
-		{{ if and (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
+		{{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
 		DeveloperFields: mesg.DeveloperFields,
 		{{ end }}
 	}
@@ -85,7 +85,7 @@ func (m {{ .Name }}) PutMessage(mesg *proto.Message) {
 		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
 	}
 
-	{{- if and (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
+	{{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
 	mesg.DeveloperFields = m.DeveloperFields
 	{{ end }}
 }

--- a/internal/cmd/testgen/big_activity.go
+++ b/internal/cmd/testgen/big_activity.go
@@ -94,7 +94,7 @@ func createBigActivityFile(ctx context.Context) error {
 	defer bw.Flush()
 
 	enc := encoder.New(bw)
-	if err := enc.Encode(context.Background(), fit); err != nil {
+	if err := enc.EncodeWithContext(context.Background(), fit); err != nil {
 		return err
 	}
 

--- a/internal/cmd/testgen/main.go
+++ b/internal/cmd/testgen/main.go
@@ -81,7 +81,7 @@ func createValidFitOnlyContainFileId(ctx context.Context) error {
 	)
 
 	enc := encoder.New(bufferedwriter.New(f))
-	if err := enc.Encode(ctx, fit); err != nil {
+	if err := enc.EncodeWithContext(ctx, fit); err != nil {
 		return err
 	}
 

--- a/kit/doc.go
+++ b/kit/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2023 The Fit SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package kit provides helpers for decoding and encoding as well as type conversion.
+package kit

--- a/kit/scaleoffset/scaleoffset.go
+++ b/kit/scaleoffset/scaleoffset.go
@@ -21,7 +21,7 @@ func Apply[T Numeric](value T, scale, offset float64) float64 {
 // Apply applies scale and offset on slice values.
 func ApplySlice[S []E, E Numeric](values S, scale, offset float64) []float64 {
 	vals := make([]float64, 0, len(values))
-	for i := 0; i < len(values); i++ {
+	for i := range values {
 		vals = append(vals, Apply[E](values[i], scale, offset))
 	}
 	return vals
@@ -91,7 +91,7 @@ func Discard(value, scale, offset float64) float64 {
 // DiscardSlice discards applied scale and offset on slice values.
 func DiscardSlice[E Numeric](values []float64, scale, offset float64) []E {
 	vals := make([]E, 0, len(values))
-	for i := 0; i < len(values); i++ {
+	for i := range values {
 		if scale == 1 && offset == 0 {
 			vals = append(vals, E(values[i]))
 			continue

--- a/profile/mesgdef/accelerometer_data_gen.go
+++ b/profile/mesgdef/accelerometer_data_gen.go
@@ -55,7 +55,7 @@ func NewAccelerometerData(mesg proto.Message) *AccelerometerData {
 		10:  nil,                    /* CompressedCalibratedAccelZ */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/activity_gen.go
+++ b/profile/mesgdef/activity_gen.go
@@ -47,7 +47,7 @@ func NewActivity(mesg proto.Message) *Activity {
 		6:   basetype.Uint8Invalid,  /* EventGroup */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/ant_channel_id_gen.go
+++ b/profile/mesgdef/ant_channel_id_gen.go
@@ -41,7 +41,7 @@ func NewAntChannelId(mesg proto.Message) *AntChannelId {
 		4: basetype.Uint8Invalid,   /* DeviceIndex */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/ant_rx_gen.go
+++ b/profile/mesgdef/ant_rx_gen.go
@@ -43,7 +43,7 @@ func NewAntRx(mesg proto.Message) *AntRx {
 		4:   nil,                    /* Data */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/ant_tx_gen.go
+++ b/profile/mesgdef/ant_tx_gen.go
@@ -43,7 +43,7 @@ func NewAntTx(mesg proto.Message) *AntTx {
 		4:   nil,                    /* Data */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/aviation_attitude_gen.go
+++ b/profile/mesgdef/aviation_attitude_gen.go
@@ -55,7 +55,7 @@ func NewAviationAttitude(mesg proto.Message) *AviationAttitude {
 		10:  nil,                    /* Validity */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/barometer_data_gen.go
+++ b/profile/mesgdef/barometer_data_gen.go
@@ -39,7 +39,7 @@ func NewBarometerData(mesg proto.Message) *BarometerData {
 		2:   nil,                    /* BaroPres */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/beat_intervals_gen.go
+++ b/profile/mesgdef/beat_intervals_gen.go
@@ -37,7 +37,7 @@ func NewBeatIntervals(mesg proto.Message) *BeatIntervals {
 		1:   nil,                    /* Time */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/bike_profile_gen.go
+++ b/profile/mesgdef/bike_profile_gen.go
@@ -95,7 +95,7 @@ func NewBikeProfile(mesg proto.Message) *BikeProfile {
 		44:  false,                   /* ShimanoDi2Enabled */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/blood_pressure_gen.go
+++ b/profile/mesgdef/blood_pressure_gen.go
@@ -53,7 +53,7 @@ func NewBloodPressure(mesg proto.Message) *BloodPressure {
 		9:   basetype.Uint16Invalid, /* UserProfileIndex */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/cadence_zone_gen.go
+++ b/profile/mesgdef/cadence_zone_gen.go
@@ -37,7 +37,7 @@ func NewCadenceZone(mesg proto.Message) *CadenceZone {
 		1:   basetype.StringInvalid, /* Name */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/camera_event_gen.go
+++ b/profile/mesgdef/camera_event_gen.go
@@ -41,7 +41,7 @@ func NewCameraEvent(mesg proto.Message) *CameraEvent {
 		3:   basetype.EnumInvalid,   /* CameraOrientation */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/capabilities_gen.go
+++ b/profile/mesgdef/capabilities_gen.go
@@ -39,7 +39,7 @@ func NewCapabilities(mesg proto.Message) *Capabilities {
 		23: basetype.Uint32zInvalid, /* ConnectivitySupported */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/climb_pro_gen.go
+++ b/profile/mesgdef/climb_pro_gen.go
@@ -46,7 +46,7 @@ func NewClimbPro(mesg proto.Message) *ClimbPro {
 		5:   math.Float32frombits(basetype.Float32Invalid), /* CurrentDist */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/connectivity_gen.go
+++ b/profile/mesgdef/connectivity_gen.go
@@ -57,7 +57,7 @@ func NewConnectivity(mesg proto.Message) *Connectivity {
 		12: false,                  /* GrouptrackEnabled */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/course_gen.go
+++ b/profile/mesgdef/course_gen.go
@@ -39,7 +39,7 @@ func NewCourse(mesg proto.Message) *Course {
 		7: basetype.EnumInvalid,    /* SubSport */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/course_point_gen.go
+++ b/profile/mesgdef/course_point_gen.go
@@ -47,7 +47,7 @@ func NewCoursePoint(mesg proto.Message) *CoursePoint {
 		8:   false,                  /* Favorite */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/developer_data_id_gen.go
+++ b/profile/mesgdef/developer_data_id_gen.go
@@ -37,7 +37,7 @@ func NewDeveloperDataId(mesg proto.Message) *DeveloperDataId {
 		4: basetype.Uint32Invalid, /* ApplicationVersion */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/device_aux_battery_info_gen.go
+++ b/profile/mesgdef/device_aux_battery_info_gen.go
@@ -41,7 +41,7 @@ func NewDeviceAuxBatteryInfo(mesg proto.Message) *DeviceAuxBatteryInfo {
 		3:   basetype.Uint8Invalid,  /* BatteryIdentifier */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/device_info_gen.go
+++ b/profile/mesgdef/device_info_gen.go
@@ -69,7 +69,7 @@ func NewDeviceInfo(mesg proto.Message) *DeviceInfo {
 		32:  basetype.Uint8Invalid,   /* BatteryLevel */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/device_settings_gen.go
+++ b/profile/mesgdef/device_settings_gen.go
@@ -79,7 +79,7 @@ func NewDeviceSettings(mesg proto.Message) *DeviceSettings {
 		174: basetype.EnumInvalid,   /* TapSensitivity */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/dive_alarm_gen.go
+++ b/profile/mesgdef/dive_alarm_gen.go
@@ -57,7 +57,7 @@ func NewDiveAlarm(mesg proto.Message) *DiveAlarm {
 		11:  basetype.Sint32Invalid, /* Speed */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/dive_apnea_alarm_gen.go
+++ b/profile/mesgdef/dive_apnea_alarm_gen.go
@@ -57,7 +57,7 @@ func NewDiveApneaAlarm(mesg proto.Message) *DiveApneaAlarm {
 		11:  basetype.Sint32Invalid, /* Speed */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/dive_gas_gen.go
+++ b/profile/mesgdef/dive_gas_gen.go
@@ -41,7 +41,7 @@ func NewDiveGas(mesg proto.Message) *DiveGas {
 		3:   basetype.EnumInvalid,   /* Mode */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/dive_settings_gen.go
+++ b/profile/mesgdef/dive_settings_gen.go
@@ -102,7 +102,7 @@ func NewDiveSettings(mesg proto.Message) *DiveSettings {
 		37:  basetype.EnumInvalid,                          /* NoFlyTimeMode */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/dive_summary_gen.go
+++ b/profile/mesgdef/dive_summary_gen.go
@@ -77,7 +77,7 @@ func NewDiveSummary(mesg proto.Message) *DiveSummary {
 		25:  basetype.Uint32Invalid, /* HangTime */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/event_gen.go
+++ b/profile/mesgdef/event_gen.go
@@ -69,7 +69,7 @@ func NewEvent(mesg proto.Message) *Event {
 		24:  basetype.Uint8Invalid,  /* RadarThreatMaxApproachSpeed */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/exd_data_concept_configuration_gen.go
+++ b/profile/mesgdef/exd_data_concept_configuration_gen.go
@@ -53,7 +53,7 @@ func NewExdDataConceptConfiguration(mesg proto.Message) *ExdDataConceptConfigura
 		11: false,                 /* IsSigned */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/exd_data_field_configuration_gen.go
+++ b/profile/mesgdef/exd_data_field_configuration_gen.go
@@ -43,7 +43,7 @@ func NewExdDataFieldConfiguration(mesg proto.Message) *ExdDataFieldConfiguration
 		5: nil,                   /* Title */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/exd_screen_configuration_gen.go
+++ b/profile/mesgdef/exd_screen_configuration_gen.go
@@ -39,7 +39,7 @@ func NewExdScreenConfiguration(mesg proto.Message) *ExdScreenConfiguration {
 		3: false,                 /* ScreenEnabled */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/exercise_title_gen.go
+++ b/profile/mesgdef/exercise_title_gen.go
@@ -39,7 +39,7 @@ func NewExerciseTitle(mesg proto.Message) *ExerciseTitle {
 		2:   nil,                    /* WktStepName */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/field_capabilities_gen.go
+++ b/profile/mesgdef/field_capabilities_gen.go
@@ -41,7 +41,7 @@ func NewFieldCapabilities(mesg proto.Message) *FieldCapabilities {
 		3:   basetype.Uint16Invalid, /* Count */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/field_description_gen.go
+++ b/profile/mesgdef/field_description_gen.go
@@ -55,7 +55,7 @@ func NewFieldDescription(mesg proto.Message) *FieldDescription {
 		15: basetype.Uint8Invalid,  /* NativeFieldNum */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/file_capabilities_gen.go
+++ b/profile/mesgdef/file_capabilities_gen.go
@@ -43,7 +43,7 @@ func NewFileCapabilities(mesg proto.Message) *FileCapabilities {
 		4:   basetype.Uint32Invalid, /* MaxSize */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/file_creator_gen.go
+++ b/profile/mesgdef/file_creator_gen.go
@@ -35,7 +35,7 @@ func NewFileCreator(mesg proto.Message) *FileCreator {
 		1: basetype.Uint8Invalid,  /* HardwareVersion */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/file_id_gen.go
+++ b/profile/mesgdef/file_id_gen.go
@@ -23,10 +23,6 @@ type FileId struct {
 	TimeCreated  typedef.DateTime // Only set for files that are can be created/erased.
 	Number       uint16           // Only set for files that are not created/erased.
 	ProductName  string           // Optional free form string to indicate the devices name or model
-
-	// Developer Fields are dynamic, can't be mapped as struct's fields.
-	// [Added since protocol version 2.0]
-	DeveloperFields []proto.DeveloperField
 }
 
 // NewFileId creates new FileId struct based on given mesg. If mesg is nil or mesg.Num is not equal to FileId mesg number, it will return nil.
@@ -45,7 +41,7 @@ func NewFileId(mesg proto.Message) *FileId {
 		8: basetype.StringInvalid,  /* ProductName */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}
@@ -60,8 +56,6 @@ func NewFileId(mesg proto.Message) *FileId {
 		TimeCreated:  typeconv.ToUint32[typedef.DateTime](vals[4]),
 		Number:       typeconv.ToUint16[uint16](vals[5]),
 		ProductName:  typeconv.ToString[string](vals[8]),
-
-		DeveloperFields: mesg.DeveloperFields,
 	}
 }
 
@@ -91,6 +85,4 @@ func (m FileId) PutMessage(mesg *proto.Message) {
 	for i := range mesg.Fields {
 		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
-
 }

--- a/profile/mesgdef/goal_gen.go
+++ b/profile/mesgdef/goal_gen.go
@@ -57,7 +57,7 @@ func NewGoal(mesg proto.Message) *Goal {
 		11:  basetype.EnumInvalid,   /* Source */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/gps_metadata_gen.go
+++ b/profile/mesgdef/gps_metadata_gen.go
@@ -49,7 +49,7 @@ func NewGpsMetadata(mesg proto.Message) *GpsMetadata {
 		7:   nil,                    /* Velocity */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/gyroscope_data_gen.go
+++ b/profile/mesgdef/gyroscope_data_gen.go
@@ -49,7 +49,7 @@ func NewGyroscopeData(mesg proto.Message) *GyroscopeData {
 		7:   nil,                    /* CalibratedGyroZ */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/hr_gen.go
+++ b/profile/mesgdef/hr_gen.go
@@ -43,7 +43,7 @@ func NewHr(mesg proto.Message) *Hr {
 		10:  nil,                    /* EventTimestamp12 */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/hr_zone_gen.go
+++ b/profile/mesgdef/hr_zone_gen.go
@@ -37,7 +37,7 @@ func NewHrZone(mesg proto.Message) *HrZone {
 		2:   basetype.StringInvalid, /* Name */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/hrm_profile_gen.go
+++ b/profile/mesgdef/hrm_profile_gen.go
@@ -41,7 +41,7 @@ func NewHrmProfile(mesg proto.Message) *HrmProfile {
 		3:   basetype.Uint8zInvalid,  /* HrmAntIdTransType */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/hrv_gen.go
+++ b/profile/mesgdef/hrv_gen.go
@@ -32,7 +32,7 @@ func NewHrv(mesg proto.Message) *Hrv {
 		0: nil, /* Time */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/hrv_status_summary_gen.go
+++ b/profile/mesgdef/hrv_status_summary_gen.go
@@ -47,7 +47,7 @@ func NewHrvStatusSummary(mesg proto.Message) *HrvStatusSummary {
 		6:   basetype.EnumInvalid,   /* Status */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/hrv_value_gen.go
+++ b/profile/mesgdef/hrv_value_gen.go
@@ -35,7 +35,7 @@ func NewHrvValue(mesg proto.Message) *HrvValue {
 		0:   basetype.Uint16Invalid, /* Value */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/jump_gen.go
+++ b/profile/mesgdef/jump_gen.go
@@ -52,7 +52,7 @@ func NewJump(mesg proto.Message) *Jump {
 		8:   basetype.Uint32Invalid,                        /* EnhancedSpeed */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/lap_gen.go
+++ b/profile/mesgdef/lap_gen.go
@@ -278,7 +278,7 @@ func NewLap(mesg proto.Message) *Lap {
 		160: basetype.Uint16Invalid,                        /* MaxCoreTemperature */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/length_gen.go
+++ b/profile/mesgdef/length_gen.go
@@ -75,7 +75,7 @@ func NewLength(mesg proto.Message) *Length {
 		25:  basetype.Uint8Invalid,  /* MaxRespirationRate */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/magnetometer_data_gen.go
+++ b/profile/mesgdef/magnetometer_data_gen.go
@@ -49,7 +49,7 @@ func NewMagnetometerData(mesg proto.Message) *MagnetometerData {
 		7:   nil,                    /* CalibratedMagZ */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/max_met_data_gen.go
+++ b/profile/mesgdef/max_met_data_gen.go
@@ -47,7 +47,7 @@ func NewMaxMetData(mesg proto.Message) *MaxMetData {
 		13: basetype.EnumInvalid,   /* SpeedSource */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/memo_glob_gen.go
+++ b/profile/mesgdef/memo_glob_gen.go
@@ -43,7 +43,7 @@ func NewMemoGlob(mesg proto.Message) *MemoGlob {
 		4:   nil,                    /* Data */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/mesg_capabilities_gen.go
+++ b/profile/mesgdef/mesg_capabilities_gen.go
@@ -41,7 +41,7 @@ func NewMesgCapabilities(mesg proto.Message) *MesgCapabilities {
 		3:   basetype.Uint16Invalid, /* Count */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/met_zone_gen.go
+++ b/profile/mesgdef/met_zone_gen.go
@@ -39,7 +39,7 @@ func NewMetZone(mesg proto.Message) *MetZone {
 		3:   basetype.Uint8Invalid,  /* FatCalories */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/monitoring_gen.go
+++ b/profile/mesgdef/monitoring_gen.go
@@ -89,7 +89,7 @@ func NewMonitoring(mesg proto.Message) *Monitoring {
 		34:  basetype.Uint16Invalid, /* VigorousActivityMinutes */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/monitoring_hr_data_gen.go
+++ b/profile/mesgdef/monitoring_hr_data_gen.go
@@ -37,7 +37,7 @@ func NewMonitoringHrData(mesg proto.Message) *MonitoringHrData {
 		1:   basetype.Uint8Invalid,  /* CurrentDayRestingHeartRate */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/monitoring_info_gen.go
+++ b/profile/mesgdef/monitoring_info_gen.go
@@ -43,7 +43,7 @@ func NewMonitoringInfo(mesg proto.Message) *MonitoringInfo {
 		5:   basetype.Uint16Invalid, /* RestingMetabolicRate */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/nmea_sentence_gen.go
+++ b/profile/mesgdef/nmea_sentence_gen.go
@@ -37,7 +37,7 @@ func NewNmeaSentence(mesg proto.Message) *NmeaSentence {
 		1:   basetype.StringInvalid, /* Sentence */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/obdii_data_gen.go
+++ b/profile/mesgdef/obdii_data_gen.go
@@ -49,7 +49,7 @@ func NewObdiiData(mesg proto.Message) *ObdiiData {
 		7:   basetype.Uint16Invalid, /* StartTimestampMs */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/ohr_settings_gen.go
+++ b/profile/mesgdef/ohr_settings_gen.go
@@ -35,7 +35,7 @@ func NewOhrSettings(mesg proto.Message) *OhrSettings {
 		0:   basetype.EnumInvalid,   /* Enabled */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/one_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/one_d_sensor_calibration_gen.go
@@ -43,7 +43,7 @@ func NewOneDSensorCalibration(mesg proto.Message) *OneDSensorCalibration {
 		4:   basetype.Sint32Invalid, /* OffsetCal */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/power_zone_gen.go
+++ b/profile/mesgdef/power_zone_gen.go
@@ -37,7 +37,7 @@ func NewPowerZone(mesg proto.Message) *PowerZone {
 		2:   basetype.StringInvalid, /* Name */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/record_gen.go
+++ b/profile/mesgdef/record_gen.go
@@ -200,7 +200,7 @@ func NewRecord(mesg proto.Message) *Record {
 		139: basetype.Uint16Invalid,                        /* CoreTemperature */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/respiration_rate_gen.go
+++ b/profile/mesgdef/respiration_rate_gen.go
@@ -35,7 +35,7 @@ func NewRespirationRate(mesg proto.Message) *RespirationRate {
 		0:   basetype.Sint16Invalid, /* RespirationRate */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/schedule_gen.go
+++ b/profile/mesgdef/schedule_gen.go
@@ -45,7 +45,7 @@ func NewSchedule(mesg proto.Message) *Schedule {
 		6: basetype.Uint32Invalid,  /* ScheduledTime */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/sdm_profile_gen.go
+++ b/profile/mesgdef/sdm_profile_gen.go
@@ -47,7 +47,7 @@ func NewSdmProfile(mesg proto.Message) *SdmProfile {
 		7:   basetype.Uint8Invalid,   /* OdometerRollover */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/segment_file_gen.go
+++ b/profile/mesgdef/segment_file_gen.go
@@ -49,7 +49,7 @@ func NewSegmentFile(mesg proto.Message) *SegmentFile {
 		11:  basetype.Uint8Invalid,  /* DefaultRaceLeader */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/segment_id_gen.go
+++ b/profile/mesgdef/segment_id_gen.go
@@ -49,7 +49,7 @@ func NewSegmentId(mesg proto.Message) *SegmentId {
 		8: basetype.EnumInvalid,   /* SelectionType */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/segment_lap_gen.go
+++ b/profile/mesgdef/segment_lap_gen.go
@@ -222,7 +222,7 @@ func NewSegmentLap(mesg proto.Message) *SegmentLap {
 		93:  basetype.Uint32Invalid,                        /* EnhancedMinAltitude */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/segment_leaderboard_entry_gen.go
+++ b/profile/mesgdef/segment_leaderboard_entry_gen.go
@@ -45,7 +45,7 @@ func NewSegmentLeaderboardEntry(mesg proto.Message) *SegmentLeaderboardEntry {
 		5:   basetype.StringInvalid, /* ActivityIdString */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/segment_point_gen.go
+++ b/profile/mesgdef/segment_point_gen.go
@@ -45,7 +45,7 @@ func NewSegmentPoint(mesg proto.Message) *SegmentPoint {
 		6:   basetype.Uint32Invalid, /* EnhancedAltitude */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/session_gen.go
+++ b/profile/mesgdef/session_gen.go
@@ -340,7 +340,7 @@ func NewSession(mesg proto.Message) *Session {
 		210: basetype.Uint16Invalid,                        /* MaxCoreTemperature */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/set_gen.go
+++ b/profile/mesgdef/set_gen.go
@@ -53,7 +53,7 @@ func NewSet(mesg proto.Message) *Set {
 		11:  basetype.Uint16Invalid, /* WktStepIndex */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/slave_device_gen.go
+++ b/profile/mesgdef/slave_device_gen.go
@@ -35,7 +35,7 @@ func NewSlaveDevice(mesg proto.Message) *SlaveDevice {
 		1: basetype.Uint16Invalid, /* Product */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/sleep_assessment_gen.go
+++ b/profile/mesgdef/sleep_assessment_gen.go
@@ -59,7 +59,7 @@ func NewSleepAssessment(mesg proto.Message) *SleepAssessment {
 		15: basetype.Uint16Invalid, /* AverageStressDuringSleep */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/sleep_level_gen.go
+++ b/profile/mesgdef/sleep_level_gen.go
@@ -35,7 +35,7 @@ func NewSleepLevel(mesg proto.Message) *SleepLevel {
 		0:   basetype.EnumInvalid,   /* SleepLevel */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/software_gen.go
+++ b/profile/mesgdef/software_gen.go
@@ -37,7 +37,7 @@ func NewSoftware(mesg proto.Message) *Software {
 		5:   basetype.StringInvalid, /* PartNumber */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/speed_zone_gen.go
+++ b/profile/mesgdef/speed_zone_gen.go
@@ -37,7 +37,7 @@ func NewSpeedZone(mesg proto.Message) *SpeedZone {
 		1:   basetype.StringInvalid, /* Name */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/split_gen.go
+++ b/profile/mesgdef/split_gen.go
@@ -41,7 +41,7 @@ func NewSplit(mesg proto.Message) *Split {
 		9: basetype.Uint32Invalid, /* StartTime */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/spo2_data_gen.go
+++ b/profile/mesgdef/spo2_data_gen.go
@@ -39,7 +39,7 @@ func NewSpo2Data(mesg proto.Message) *Spo2Data {
 		2:   basetype.EnumInvalid,   /* Mode */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/sport_gen.go
+++ b/profile/mesgdef/sport_gen.go
@@ -37,7 +37,7 @@ func NewSport(mesg proto.Message) *Sport {
 		3: basetype.StringInvalid, /* Name */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/stress_level_gen.go
+++ b/profile/mesgdef/stress_level_gen.go
@@ -35,7 +35,7 @@ func NewStressLevel(mesg proto.Message) *StressLevel {
 		1: basetype.Uint32Invalid, /* StressLevelTime */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/tank_summary_gen.go
+++ b/profile/mesgdef/tank_summary_gen.go
@@ -41,7 +41,7 @@ func NewTankSummary(mesg proto.Message) *TankSummary {
 		3:   basetype.Uint32Invalid,  /* VolumeUsed */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/tank_update_gen.go
+++ b/profile/mesgdef/tank_update_gen.go
@@ -37,7 +37,7 @@ func NewTankUpdate(mesg proto.Message) *TankUpdate {
 		1:   basetype.Uint16Invalid,  /* Pressure */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/three_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/three_d_sensor_calibration_gen.go
@@ -45,7 +45,7 @@ func NewThreeDSensorCalibration(mesg proto.Message) *ThreeDSensorCalibration {
 		5:   nil,                    /* OrientationMatrix */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/time_in_zone_gen.go
+++ b/profile/mesgdef/time_in_zone_gen.go
@@ -65,7 +65,7 @@ func NewTimeInZone(mesg proto.Message) *TimeInZone {
 		15:  basetype.Uint16Invalid, /* FunctionalThresholdPower */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/timestamp_correlation_gen.go
+++ b/profile/mesgdef/timestamp_correlation_gen.go
@@ -45,7 +45,7 @@ func NewTimestampCorrelation(mesg proto.Message) *TimestampCorrelation {
 		5:   basetype.Uint16Invalid, /* SystemTimestampMs */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/totals_gen.go
+++ b/profile/mesgdef/totals_gen.go
@@ -51,7 +51,7 @@ func NewTotals(mesg proto.Message) *Totals {
 		9:   basetype.Uint8Invalid,  /* SportIndex */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/training_file_gen.go
+++ b/profile/mesgdef/training_file_gen.go
@@ -43,7 +43,7 @@ func NewTrainingFile(mesg proto.Message) *TrainingFile {
 		4:   basetype.Uint32Invalid,  /* TimeCreated */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/user_profile_gen.go
+++ b/profile/mesgdef/user_profile_gen.go
@@ -89,7 +89,7 @@ func NewUserProfile(mesg proto.Message) *UserProfile {
 		49:  basetype.Uint32Invalid, /* DiveCount */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/video_clip_gen.go
+++ b/profile/mesgdef/video_clip_gen.go
@@ -45,7 +45,7 @@ func NewVideoClip(mesg proto.Message) *VideoClip {
 		7: basetype.Uint32Invalid, /* ClipEnd */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/video_description_gen.go
+++ b/profile/mesgdef/video_description_gen.go
@@ -37,7 +37,7 @@ func NewVideoDescription(mesg proto.Message) *VideoDescription {
 		1:   basetype.StringInvalid, /* Text */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/video_frame_gen.go
+++ b/profile/mesgdef/video_frame_gen.go
@@ -37,7 +37,7 @@ func NewVideoFrame(mesg proto.Message) *VideoFrame {
 		1:   basetype.Uint32Invalid, /* FrameNumber */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/video_gen.go
+++ b/profile/mesgdef/video_gen.go
@@ -37,7 +37,7 @@ func NewVideo(mesg proto.Message) *Video {
 		2: basetype.Uint32Invalid, /* Duration */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/video_title_gen.go
+++ b/profile/mesgdef/video_title_gen.go
@@ -37,7 +37,7 @@ func NewVideoTitle(mesg proto.Message) *VideoTitle {
 		1:   basetype.StringInvalid, /* Text */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/watchface_settings_gen.go
+++ b/profile/mesgdef/watchface_settings_gen.go
@@ -37,7 +37,7 @@ func NewWatchfaceSettings(mesg proto.Message) *WatchfaceSettings {
 		1:   basetype.ByteInvalid,   /* Layout */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/weather_alert_gen.go
+++ b/profile/mesgdef/weather_alert_gen.go
@@ -43,7 +43,7 @@ func NewWeatherAlert(mesg proto.Message) *WeatherAlert {
 		4:   basetype.EnumInvalid,   /* Type */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/weather_conditions_gen.go
+++ b/profile/mesgdef/weather_conditions_gen.go
@@ -63,7 +63,7 @@ func NewWeatherConditions(mesg proto.Message) *WeatherConditions {
 		14:  basetype.Sint8Invalid,  /* LowTemperature */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/weight_scale_gen.go
+++ b/profile/mesgdef/weight_scale_gen.go
@@ -59,7 +59,7 @@ func NewWeightScale(mesg proto.Message) *WeightScale {
 		13:  basetype.Uint16Invalid, /* Bmi */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/workout_gen.go
+++ b/profile/mesgdef/workout_gen.go
@@ -47,7 +47,7 @@ func NewWorkout(mesg proto.Message) *Workout {
 		15:  basetype.EnumInvalid,    /* PoolLengthUnit */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/workout_session_gen.go
+++ b/profile/mesgdef/workout_session_gen.go
@@ -45,7 +45,7 @@ func NewWorkoutSession(mesg proto.Message) *WorkoutSession {
 		5:   basetype.EnumInvalid,   /* PoolLengthUnit */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/workout_step_gen.go
+++ b/profile/mesgdef/workout_step_gen.go
@@ -69,7 +69,7 @@ func NewWorkoutStep(mesg proto.Message) *WorkoutStep {
 		22:  basetype.Uint32Invalid, /* SecondaryCustomTargetValueHigh */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/mesgdef/zones_target_gen.go
+++ b/profile/mesgdef/zones_target_gen.go
@@ -41,7 +41,7 @@ func NewZonesTarget(mesg proto.Message) *ZonesTarget {
 		7: basetype.EnumInvalid,   /* PwrCalcType */
 	}
 
-	for i := 0; i < len(mesg.Fields); i++ {
+	for i := range mesg.Fields {
 		if mesg.Fields[i].Value == nil {
 			continue // keep the invalid value
 		}

--- a/profile/typedef/marshal.go
+++ b/profile/typedef/marshal.go
@@ -35,7 +35,7 @@ func Marshal(v any, bo binary.ByteOrder) ([]byte, error) {
 		return []byte{byte(boolean)}, nil
 	case []bool:
 		b := make([]byte, 0, len(val))
-		for i := 0; i < len(val); i++ {
+		for i := range val {
 			if val[i] {
 				b = append(b, 1)
 			} else {
@@ -47,7 +47,7 @@ func Marshal(v any, bo binary.ByteOrder) ([]byte, error) {
 		return []byte{byte(val)}, nil
 	case []int8:
 		b := make([]byte, 0, len(val))
-		for i := 0; i < len(val); i++ {
+		for i := range val {
 			b = append(b, byte(val[i]))
 		}
 		return b, nil
@@ -62,7 +62,7 @@ func Marshal(v any, bo binary.ByteOrder) ([]byte, error) {
 	case []int16:
 		n, cur := 2, 0
 		b := make([]byte, len(val)*n)
-		for i := 0; i < len(val); i++ {
+		for i := range val {
 			bo.PutUint16(b[cur:cur+n], uint16(val[i]))
 			cur += n
 		}
@@ -74,7 +74,7 @@ func Marshal(v any, bo binary.ByteOrder) ([]byte, error) {
 	case []uint16:
 		n, cur := 2, 0
 		b := make([]byte, len(val)*n)
-		for i := 0; i < len(val); i++ {
+		for i := range val {
 			bo.PutUint16(b[cur:cur+n], val[i])
 			cur += n
 		}
@@ -86,7 +86,7 @@ func Marshal(v any, bo binary.ByteOrder) ([]byte, error) {
 	case []int32:
 		n, cur := 4, 0
 		b := make([]byte, len(val)*n)
-		for i := 0; i < len(val); i++ {
+		for i := range val {
 			bo.PutUint32(b[cur:cur+n], uint32(val[i]))
 			cur += n
 		}
@@ -98,7 +98,7 @@ func Marshal(v any, bo binary.ByteOrder) ([]byte, error) {
 	case []uint32:
 		n, cur := 4, 0
 		b := make([]byte, len(val)*n)
-		for i := 0; i < len(val); i++ {
+		for i := range val {
 			bo.PutUint32(b[cur:cur+n], val[i])
 			cur += n
 		}
@@ -110,7 +110,7 @@ func Marshal(v any, bo binary.ByteOrder) ([]byte, error) {
 	case []int64:
 		n, cur := 8, 0
 		b := make([]byte, len(val)*n)
-		for i := 0; i < len(val); i++ {
+		for i := range val {
 			bo.PutUint64(b[cur:cur+n], uint64(val[i]))
 			cur += n
 		}
@@ -122,7 +122,7 @@ func Marshal(v any, bo binary.ByteOrder) ([]byte, error) {
 	case []uint64:
 		n, cur := 8, 0
 		b := make([]byte, len(val)*n)
-		for i := 0; i < len(val); i++ {
+		for i := range val {
 			bo.PutUint64(b[cur:cur+n], val[i])
 			cur += n
 		}
@@ -135,7 +135,7 @@ func Marshal(v any, bo binary.ByteOrder) ([]byte, error) {
 	case []float32:
 		n, cur := 4, 0
 		b := make([]byte, len(val)*n)
-		for i := 0; i < len(val); i++ {
+		for i := range val {
 			bo.PutUint32(b[cur:cur+n], math.Float32bits(val[i]))
 			cur += n
 		}
@@ -148,7 +148,7 @@ func Marshal(v any, bo binary.ByteOrder) ([]byte, error) {
 	case []float64:
 		n, cur := 8, 0
 		b := make([]byte, len(val)*n)
-		for i := 0; i < len(val); i++ {
+		for i := range val {
 			bo.PutUint64(b[cur:cur+n], math.Float64bits(val[i]))
 			cur += n
 		}

--- a/proto/doc.go
+++ b/proto/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2023 The Fit SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package proto defines the abstraction for Fit Protocol.
+//
+// Fit Protocol is the core of a Fit file and it's the fundamental building block for decoding and encoding fit files.
+package proto

--- a/proto/marshaler.go
+++ b/proto/marshaler.go
@@ -16,10 +16,6 @@ import (
 
 // Marshaler should only do one thing: marshaling to its bytes representation, any validation should be done outside.
 
-const (
-	DevDataMask = 0b00100000 // Mask for determining if a message contains developer fields.
-)
-
 var (
 	_ encoding.BinaryMarshaler = &FileHeader{}
 	_ encoding.BinaryMarshaler = &MessageDefinition{}

--- a/proto/marshaler_test.go
+++ b/proto/marshaler_test.go
@@ -64,8 +64,7 @@ func TestMessageDefinitionMarshaler(t *testing.T) {
 			name: "mesg def fields only",
 			mesgdef: &proto.MessageDefinition{
 				Header:       64,
-				LocalMesgNum: 0,
-				Reserved:     0,
+				Reserved:     1,
 				Architecture: 0,
 				MesgNum:      typedef.MesgNumFileId,
 				FieldDefinitions: []proto.FieldDefinition{
@@ -78,12 +77,11 @@ func TestMessageDefinitionMarshaler(t *testing.T) {
 				},
 				DeveloperFieldDefinitions: nil},
 			b: []byte{
-				64, // Header
-				0,  // LocalMesgNum
-				0,  // Reserved
-				0,  // Architecture
-				0,  // MesgNum
-				6,  // len(FieldDefinitions)
+				64,   // Header
+				1,    // Reserved
+				0,    // Architecture
+				0, 0, // MesgNum
+				6, // len(FieldDefinitions)
 				0, 1, 0,
 				1, 2, 132,
 				2, 2, 132,
@@ -93,11 +91,9 @@ func TestMessageDefinitionMarshaler(t *testing.T) {
 			},
 		},
 		{
-			name: "mesg def fields only",
+			name: "mesg def fields and developer fields",
 			mesgdef: &proto.MessageDefinition{
 				Header:       64 | 32,
-				LocalMesgNum: 0,
-				Reserved:     0,
 				Architecture: 0,
 				MesgNum:      typedef.MesgNumFileId,
 				FieldDefinitions: []proto.FieldDefinition{
@@ -113,11 +109,10 @@ func TestMessageDefinitionMarshaler(t *testing.T) {
 				}},
 			b: []byte{
 				64 | 32, // Header
-				0,       // LocalMesgNum
 				0,       // Reserved
 				0,       // Architecture
-				0,       // MesgNum
-				6,       // len(FieldDefinitions)
+				0, 0,    // MesgNum
+				6, // len(FieldDefinitions)
 				0, 1, 0,
 				1, 2, 132,
 				2, 2, 132,
@@ -159,10 +154,8 @@ func TestMessageMarshaler(t *testing.T) {
 		{
 			name: "file_id mesg",
 			mesg: &proto.Message{
-				Header:   0,
-				Name:     "file_id",
-				Num:      typedef.MesgNumFileId,
-				LocalNum: 0,
+				Header: 0,
+				Num:    typedef.MesgNumFileId,
 				Fields: []proto.Field{
 					{Value: uint8(4)},
 					{Value: uint16(292)},
@@ -186,10 +179,8 @@ func TestMessageMarshaler(t *testing.T) {
 		{
 			name: "record mesg with developer fields",
 			mesg: &proto.Message{
-				Header:   0,
-				Name:     "record",
-				Num:      typedef.MesgNumRecord,
-				LocalNum: 0,
+				Header: 0,
+				Num:    typedef.MesgNumRecord,
 				Fields: []proto.Field{
 					{Value: uint8(4)},
 					{Value: uint16(292)},
@@ -216,10 +207,8 @@ func TestMessageMarshaler(t *testing.T) {
 		{
 			name: "marshal fields return error",
 			mesg: &proto.Message{
-				Header:   0,
-				Name:     "file_id",
-				Num:      typedef.MesgNumFileId,
-				LocalNum: 0,
+				Header: 0,
+				Num:    typedef.MesgNumFileId,
 				Fields: []proto.Field{
 					{FieldBase: &proto.FieldBase{Num: 99, Name: "error"}, Value: struct{}{}},
 				},
@@ -230,10 +219,8 @@ func TestMessageMarshaler(t *testing.T) {
 		{
 			name: "marshal fields return error",
 			mesg: &proto.Message{
-				Header:   0,
-				Name:     "file_id",
-				Num:      typedef.MesgNumFileId,
-				LocalNum: 0,
+				Header: 0,
+				Num:    typedef.MesgNumFileId,
 				DeveloperFields: []proto.DeveloperField{
 					{Num: 0, DeveloperDataIndex: 0, Value: struct{}{}},
 				},

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -5,6 +5,7 @@
 package proto_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -15,6 +16,31 @@ import (
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
 )
+
+func TestLocalMesgNum(t *testing.T) {
+	tt := []struct {
+		header       byte
+		localMesgNum byte
+	}{
+		{
+			header:       proto.MesgCompressedHeaderMask | 0b00111111,
+			localMesgNum: 1,
+		},
+		{
+			header:       proto.MesgNormalHeaderMask | 2,
+			localMesgNum: 2,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(fmt.Sprintf("0b%08b", tc.header), func(t *testing.T) {
+			localMesgNum := proto.LocalMesgNum(tc.header)
+			if localMesgNum != tc.localMesgNum {
+				t.Fatalf("expected: %d, got: %d", tc.localMesgNum, localMesgNum)
+			}
+		})
+	}
+}
 
 func TestFitWithMessages(t *testing.T) {
 	tt := []struct {


### PR DESCRIPTION
Performance Improvement:
- Field `LocalMesgNum` is removed in both proto.MessageDefinition and proto.Message.
- Field `Name` is removed in proto.Message since we can get the name from Num.String(), this reduce significant amount of memory alloc per message.
- improve consistency by using `for i := range` whenever possible instead of `for`.
- move some constants to `proto` package instead of scattered in decoder and encoder.

Feature:
- Add new decoder.Option `WithNoComponentExpansion` to direct the Decoder to not expand the components.

Fix:
- proto.Message now have `Reserved` field retrieved from proto.MessageDefinition during decoding, this allow the Reserved value to be encoded as the original value rather than default zero.
- expand component should only add the componentField into mesg.Fields slices, not appending to the existing field's value.

Breaking Changes:
- Decode is renamed to `DecodeWithContext` and decode is now exported (Decode).
- Encode is renamed to `EncodeWithContext` and encode is now exported (Encode).
- PeekFileId is no longer receives context, as peeking should be instantaneous.