### PR TITLE
refactor(decoder): simplify component expansion

### DIFF
--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -1137,19 +1137,6 @@ func TestExpandComponents(t *testing.T) {
 			nFieldAfterExpansion: 4, // 1 for Event, 3 for expansion fields (rear_gear_num, rear_gear, front_gear_num)
 		},
 		{
-			name: "expand components invalid fieldnum",
-			mesg: factory.CreateMesgOnly(mesgnum.Record).WithFields(
-				factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed).WithValue(uint16(1000)),
-			),
-			containingField: factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed).WithValue(uint16(1000)),
-			components: []proto.Component{
-				{
-					FieldNum: 255, // invalid
-				},
-			},
-			nFieldAfterExpansion: 1,
-		},
-		{
 			name: "expand components containing field value mismatch",
 			mesg: factory.CreateMesgOnly(mesgnum.Record).WithFields(
 				factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed).WithValue("invalid value"),


### PR DESCRIPTION
- component expansion is no longer using map to hold the bit value since it will only hold containingField's value
- remove unecessary check on component.FieldNum, we have no invalid component.FieldNum in the factory