### PR TITLE
internal: update fitgen relative path and add units in fieldnum

### DIFF
--- a/internal/cmd/fitgen/profile/builder.go
+++ b/internal/cmd/fitgen/profile/builder.go
@@ -38,7 +38,9 @@ func NewBuilder(path, sdkVersion string, types []parser.Type) builder.Builder {
 	return &profilebuilder{
 		template: template.Must(template.New("main").
 			Funcs(shared.FuncMap()).
-			ParseFiles(filepath.Join(cd, "profile.tmpl"), "builder/shared/constant.tmpl")),
+			ParseFiles(
+				filepath.Join(cd, "profile.tmpl"),
+				filepath.Join(cd, "..", "builder", "shared", "constant.tmpl"))),
 		path:       filepath.Join(path, "profile"),
 		sdkVersion: sdkVersion,
 		types:      types,

--- a/internal/cmd/fitgen/profile/typedef/builder.go
+++ b/internal/cmd/fitgen/profile/typedef/builder.go
@@ -37,7 +37,9 @@ func NewBuilder(path, sdkVersion string, types []parser.Type) builder.Builder {
 	return &typebuilder{
 		template: template.Must(template.New("main").
 			Funcs(shared.FuncMap()).
-			ParseFiles(filepath.Join(cd, "typedef.tmpl"), "builder/shared/constant.tmpl")),
+			ParseFiles(
+				filepath.Join(cd, "typedef.tmpl"),
+				filepath.Join(cd, "..", "..", "builder", "shared", "constant.tmpl"))),
 		templateExec: "typedef",
 		path:         filepath.Join(path, "profile", "typedef"),
 		sdkVersion:   sdkVersion,

--- a/internal/cmd/fitgen/profile/untyped/fieldnum/builder.go
+++ b/internal/cmd/fitgen/profile/untyped/fieldnum/builder.go
@@ -46,7 +46,9 @@ func NewBuilder(path, version string, message []parser.Message, types []parser.T
 	return &fieldnumBuilder{
 		template: template.Must(template.New("main").
 			Funcs(shared.FuncMap()).
-			ParseFiles(filepath.Join(cd, "fieldnum.tmpl"), "builder/shared/untyped_constant.tmpl")),
+			ParseFiles(
+				filepath.Join(cd, "fieldnum.tmpl"),
+				filepath.Join(cd, "..", "..", "..", "builder", "shared", "untyped_constant.tmpl"))),
 		templateExec: "fieldnum",
 		path:         filepath.Join(path, "profile", "untyped", "fieldnum"),
 		sdkVersion:   version,
@@ -84,16 +86,23 @@ func (b *fieldnumBuilder) Build() ([]builder.Data, error) {
 			if scale != 1 || offset != 0 {
 				scaleOffset = fmt.Sprintf(", Scale: %g, Offset: %g", scale, offset)
 			}
+
+			var units string
+			if field.Units != "" {
+				units = fmt.Sprintf(", Units: %s", field.Units)
+			}
+
 			c := shared.Constant{
 				Name:   strutil.ToTitle(mesg.Name) + strutil.ToTitle(field.Name),
 				Type:   _type,
 				Op:     "=",
 				Value:  strconv.Itoa(int(field.Num)),
 				String: mesg.Name + ": " + field.Name,
-				Comment: fmt.Sprintf("[Type: %s, Base: %s%s]; %s",
+				Comment: fmt.Sprintf("[Type: %s, Base: %s%s%s]; %s",
 					strutil.ToTitle(field.Type),
 					b.baseTypeMapByProfileType[field.Type],
 					scaleOffset,
+					units,
 					field.Comment),
 			}
 			constants = append(constants, c)

--- a/internal/cmd/fitgen/profile/untyped/mesgnum/builder.go
+++ b/internal/cmd/fitgen/profile/untyped/mesgnum/builder.go
@@ -36,7 +36,9 @@ func NewBuilder(path, sdkVersion string, types []parser.Type) builder.Builder {
 	return &mesgnumbuilder{
 		template: template.Must(template.New("main").
 			Funcs(shared.FuncMap()).
-			ParseFiles(filepath.Join(cd, "mesgnum.tmpl"), "builder/shared/untyped_constant.tmpl")),
+			ParseFiles(
+				filepath.Join(cd, "mesgnum.tmpl"),
+				filepath.Join(cd, "..", "..", "..", "builder", "shared", "untyped_constant.tmpl"))),
 		templateExec: "mesgnum",
 		path:         filepath.Join(path, "profile", "untyped", "mesgnum"),
 		sdkVersion:   sdkVersion,


### PR DESCRIPTION
- update fitgen builder's relative path which was relative to main, now relative to the caller file itself, this is to enable running the cli from any path rather than only from main executable path.

- add Units in fieldnum constants to help users know the units right from code documentation.