### PR TITLE
feat(kit): datetime's ToLocalTime now support value already in time

### DIFF
--- a/kit/datetime/datetime.go
+++ b/kit/datetime/datetime.go
@@ -40,8 +40,12 @@ func ToTime(value any) time.Time {
 
 // ToLocalTime returns time in local time zone by specifying the time zone offset hours (+7 for GMT+7).
 func ToLocalTime(value any, tzOffsetHours int) time.Time {
-	t := ToTime(value)
-	if t == (time.Time{}) {
+	t, ok := value.(time.Time)
+	if !ok {
+		t = ToTime(value)
+	}
+
+	if t.IsZero() {
 		return t
 	}
 

--- a/kit/datetime/datetime_test.go
+++ b/kit/datetime/datetime_test.go
@@ -45,7 +45,7 @@ func TestToTime(t *testing.T) {
 	}
 }
 
-func Test(t *testing.T) {
+func TestToLocalTime(t *testing.T) {
 	locJakarta, err := time.LoadLocation("Asia/Jakarta")
 	if err != nil {
 		t.Fatal(err)
@@ -66,6 +66,11 @@ func Test(t *testing.T) {
 			value:  1029622579, // int int
 			result: time.Time{},
 		},
+		{
+			name:   "value is already in time.Time",
+			value:  time.Date(2022, 8, 17, 05, 16, 19, 0, time.UTC),
+			result: time.Date(2022, 8, 17, 12, 16, 19, 0, locJakarta),
+		},
 	}
 
 	for _, tc := range tt {
@@ -78,6 +83,7 @@ func Test(t *testing.T) {
 	}
 }
 
+// 2022-08-17T05:16:19+07:00, got: 2022-08-17T12:16:19+07:00
 func TestTzOffsetHours(t *testing.T) {
 	tt := []struct {
 		name          string


### PR DESCRIPTION
Sometimes we implement a listener that already convert `uint32 time` into `time.Time{}`. And since we can only convert timestamp to local time after retrieving `Activity mesg` which typically located at the end of the file, it is make sense to accept time.Time{} to proceed the conversion later on.