### PR TITLE
feat: register manufacturer-specific types and messages

### DIFF
--- a/factory/exported_gen.go
+++ b/factory/exported_gen.go
@@ -36,8 +36,9 @@ func CreateField(mesgNum typedef.MesgNum, num byte) proto.Field {
 	return std.CreateField(mesgNum, num)
 }
 
-// RegisterMesg registers manufacturer specific message within available range between 0xFF00 - 0xFFFE.
-// Return an error if num is outside that range. If same mesg number is given, it will replace the old mesg of the same number.
+// RegisterMesg registers a new message that is not defined in the profile.xlsx.
+// You can not edit or replace existing message in the factory, including the messages you have registered.
+// If you intend to edit your own messages, create a new factory instance using New() and define the new message definitions on it.
 //
 // By registering, any Fit file containing these messages can be recognized instead of returning "unknown" message.
 func RegisterMesg(mesg proto.Message) error {

--- a/factory/factory_gen.go
+++ b/factory/factory_gen.go
@@ -103,14 +103,18 @@ func createUnknownField(mesgNum typedef.MesgNum, num byte) proto.Field {
 	return proto.Field{FieldBase: &proto.FieldBase{Name: NameUnknown, Num: num, Scale: 1, Offset: 0}}
 }
 
-// RegisterMesg registers manufacturer specific message within available range between 0xFF00 - 0xFFFE.
-// Return an error if num is outside that range. If same mesg number is given, it will replace the old mesg of the same number.
+// RegisterMesg registers a new message that is not defined in the profile.xlsx.
+// You can not edit or replace existing message in the factory, including the messages you have registered.
+// If you intend to edit your own messages, create a new factory instance using New() and define the new message definitions on it.
 //
 // By registering, any Fit file containing these messages can be recognized instead of returning "unknown" message.
 func (f *Factory) RegisterMesg(mesg proto.Message) error {
-	if mesg.Num < typedef.MesgNumMfgRangeMin || mesg.Num > typedef.MesgNumMfgRangeMax {
-		return fmt.Errorf("could not register mesg num \"%#X\", available range: %#X-%#X: %w",
-			mesg.Num, typedef.MesgNumMfgRangeMin, typedef.MesgNumMfgRangeMax, ErrRegisterForbidden)
+	if mesg.Num > typedef.MesgNumMfgRangeMax {
+		return fmt.Errorf("could not register outside max range: %d", typedef.MesgNumMfgRangeMax)
+	}
+
+	if f.mesgs[mesg.Num].Num == mesg.Num {
+		return fmt.Errorf("could not register to an existing message: %d (%s)", mesg.Num, mesg.Num)
 	}
 
 	mesg = mesg.Clone()

--- a/internal/cmd/fitgen/builder/shared/constant.tmpl
+++ b/internal/cmd/fitgen/builder/shared/constant.tmpl
@@ -125,18 +125,30 @@ func ({{ $r }} {{ .Type }}) String() string {
 }
 {{ end }}
 
-// Registrer Manufacturer Specific Range:
+// Registrer Manufacturer Specific Type:
 {{ define "register" }}
-// RegisterMfgRange registers manufacturer specific {{ .Package }} so that the value can be recognized instead of getting Invalid value, 
-// while you define the constants somewhere else (not a must but preferred to tracks your own specifications).
+// {{ .Type }}Register registers a manufacturer specific {{ .Type }} so that the value can be recognized. 
+// It is recommended to define the constants somewhere else to track your own specifications.
 // 
 // This is intended for those who prefer using this SDK as it is without the need to generate custom SDK using cmd/fitgen.
-func {{ .Type }}RegisterMfgRange(v {{ .Type }}, s string) error {
-	if v < {{ .Type }}MfgRangeMin || v > {{ .Type }}MfgRangeMax {
-		return fmt.Errorf("v is outside available range %#X-%#X", {{ .Type }}MfgRangeMin, {{ .Type }}MfgRangeMax )
+func {{ .Type }}Register(v {{ .Type }}, s string) error {
+	if v >= {{ .Type}}Invalid {
+		return fmt.Errorf("could not register outside max range: %d", {{ .Type}}Invalid)
 	}
+
+	{{ if eq .StringerMode 0x0 -}} 
+		if str, ok := {{ .Type | ToLower }}tostrs[v]; ok {
+			return fmt.Errorf("could not register to an existing {{ .Type }}: %d (%s)", v, str)
+		}
+	{{ else -}}
+		if str := {{ .Type | ToLower }}tostrs[v]; v != "" {
+			return fmt.Errorf("could not register to an existing {{ .Type }}: %d (%s)", v, str)
+		}
+	{{ end }}
+
 	{{ .Type | ToLower }}tostrs[v] = s
 	strto{{ .Type | ToLower }}[s] = v
+
 	return nil
 }
 {{ end }}

--- a/internal/cmd/fitgen/factory/factory.tmpl
+++ b/internal/cmd/fitgen/factory/factory.tmpl
@@ -109,9 +109,12 @@ func createUnknownField(mesgNum typedef.MesgNum, num byte) proto.Field {
 
 {{ template "register_mesg_doc" -}}
 func (f *Factory) RegisterMesg(mesg proto.Message) error {
-	if mesg.Num < typedef.MesgNumMfgRangeMin || mesg.Num > typedef.MesgNumMfgRangeMax {
-		return fmt.Errorf("could not register mesg num \"%#X\", available range: %#X-%#X: %w",
-			mesg.Num, typedef.MesgNumMfgRangeMin, typedef.MesgNumMfgRangeMax, ErrRegisterForbidden)
+    if mesg.Num > typedef.MesgNumMfgRangeMax {
+		return fmt.Errorf("could not register outside max range: %d", typedef.MesgNumMfgRangeMax)
+	}
+
+	if f.mesgs[mesg.Num].Num == mesg.Num {
+		return fmt.Errorf("could not register to an existing message: %d (%s)", mesg.Num, mesg.Num)
 	}
 	
 	mesg = mesg.Clone()
@@ -181,8 +184,9 @@ func RegisterMesg(mesg proto.Message) error {
 {{ end }}
 
 {{ define "register_mesg_doc" }}
-// RegisterMesg registers manufacturer specific message within available range between 0xFF00 - 0xFFFE.
-// Return an error if num is outside that range. If same mesg number is given, it will replace the old mesg of the same number.
+// RegisterMesg registers a new message that is not defined in the profile.xlsx. 
+// You can not edit or replace existing message in the factory, including the messages you have registered.
+// If you intend to edit your own messages, create a new factory instance using New() and define the new message definitions on it.
 //
 // By registering, any Fit file containing these messages can be recognized instead of returning "unknown" message.
 {{ end }}

--- a/profile/typedef/file_gen.go
+++ b/profile/typedef/file_gen.go
@@ -96,15 +96,21 @@ func ListFile() []File {
 	return vs
 }
 
-// RegisterMfgRange registers manufacturer specific typedef so that the value can be recognized instead of getting Invalid value,
-// while you define the constants somewhere else (not a must but preferred to tracks your own specifications).
+// FileRegister registers a manufacturer specific File so that the value can be recognized.
+// It is recommended to define the constants somewhere else to track your own specifications.
 //
 // This is intended for those who prefer using this SDK as it is without the need to generate custom SDK using cmd/fitgen.
-func FileRegisterMfgRange(v File, s string) error {
-	if v < FileMfgRangeMin || v > FileMfgRangeMax {
-		return fmt.Errorf("v is outside available range %#X-%#X", FileMfgRangeMin, FileMfgRangeMax)
+func FileRegister(v File, s string) error {
+	if v >= FileInvalid {
+		return fmt.Errorf("could not register outside max range: %d", FileInvalid)
 	}
+
+	if str, ok := filetostrs[v]; ok {
+		return fmt.Errorf("could not register to an existing File: %d (%s)", v, str)
+	}
+
 	filetostrs[v] = s
 	strtofile[s] = v
+
 	return nil
 }

--- a/profile/typedef/mesg_num_gen.go
+++ b/profile/typedef/mesg_num_gen.go
@@ -266,15 +266,21 @@ func ListMesgNum() []MesgNum {
 	return vs
 }
 
-// RegisterMfgRange registers manufacturer specific typedef so that the value can be recognized instead of getting Invalid value,
-// while you define the constants somewhere else (not a must but preferred to tracks your own specifications).
+// MesgNumRegister registers a manufacturer specific MesgNum so that the value can be recognized.
+// It is recommended to define the constants somewhere else to track your own specifications.
 //
 // This is intended for those who prefer using this SDK as it is without the need to generate custom SDK using cmd/fitgen.
-func MesgNumRegisterMfgRange(v MesgNum, s string) error {
-	if v < MesgNumMfgRangeMin || v > MesgNumMfgRangeMax {
-		return fmt.Errorf("v is outside available range %#X-%#X", MesgNumMfgRangeMin, MesgNumMfgRangeMax)
+func MesgNumRegister(v MesgNum, s string) error {
+	if v >= MesgNumInvalid {
+		return fmt.Errorf("could not register outside max range: %d", MesgNumInvalid)
 	}
+
+	if str, ok := mesgnumtostrs[v]; ok {
+		return fmt.Errorf("could not register to an existing MesgNum: %d (%s)", v, str)
+	}
+
 	mesgnumtostrs[v] = s
 	strtomesgnum[s] = v
+
 	return nil
 }


### PR DESCRIPTION
Registering manufacturer-specific types and messages are no longer restricted to the manufacturer's range; however, it still complies with not modifying existing types or messages.

I see some manufacturers using `Message Number` outside the range `0xFF00-0xFFFE`, e.g. `68` on Fit files generated by Bryton. The number is not specified in `Profile.xlsx`, it's probably used for internal purpose by Garmin as the creator of the Fit Protocol and the manufacturers. The ability to define it outside range will benefit the engineers using this SDK for manufacturer specific purpose.