### PR TITLE
chore: fitgen's mesgdef: simplify builder and only create array as needed

### DIFF
--- a/internal/cmd/fitgen/profile/mesgdef/builder.go
+++ b/internal/cmd/fitgen/profile/mesgdef/builder.go
@@ -80,7 +80,6 @@ func (b *mesgdefBuilder) Build() ([]builder.Data, error) {
 				Name:          strutil.ToTitle(mesg.Fields[i].Name),
 				String:        field.Name,
 				Type:          transformType(field.Type, field.Array),
-				InvalidValue:  b.baseTypeInvalid(strutil.ToTitle(b.baseTypeMapByProfileType[field.Type]), field.Array),
 				AssignedValue: b.transformValue(field.Num, field.Type, field.Array),
 				Comment:       field.Comment,
 			}
@@ -105,12 +104,8 @@ func (b *mesgdefBuilder) Build() ([]builder.Data, error) {
 			}
 
 			fields = append(fields, f)
-			if strings.HasPrefix(f.InvalidValue, "basetype") {
+			if strings.HasPrefix(f.Type, "basetype") {
 				imports["github.com/muktihari/fit/profile/basetype"] = struct{}{}
-			}
-
-			if strings.HasPrefix(f.InvalidValue, "math") {
-				imports["math"] = struct{}{}
 			}
 		}
 
@@ -131,26 +126,6 @@ func (b *mesgdefBuilder) Build() ([]builder.Data, error) {
 	}
 
 	return dataBuilders, nil
-}
-
-func (b *mesgdefBuilder) baseTypeInvalid(_type, array string) string {
-	if strings.ToLower(_type) == "bool" {
-		return "false"
-	}
-
-	if array == "" {
-		if strings.HasPrefix(_type, "Float32") {
-			return fmt.Sprintf("math.Float32frombits(basetype.%sInvalid)", _type)
-		}
-
-		if strings.HasPrefix(_type, "Float64") {
-			return fmt.Sprintf("math.Float64frombits(basetype.%sInvalid)", _type)
-		}
-
-		return fmt.Sprintf("basetype.%sInvalid", _type)
-	}
-
-	return "nil"
 }
 
 func transformType(name, array string) string {

--- a/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
+++ b/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
@@ -38,17 +38,18 @@ func New{{ .Name }}(mesg proto.Message) *{{ .Name }} {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
 		{{ range .Fields -}}
-			{{ .Num }}: {{ .InvalidValue }}, /* {{ .Name }} */
+			{{ .Num }}: nil, /* {{ .Name }} */
 		{{ end -}}
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &{{ .Name }}{
@@ -75,18 +76,22 @@ func (m {{ .Name }}) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		{{ range .Fields -}}
 			{{ .Num }}: m.{{ .Name }},
 		{{ end -}}
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
 
-	{{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
+	{{ if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
 	mesg.DeveloperFields = m.DeveloperFields
-	{{ end }}
+	{{ end -}}
 }
 {{ end }}

--- a/profile/mesgdef/accelerometer_data_gen.go
+++ b/profile/mesgdef/accelerometer_data_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -40,26 +39,27 @@ func NewAccelerometerData(mesg proto.Message) *AccelerometerData {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* TimestampMs */
-		1:   nil,                    /* SampleTimeOffset */
-		2:   nil,                    /* AccelX */
-		3:   nil,                    /* AccelY */
-		4:   nil,                    /* AccelZ */
-		5:   nil,                    /* CalibratedAccelX */
-		6:   nil,                    /* CalibratedAccelY */
-		7:   nil,                    /* CalibratedAccelZ */
-		8:   nil,                    /* CompressedCalibratedAccelX */
-		9:   nil,                    /* CompressedCalibratedAccelY */
-		10:  nil,                    /* CompressedCalibratedAccelZ */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* TimestampMs */
+		1:   nil, /* SampleTimeOffset */
+		2:   nil, /* AccelX */
+		3:   nil, /* AccelY */
+		4:   nil, /* AccelZ */
+		5:   nil, /* CalibratedAccelX */
+		6:   nil, /* CalibratedAccelY */
+		7:   nil, /* CalibratedAccelZ */
+		8:   nil, /* CompressedCalibratedAccelX */
+		9:   nil, /* CompressedCalibratedAccelY */
+		10:  nil, /* CompressedCalibratedAccelZ */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &AccelerometerData{
@@ -93,7 +93,7 @@ func (m AccelerometerData) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.TimestampMs,
 		1:   m.SampleTimeOffset,
@@ -109,8 +109,12 @@ func (m AccelerometerData) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/ant_channel_id_gen.go
+++ b/profile/mesgdef/ant_channel_id_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -33,19 +32,20 @@ func NewAntChannelId(mesg proto.Message) *AntChannelId {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0: basetype.Uint8Invalid,   /* ChannelNumber */
-		1: basetype.Uint8zInvalid,  /* DeviceType */
-		2: basetype.Uint16zInvalid, /* DeviceNumber */
-		3: basetype.Uint8zInvalid,  /* TransmissionType */
-		4: basetype.Uint8Invalid,   /* DeviceIndex */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0: nil, /* ChannelNumber */
+		1: nil, /* DeviceType */
+		2: nil, /* DeviceNumber */
+		3: nil, /* TransmissionType */
+		4: nil, /* DeviceIndex */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &AntChannelId{
@@ -72,7 +72,7 @@ func (m AntChannelId) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0: m.ChannelNumber,
 		1: m.DeviceType,
 		2: m.DeviceNumber,
@@ -81,8 +81,12 @@ func (m AntChannelId) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/ant_rx_gen.go
+++ b/profile/mesgdef/ant_rx_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -34,20 +33,21 @@ func NewAntRx(mesg proto.Message) *AntRx {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* FractionalTimestamp */
-		1:   basetype.ByteInvalid,   /* MesgId */
-		2:   nil,                    /* MesgData */
-		3:   basetype.Uint8Invalid,  /* ChannelNumber */
-		4:   nil,                    /* Data */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* FractionalTimestamp */
+		1:   nil, /* MesgId */
+		2:   nil, /* MesgData */
+		3:   nil, /* ChannelNumber */
+		4:   nil, /* Data */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &AntRx{
@@ -75,7 +75,7 @@ func (m AntRx) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.FractionalTimestamp,
 		1:   m.MesgId,
@@ -85,8 +85,12 @@ func (m AntRx) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/ant_tx_gen.go
+++ b/profile/mesgdef/ant_tx_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -34,20 +33,21 @@ func NewAntTx(mesg proto.Message) *AntTx {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* FractionalTimestamp */
-		1:   basetype.ByteInvalid,   /* MesgId */
-		2:   nil,                    /* MesgData */
-		3:   basetype.Uint8Invalid,  /* ChannelNumber */
-		4:   nil,                    /* Data */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* FractionalTimestamp */
+		1:   nil, /* MesgId */
+		2:   nil, /* MesgData */
+		3:   nil, /* ChannelNumber */
+		4:   nil, /* Data */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &AntTx{
@@ -75,7 +75,7 @@ func (m AntTx) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.FractionalTimestamp,
 		1:   m.MesgId,
@@ -85,8 +85,12 @@ func (m AntTx) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/aviation_attitude_gen.go
+++ b/profile/mesgdef/aviation_attitude_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -40,26 +39,27 @@ func NewAviationAttitude(mesg proto.Message) *AviationAttitude {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* TimestampMs */
-		1:   nil,                    /* SystemTime */
-		2:   nil,                    /* Pitch */
-		3:   nil,                    /* Roll */
-		4:   nil,                    /* AccelLateral */
-		5:   nil,                    /* AccelNormal */
-		6:   nil,                    /* TurnRate */
-		7:   nil,                    /* Stage */
-		8:   nil,                    /* AttitudeStageComplete */
-		9:   nil,                    /* Track */
-		10:  nil,                    /* Validity */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* TimestampMs */
+		1:   nil, /* SystemTime */
+		2:   nil, /* Pitch */
+		3:   nil, /* Roll */
+		4:   nil, /* AccelLateral */
+		5:   nil, /* AccelNormal */
+		6:   nil, /* TurnRate */
+		7:   nil, /* Stage */
+		8:   nil, /* AttitudeStageComplete */
+		9:   nil, /* Track */
+		10:  nil, /* Validity */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &AviationAttitude{
@@ -93,7 +93,7 @@ func (m AviationAttitude) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.TimestampMs,
 		1:   m.SystemTime,
@@ -109,8 +109,12 @@ func (m AviationAttitude) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/barometer_data_gen.go
+++ b/profile/mesgdef/barometer_data_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -32,18 +31,19 @@ func NewBarometerData(mesg proto.Message) *BarometerData {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* TimestampMs */
-		1:   nil,                    /* SampleTimeOffset */
-		2:   nil,                    /* BaroPres */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* TimestampMs */
+		1:   nil, /* SampleTimeOffset */
+		2:   nil, /* BaroPres */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &BarometerData{
@@ -69,7 +69,7 @@ func (m BarometerData) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.TimestampMs,
 		1:   m.SampleTimeOffset,
@@ -77,8 +77,12 @@ func (m BarometerData) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/beat_intervals_gen.go
+++ b/profile/mesgdef/beat_intervals_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewBeatIntervals(mesg proto.Message) *BeatIntervals {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* TimestampMs */
-		1:   nil,                    /* Time */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* TimestampMs */
+		1:   nil, /* Time */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &BeatIntervals{
@@ -66,15 +66,19 @@ func (m BeatIntervals) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.TimestampMs,
 		1:   m.Time,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/bike_profile_gen.go
+++ b/profile/mesgdef/bike_profile_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -60,46 +59,47 @@ func NewBikeProfile(mesg proto.Message) *BikeProfile {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid,  /* MessageIndex */
-		0:   basetype.StringInvalid,  /* Name */
-		1:   basetype.EnumInvalid,    /* Sport */
-		2:   basetype.EnumInvalid,    /* SubSport */
-		3:   basetype.Uint32Invalid,  /* Odometer */
-		4:   basetype.Uint16zInvalid, /* BikeSpdAntId */
-		5:   basetype.Uint16zInvalid, /* BikeCadAntId */
-		6:   basetype.Uint16zInvalid, /* BikeSpdcadAntId */
-		7:   basetype.Uint16zInvalid, /* BikePowerAntId */
-		8:   basetype.Uint16Invalid,  /* CustomWheelsize */
-		9:   basetype.Uint16Invalid,  /* AutoWheelsize */
-		10:  basetype.Uint16Invalid,  /* BikeWeight */
-		11:  basetype.Uint16Invalid,  /* PowerCalFactor */
-		12:  false,                   /* AutoWheelCal */
-		13:  false,                   /* AutoPowerZero */
-		14:  basetype.Uint8Invalid,   /* Id */
-		15:  false,                   /* SpdEnabled */
-		16:  false,                   /* CadEnabled */
-		17:  false,                   /* SpdcadEnabled */
-		18:  false,                   /* PowerEnabled */
-		19:  basetype.Uint8Invalid,   /* CrankLength */
-		20:  false,                   /* Enabled */
-		21:  basetype.Uint8zInvalid,  /* BikeSpdAntIdTransType */
-		22:  basetype.Uint8zInvalid,  /* BikeCadAntIdTransType */
-		23:  basetype.Uint8zInvalid,  /* BikeSpdcadAntIdTransType */
-		24:  basetype.Uint8zInvalid,  /* BikePowerAntIdTransType */
-		37:  basetype.Uint8Invalid,   /* OdometerRollover */
-		38:  basetype.Uint8zInvalid,  /* FrontGearNum */
-		39:  nil,                     /* FrontGear */
-		40:  basetype.Uint8zInvalid,  /* RearGearNum */
-		41:  nil,                     /* RearGear */
-		44:  false,                   /* ShimanoDi2Enabled */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* Name */
+		1:   nil, /* Sport */
+		2:   nil, /* SubSport */
+		3:   nil, /* Odometer */
+		4:   nil, /* BikeSpdAntId */
+		5:   nil, /* BikeCadAntId */
+		6:   nil, /* BikeSpdcadAntId */
+		7:   nil, /* BikePowerAntId */
+		8:   nil, /* CustomWheelsize */
+		9:   nil, /* AutoWheelsize */
+		10:  nil, /* BikeWeight */
+		11:  nil, /* PowerCalFactor */
+		12:  nil, /* AutoWheelCal */
+		13:  nil, /* AutoPowerZero */
+		14:  nil, /* Id */
+		15:  nil, /* SpdEnabled */
+		16:  nil, /* CadEnabled */
+		17:  nil, /* SpdcadEnabled */
+		18:  nil, /* PowerEnabled */
+		19:  nil, /* CrankLength */
+		20:  nil, /* Enabled */
+		21:  nil, /* BikeSpdAntIdTransType */
+		22:  nil, /* BikeCadAntIdTransType */
+		23:  nil, /* BikeSpdcadAntIdTransType */
+		24:  nil, /* BikePowerAntIdTransType */
+		37:  nil, /* OdometerRollover */
+		38:  nil, /* FrontGearNum */
+		39:  nil, /* FrontGear */
+		40:  nil, /* RearGearNum */
+		41:  nil, /* RearGear */
+		44:  nil, /* ShimanoDi2Enabled */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &BikeProfile{
@@ -153,7 +153,7 @@ func (m BikeProfile) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.Name,
 		1:   m.Sport,
@@ -189,8 +189,12 @@ func (m BikeProfile) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/blood_pressure_gen.go
+++ b/profile/mesgdef/blood_pressure_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -39,25 +38,26 @@ func NewBloodPressure(mesg proto.Message) *BloodPressure {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* SystolicPressure */
-		1:   basetype.Uint16Invalid, /* DiastolicPressure */
-		2:   basetype.Uint16Invalid, /* MeanArterialPressure */
-		3:   basetype.Uint16Invalid, /* Map3SampleMean */
-		4:   basetype.Uint16Invalid, /* MapMorningValues */
-		5:   basetype.Uint16Invalid, /* MapEveningValues */
-		6:   basetype.Uint8Invalid,  /* HeartRate */
-		7:   basetype.EnumInvalid,   /* HeartRateType */
-		8:   basetype.EnumInvalid,   /* Status */
-		9:   basetype.Uint16Invalid, /* UserProfileIndex */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* SystolicPressure */
+		1:   nil, /* DiastolicPressure */
+		2:   nil, /* MeanArterialPressure */
+		3:   nil, /* Map3SampleMean */
+		4:   nil, /* MapMorningValues */
+		5:   nil, /* MapEveningValues */
+		6:   nil, /* HeartRate */
+		7:   nil, /* HeartRateType */
+		8:   nil, /* Status */
+		9:   nil, /* UserProfileIndex */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &BloodPressure{
@@ -90,7 +90,7 @@ func (m BloodPressure) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.SystolicPressure,
 		1:   m.DiastolicPressure,
@@ -105,8 +105,12 @@ func (m BloodPressure) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/cadence_zone_gen.go
+++ b/profile/mesgdef/cadence_zone_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewCadenceZone(mesg proto.Message) *CadenceZone {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.Uint8Invalid,  /* HighValue */
-		1:   basetype.StringInvalid, /* Name */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* HighValue */
+		1:   nil, /* Name */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &CadenceZone{
@@ -66,15 +66,19 @@ func (m CadenceZone) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.HighValue,
 		1:   m.Name,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/climb_pro_gen.go
+++ b/profile/mesgdef/climb_pro_gen.go
@@ -9,10 +9,8 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
-	"math"
 )
 
 // ClimbPro is a ClimbPro message.
@@ -36,21 +34,22 @@ func NewClimbPro(mesg proto.Message) *ClimbPro {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid,                        /* Timestamp */
-		0:   basetype.Sint32Invalid,                        /* PositionLat */
-		1:   basetype.Sint32Invalid,                        /* PositionLong */
-		2:   basetype.EnumInvalid,                          /* ClimbProEvent */
-		3:   basetype.Uint16Invalid,                        /* ClimbNumber */
-		4:   basetype.Uint8Invalid,                         /* ClimbCategory */
-		5:   math.Float32frombits(basetype.Float32Invalid), /* CurrentDist */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* PositionLat */
+		1:   nil, /* PositionLong */
+		2:   nil, /* ClimbProEvent */
+		3:   nil, /* ClimbNumber */
+		4:   nil, /* ClimbCategory */
+		5:   nil, /* CurrentDist */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &ClimbPro{
@@ -79,7 +78,7 @@ func (m ClimbPro) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.PositionLat,
 		1:   m.PositionLong,
@@ -90,8 +89,12 @@ func (m ClimbPro) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/connectivity_gen.go
+++ b/profile/mesgdef/connectivity_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -41,27 +40,28 @@ func NewConnectivity(mesg proto.Message) *Connectivity {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0:  false,                  /* BluetoothEnabled */
-		1:  false,                  /* BluetoothLeEnabled */
-		2:  false,                  /* AntEnabled */
-		3:  basetype.StringInvalid, /* Name */
-		4:  false,                  /* LiveTrackingEnabled */
-		5:  false,                  /* WeatherConditionsEnabled */
-		6:  false,                  /* WeatherAlertsEnabled */
-		7:  false,                  /* AutoActivityUploadEnabled */
-		8:  false,                  /* CourseDownloadEnabled */
-		9:  false,                  /* WorkoutDownloadEnabled */
-		10: false,                  /* GpsEphemerisDownloadEnabled */
-		11: false,                  /* IncidentDetectionEnabled */
-		12: false,                  /* GrouptrackEnabled */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0:  nil, /* BluetoothEnabled */
+		1:  nil, /* BluetoothLeEnabled */
+		2:  nil, /* AntEnabled */
+		3:  nil, /* Name */
+		4:  nil, /* LiveTrackingEnabled */
+		5:  nil, /* WeatherConditionsEnabled */
+		6:  nil, /* WeatherAlertsEnabled */
+		7:  nil, /* AutoActivityUploadEnabled */
+		8:  nil, /* CourseDownloadEnabled */
+		9:  nil, /* WorkoutDownloadEnabled */
+		10: nil, /* GpsEphemerisDownloadEnabled */
+		11: nil, /* IncidentDetectionEnabled */
+		12: nil, /* GrouptrackEnabled */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Connectivity{
@@ -96,7 +96,7 @@ func (m Connectivity) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0:  m.BluetoothEnabled,
 		1:  m.BluetoothLeEnabled,
 		2:  m.AntEnabled,
@@ -113,8 +113,12 @@ func (m Connectivity) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/course_gen.go
+++ b/profile/mesgdef/course_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -32,18 +31,19 @@ func NewCourse(mesg proto.Message) *Course {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		4: basetype.EnumInvalid,    /* Sport */
-		5: basetype.StringInvalid,  /* Name */
-		6: basetype.Uint32zInvalid, /* Capabilities */
-		7: basetype.EnumInvalid,    /* SubSport */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		4: nil, /* Sport */
+		5: nil, /* Name */
+		6: nil, /* Capabilities */
+		7: nil, /* SubSport */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Course{
@@ -69,7 +69,7 @@ func (m Course) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		4: m.Sport,
 		5: m.Name,
 		6: m.Capabilities,
@@ -77,8 +77,12 @@ func (m Course) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/developer_data_id_gen.go
+++ b/profile/mesgdef/developer_data_id_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -29,19 +28,20 @@ func NewDeveloperDataId(mesg proto.Message) *DeveloperDataId {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0: nil,                    /* DeveloperId */
-		1: nil,                    /* ApplicationId */
-		2: basetype.Uint16Invalid, /* ManufacturerId */
-		3: basetype.Uint8Invalid,  /* DeveloperDataIndex */
-		4: basetype.Uint32Invalid, /* ApplicationVersion */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0: nil, /* DeveloperId */
+		1: nil, /* ApplicationId */
+		2: nil, /* ManufacturerId */
+		3: nil, /* DeveloperDataIndex */
+		4: nil, /* ApplicationVersion */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &DeveloperDataId{
@@ -66,7 +66,7 @@ func (m DeveloperDataId) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0: m.DeveloperId,
 		1: m.ApplicationId,
 		2: m.ManufacturerId,
@@ -75,6 +75,11 @@ func (m DeveloperDataId) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
+
 }

--- a/profile/mesgdef/device_info_gen.go
+++ b/profile/mesgdef/device_info_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -47,33 +46,34 @@ func NewDeviceInfo(mesg proto.Message) *DeviceInfo {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid,  /* Timestamp */
-		0:   basetype.Uint8Invalid,   /* DeviceIndex */
-		1:   basetype.Uint8Invalid,   /* DeviceType */
-		2:   basetype.Uint16Invalid,  /* Manufacturer */
-		3:   basetype.Uint32zInvalid, /* SerialNumber */
-		4:   basetype.Uint16Invalid,  /* Product */
-		5:   basetype.Uint16Invalid,  /* SoftwareVersion */
-		6:   basetype.Uint8Invalid,   /* HardwareVersion */
-		7:   basetype.Uint32Invalid,  /* CumOperatingTime */
-		10:  basetype.Uint16Invalid,  /* BatteryVoltage */
-		11:  basetype.Uint8Invalid,   /* BatteryStatus */
-		18:  basetype.EnumInvalid,    /* SensorPosition */
-		19:  basetype.StringInvalid,  /* Descriptor */
-		20:  basetype.Uint8zInvalid,  /* AntTransmissionType */
-		21:  basetype.Uint16zInvalid, /* AntDeviceNumber */
-		22:  basetype.EnumInvalid,    /* AntNetwork */
-		25:  basetype.EnumInvalid,    /* SourceType */
-		27:  basetype.StringInvalid,  /* ProductName */
-		32:  basetype.Uint8Invalid,   /* BatteryLevel */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* DeviceIndex */
+		1:   nil, /* DeviceType */
+		2:   nil, /* Manufacturer */
+		3:   nil, /* SerialNumber */
+		4:   nil, /* Product */
+		5:   nil, /* SoftwareVersion */
+		6:   nil, /* HardwareVersion */
+		7:   nil, /* CumOperatingTime */
+		10:  nil, /* BatteryVoltage */
+		11:  nil, /* BatteryStatus */
+		18:  nil, /* SensorPosition */
+		19:  nil, /* Descriptor */
+		20:  nil, /* AntTransmissionType */
+		21:  nil, /* AntDeviceNumber */
+		22:  nil, /* AntNetwork */
+		25:  nil, /* SourceType */
+		27:  nil, /* ProductName */
+		32:  nil, /* BatteryLevel */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &DeviceInfo{
@@ -114,7 +114,7 @@ func (m DeviceInfo) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.DeviceIndex,
 		1:   m.DeviceType,
@@ -137,8 +137,12 @@ func (m DeviceInfo) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/device_settings_gen.go
+++ b/profile/mesgdef/device_settings_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -52,38 +51,39 @@ func NewDeviceSettings(mesg proto.Message) *DeviceSettings {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0:   basetype.Uint8Invalid,  /* ActiveTimeZone */
-		1:   basetype.Uint32Invalid, /* UtcOffset */
-		2:   nil,                    /* TimeOffset */
-		4:   nil,                    /* TimeMode */
-		5:   nil,                    /* TimeZoneOffset */
-		12:  basetype.EnumInvalid,   /* BacklightMode */
-		36:  false,                  /* ActivityTrackerEnabled */
-		39:  basetype.Uint32Invalid, /* ClockTime */
-		40:  nil,                    /* PagesEnabled */
-		46:  false,                  /* MoveAlertEnabled */
-		47:  basetype.EnumInvalid,   /* DateMode */
-		55:  basetype.EnumInvalid,   /* DisplayOrientation */
-		56:  basetype.EnumInvalid,   /* MountingSide */
-		57:  nil,                    /* DefaultPage */
-		58:  basetype.Uint16Invalid, /* AutosyncMinSteps */
-		59:  basetype.Uint16Invalid, /* AutosyncMinTime */
-		80:  false,                  /* LactateThresholdAutodetectEnabled */
-		86:  false,                  /* BleAutoUploadEnabled */
-		89:  basetype.EnumInvalid,   /* AutoSyncFrequency */
-		90:  basetype.Uint32Invalid, /* AutoActivityDetect */
-		94:  basetype.Uint8Invalid,  /* NumberOfScreens */
-		95:  basetype.EnumInvalid,   /* SmartNotificationDisplayOrientation */
-		134: basetype.EnumInvalid,   /* TapInterface */
-		174: basetype.EnumInvalid,   /* TapSensitivity */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0:   nil, /* ActiveTimeZone */
+		1:   nil, /* UtcOffset */
+		2:   nil, /* TimeOffset */
+		4:   nil, /* TimeMode */
+		5:   nil, /* TimeZoneOffset */
+		12:  nil, /* BacklightMode */
+		36:  nil, /* ActivityTrackerEnabled */
+		39:  nil, /* ClockTime */
+		40:  nil, /* PagesEnabled */
+		46:  nil, /* MoveAlertEnabled */
+		47:  nil, /* DateMode */
+		55:  nil, /* DisplayOrientation */
+		56:  nil, /* MountingSide */
+		57:  nil, /* DefaultPage */
+		58:  nil, /* AutosyncMinSteps */
+		59:  nil, /* AutosyncMinTime */
+		80:  nil, /* LactateThresholdAutodetectEnabled */
+		86:  nil, /* BleAutoUploadEnabled */
+		89:  nil, /* AutoSyncFrequency */
+		90:  nil, /* AutoActivityDetect */
+		94:  nil, /* NumberOfScreens */
+		95:  nil, /* SmartNotificationDisplayOrientation */
+		134: nil, /* TapInterface */
+		174: nil, /* TapSensitivity */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &DeviceSettings{
@@ -129,7 +129,7 @@ func (m DeviceSettings) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0:   m.ActiveTimeZone,
 		1:   m.UtcOffset,
 		2:   m.TimeOffset,
@@ -157,8 +157,12 @@ func (m DeviceSettings) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/dive_alarm_gen.go
+++ b/profile/mesgdef/dive_alarm_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -41,27 +40,28 @@ func NewDiveAlarm(mesg proto.Message) *DiveAlarm {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.Uint32Invalid, /* Depth */
-		1:   basetype.Sint32Invalid, /* Time */
-		2:   false,                  /* Enabled */
-		3:   basetype.EnumInvalid,   /* AlarmType */
-		4:   basetype.EnumInvalid,   /* Sound */
-		5:   nil,                    /* DiveTypes */
-		6:   basetype.Uint32Invalid, /* Id */
-		7:   false,                  /* PopupEnabled */
-		8:   false,                  /* TriggerOnDescent */
-		9:   false,                  /* TriggerOnAscent */
-		10:  false,                  /* Repeating */
-		11:  basetype.Sint32Invalid, /* Speed */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* Depth */
+		1:   nil, /* Time */
+		2:   nil, /* Enabled */
+		3:   nil, /* AlarmType */
+		4:   nil, /* Sound */
+		5:   nil, /* DiveTypes */
+		6:   nil, /* Id */
+		7:   nil, /* PopupEnabled */
+		8:   nil, /* TriggerOnDescent */
+		9:   nil, /* TriggerOnAscent */
+		10:  nil, /* Repeating */
+		11:  nil, /* Speed */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &DiveAlarm{
@@ -96,7 +96,7 @@ func (m DiveAlarm) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.Depth,
 		1:   m.Time,
@@ -113,8 +113,12 @@ func (m DiveAlarm) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/dive_apnea_alarm_gen.go
+++ b/profile/mesgdef/dive_apnea_alarm_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -41,27 +40,28 @@ func NewDiveApneaAlarm(mesg proto.Message) *DiveApneaAlarm {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.Uint32Invalid, /* Depth */
-		1:   basetype.Sint32Invalid, /* Time */
-		2:   false,                  /* Enabled */
-		3:   basetype.EnumInvalid,   /* AlarmType */
-		4:   basetype.EnumInvalid,   /* Sound */
-		5:   nil,                    /* DiveTypes */
-		6:   basetype.Uint32Invalid, /* Id */
-		7:   false,                  /* PopupEnabled */
-		8:   false,                  /* TriggerOnDescent */
-		9:   false,                  /* TriggerOnAscent */
-		10:  false,                  /* Repeating */
-		11:  basetype.Sint32Invalid, /* Speed */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* Depth */
+		1:   nil, /* Time */
+		2:   nil, /* Enabled */
+		3:   nil, /* AlarmType */
+		4:   nil, /* Sound */
+		5:   nil, /* DiveTypes */
+		6:   nil, /* Id */
+		7:   nil, /* PopupEnabled */
+		8:   nil, /* TriggerOnDescent */
+		9:   nil, /* TriggerOnAscent */
+		10:  nil, /* Repeating */
+		11:  nil, /* Speed */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &DiveApneaAlarm{
@@ -96,7 +96,7 @@ func (m DiveApneaAlarm) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.Depth,
 		1:   m.Time,
@@ -113,8 +113,12 @@ func (m DiveApneaAlarm) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/dive_settings_gen.go
+++ b/profile/mesgdef/dive_settings_gen.go
@@ -9,10 +9,8 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
-	"math"
 )
 
 // DiveSettings is a DiveSettings message.
@@ -64,49 +62,50 @@ func NewDiveSettings(mesg proto.Message) *DiveSettings {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid,                        /* Timestamp */
-		254: basetype.Uint16Invalid,                        /* MessageIndex */
-		0:   basetype.StringInvalid,                        /* Name */
-		1:   basetype.EnumInvalid,                          /* Model */
-		2:   basetype.Uint8Invalid,                         /* GfLow */
-		3:   basetype.Uint8Invalid,                         /* GfHigh */
-		4:   basetype.EnumInvalid,                          /* WaterType */
-		5:   math.Float32frombits(basetype.Float32Invalid), /* WaterDensity */
-		6:   basetype.Uint8Invalid,                         /* Po2Warn */
-		7:   basetype.Uint8Invalid,                         /* Po2Critical */
-		8:   basetype.Uint8Invalid,                         /* Po2Deco */
-		9:   false,                                         /* SafetyStopEnabled */
-		10:  math.Float32frombits(basetype.Float32Invalid), /* BottomDepth */
-		11:  basetype.Uint32Invalid,                        /* BottomTime */
-		12:  false,                                         /* ApneaCountdownEnabled */
-		13:  basetype.Uint32Invalid,                        /* ApneaCountdownTime */
-		14:  basetype.EnumInvalid,                          /* BacklightMode */
-		15:  basetype.Uint8Invalid,                         /* BacklightBrightness */
-		16:  basetype.Uint8Invalid,                         /* BacklightTimeout */
-		17:  basetype.Uint16Invalid,                        /* RepeatDiveInterval */
-		18:  basetype.Uint16Invalid,                        /* SafetyStopTime */
-		19:  basetype.EnumInvalid,                          /* HeartRateSourceType */
-		20:  basetype.Uint8Invalid,                         /* HeartRateSource */
-		21:  basetype.Uint16Invalid,                        /* TravelGas */
-		22:  basetype.EnumInvalid,                          /* CcrLowSetpointSwitchMode */
-		23:  basetype.Uint8Invalid,                         /* CcrLowSetpoint */
-		24:  basetype.Uint32Invalid,                        /* CcrLowSetpointDepth */
-		25:  basetype.EnumInvalid,                          /* CcrHighSetpointSwitchMode */
-		26:  basetype.Uint8Invalid,                         /* CcrHighSetpoint */
-		27:  basetype.Uint32Invalid,                        /* CcrHighSetpointDepth */
-		29:  basetype.EnumInvalid,                          /* GasConsumptionDisplay */
-		30:  false,                                         /* UpKeyEnabled */
-		35:  basetype.EnumInvalid,                          /* DiveSounds */
-		36:  basetype.Uint8Invalid,                         /* LastStopMultiple */
-		37:  basetype.EnumInvalid,                          /* NoFlyTimeMode */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		254: nil, /* MessageIndex */
+		0:   nil, /* Name */
+		1:   nil, /* Model */
+		2:   nil, /* GfLow */
+		3:   nil, /* GfHigh */
+		4:   nil, /* WaterType */
+		5:   nil, /* WaterDensity */
+		6:   nil, /* Po2Warn */
+		7:   nil, /* Po2Critical */
+		8:   nil, /* Po2Deco */
+		9:   nil, /* SafetyStopEnabled */
+		10:  nil, /* BottomDepth */
+		11:  nil, /* BottomTime */
+		12:  nil, /* ApneaCountdownEnabled */
+		13:  nil, /* ApneaCountdownTime */
+		14:  nil, /* BacklightMode */
+		15:  nil, /* BacklightBrightness */
+		16:  nil, /* BacklightTimeout */
+		17:  nil, /* RepeatDiveInterval */
+		18:  nil, /* SafetyStopTime */
+		19:  nil, /* HeartRateSourceType */
+		20:  nil, /* HeartRateSource */
+		21:  nil, /* TravelGas */
+		22:  nil, /* CcrLowSetpointSwitchMode */
+		23:  nil, /* CcrLowSetpoint */
+		24:  nil, /* CcrLowSetpointDepth */
+		25:  nil, /* CcrHighSetpointSwitchMode */
+		26:  nil, /* CcrHighSetpoint */
+		27:  nil, /* CcrHighSetpointDepth */
+		29:  nil, /* GasConsumptionDisplay */
+		30:  nil, /* UpKeyEnabled */
+		35:  nil, /* DiveSounds */
+		36:  nil, /* LastStopMultiple */
+		37:  nil, /* NoFlyTimeMode */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &DiveSettings{
@@ -163,7 +162,7 @@ func (m DiveSettings) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		254: m.MessageIndex,
 		0:   m.Name,
@@ -202,8 +201,12 @@ func (m DiveSettings) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/dive_summary_gen.go
+++ b/profile/mesgdef/dive_summary_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -51,37 +50,38 @@ func NewDiveSummary(mesg proto.Message) *DiveSummary {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* ReferenceMesg */
-		1:   basetype.Uint16Invalid, /* ReferenceIndex */
-		2:   basetype.Uint32Invalid, /* AvgDepth */
-		3:   basetype.Uint32Invalid, /* MaxDepth */
-		4:   basetype.Uint32Invalid, /* SurfaceInterval */
-		5:   basetype.Uint8Invalid,  /* StartCns */
-		6:   basetype.Uint8Invalid,  /* EndCns */
-		7:   basetype.Uint16Invalid, /* StartN2 */
-		8:   basetype.Uint16Invalid, /* EndN2 */
-		9:   basetype.Uint16Invalid, /* O2Toxicity */
-		10:  basetype.Uint32Invalid, /* DiveNumber */
-		11:  basetype.Uint32Invalid, /* BottomTime */
-		12:  basetype.Uint16Invalid, /* AvgPressureSac */
-		13:  basetype.Uint16Invalid, /* AvgVolumeSac */
-		14:  basetype.Uint16Invalid, /* AvgRmv */
-		15:  basetype.Uint32Invalid, /* DescentTime */
-		16:  basetype.Uint32Invalid, /* AscentTime */
-		17:  basetype.Sint32Invalid, /* AvgAscentRate */
-		22:  basetype.Uint32Invalid, /* AvgDescentRate */
-		23:  basetype.Uint32Invalid, /* MaxAscentRate */
-		24:  basetype.Uint32Invalid, /* MaxDescentRate */
-		25:  basetype.Uint32Invalid, /* HangTime */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* ReferenceMesg */
+		1:   nil, /* ReferenceIndex */
+		2:   nil, /* AvgDepth */
+		3:   nil, /* MaxDepth */
+		4:   nil, /* SurfaceInterval */
+		5:   nil, /* StartCns */
+		6:   nil, /* EndCns */
+		7:   nil, /* StartN2 */
+		8:   nil, /* EndN2 */
+		9:   nil, /* O2Toxicity */
+		10:  nil, /* DiveNumber */
+		11:  nil, /* BottomTime */
+		12:  nil, /* AvgPressureSac */
+		13:  nil, /* AvgVolumeSac */
+		14:  nil, /* AvgRmv */
+		15:  nil, /* DescentTime */
+		16:  nil, /* AscentTime */
+		17:  nil, /* AvgAscentRate */
+		22:  nil, /* AvgDescentRate */
+		23:  nil, /* MaxAscentRate */
+		24:  nil, /* MaxDescentRate */
+		25:  nil, /* HangTime */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &DiveSummary{
@@ -126,7 +126,7 @@ func (m DiveSummary) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.ReferenceMesg,
 		1:   m.ReferenceIndex,
@@ -153,8 +153,12 @@ func (m DiveSummary) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/event_gen.go
+++ b/profile/mesgdef/event_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -47,33 +46,34 @@ func NewEvent(mesg proto.Message) *Event {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.EnumInvalid,   /* Event */
-		1:   basetype.EnumInvalid,   /* EventType */
-		2:   basetype.Uint16Invalid, /* Data16 */
-		3:   basetype.Uint32Invalid, /* Data */
-		4:   basetype.Uint8Invalid,  /* EventGroup */
-		7:   basetype.Uint16Invalid, /* Score */
-		8:   basetype.Uint16Invalid, /* OpponentScore */
-		9:   basetype.Uint8zInvalid, /* FrontGearNum */
-		10:  basetype.Uint8zInvalid, /* FrontGear */
-		11:  basetype.Uint8zInvalid, /* RearGearNum */
-		12:  basetype.Uint8zInvalid, /* RearGear */
-		13:  basetype.Uint8Invalid,  /* DeviceIndex */
-		14:  basetype.EnumInvalid,   /* ActivityType */
-		15:  basetype.Uint32Invalid, /* StartTimestamp */
-		21:  basetype.EnumInvalid,   /* RadarThreatLevelMax */
-		22:  basetype.Uint8Invalid,  /* RadarThreatCount */
-		23:  basetype.Uint8Invalid,  /* RadarThreatAvgApproachSpeed */
-		24:  basetype.Uint8Invalid,  /* RadarThreatMaxApproachSpeed */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* Event */
+		1:   nil, /* EventType */
+		2:   nil, /* Data16 */
+		3:   nil, /* Data */
+		4:   nil, /* EventGroup */
+		7:   nil, /* Score */
+		8:   nil, /* OpponentScore */
+		9:   nil, /* FrontGearNum */
+		10:  nil, /* FrontGear */
+		11:  nil, /* RearGearNum */
+		12:  nil, /* RearGear */
+		13:  nil, /* DeviceIndex */
+		14:  nil, /* ActivityType */
+		15:  nil, /* StartTimestamp */
+		21:  nil, /* RadarThreatLevelMax */
+		22:  nil, /* RadarThreatCount */
+		23:  nil, /* RadarThreatAvgApproachSpeed */
+		24:  nil, /* RadarThreatMaxApproachSpeed */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Event{
@@ -114,7 +114,7 @@ func (m Event) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.Event,
 		1:   m.EventType,
@@ -137,8 +137,12 @@ func (m Event) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/exd_data_concept_configuration_gen.go
+++ b/profile/mesgdef/exd_data_concept_configuration_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -39,25 +38,26 @@ func NewExdDataConceptConfiguration(mesg proto.Message) *ExdDataConceptConfigura
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0:  basetype.Uint8Invalid, /* ScreenIndex */
-		1:  basetype.ByteInvalid,  /* ConceptField */
-		2:  basetype.Uint8Invalid, /* FieldId */
-		3:  basetype.Uint8Invalid, /* ConceptIndex */
-		4:  basetype.Uint8Invalid, /* DataPage */
-		5:  basetype.Uint8Invalid, /* ConceptKey */
-		6:  basetype.Uint8Invalid, /* Scaling */
-		8:  basetype.EnumInvalid,  /* DataUnits */
-		9:  basetype.EnumInvalid,  /* Qualifier */
-		10: basetype.EnumInvalid,  /* Descriptor */
-		11: false,                 /* IsSigned */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0:  nil, /* ScreenIndex */
+		1:  nil, /* ConceptField */
+		2:  nil, /* FieldId */
+		3:  nil, /* ConceptIndex */
+		4:  nil, /* DataPage */
+		5:  nil, /* ConceptKey */
+		6:  nil, /* Scaling */
+		8:  nil, /* DataUnits */
+		9:  nil, /* Qualifier */
+		10: nil, /* Descriptor */
+		11: nil, /* IsSigned */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &ExdDataConceptConfiguration{
@@ -90,7 +90,7 @@ func (m ExdDataConceptConfiguration) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0:  m.ScreenIndex,
 		1:  m.ConceptField,
 		2:  m.FieldId,
@@ -105,8 +105,12 @@ func (m ExdDataConceptConfiguration) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/exd_screen_configuration_gen.go
+++ b/profile/mesgdef/exd_screen_configuration_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -32,18 +31,19 @@ func NewExdScreenConfiguration(mesg proto.Message) *ExdScreenConfiguration {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0: basetype.Uint8Invalid, /* ScreenIndex */
-		1: basetype.Uint8Invalid, /* FieldCount */
-		2: basetype.EnumInvalid,  /* Layout */
-		3: false,                 /* ScreenEnabled */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0: nil, /* ScreenIndex */
+		1: nil, /* FieldCount */
+		2: nil, /* Layout */
+		3: nil, /* ScreenEnabled */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &ExdScreenConfiguration{
@@ -69,7 +69,7 @@ func (m ExdScreenConfiguration) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0: m.ScreenIndex,
 		1: m.FieldCount,
 		2: m.Layout,
@@ -77,8 +77,12 @@ func (m ExdScreenConfiguration) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/exercise_title_gen.go
+++ b/profile/mesgdef/exercise_title_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -32,18 +31,19 @@ func NewExerciseTitle(mesg proto.Message) *ExerciseTitle {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.Uint16Invalid, /* ExerciseCategory */
-		1:   basetype.Uint16Invalid, /* ExerciseName */
-		2:   nil,                    /* WktStepName */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* ExerciseCategory */
+		1:   nil, /* ExerciseName */
+		2:   nil, /* WktStepName */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &ExerciseTitle{
@@ -69,7 +69,7 @@ func (m ExerciseTitle) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.ExerciseCategory,
 		1:   m.ExerciseName,
@@ -77,8 +77,12 @@ func (m ExerciseTitle) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/field_capabilities_gen.go
+++ b/profile/mesgdef/field_capabilities_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -33,19 +32,20 @@ func NewFieldCapabilities(mesg proto.Message) *FieldCapabilities {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.EnumInvalid,   /* File */
-		1:   basetype.Uint16Invalid, /* MesgNum */
-		2:   basetype.Uint8Invalid,  /* FieldNum */
-		3:   basetype.Uint16Invalid, /* Count */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* File */
+		1:   nil, /* MesgNum */
+		2:   nil, /* FieldNum */
+		3:   nil, /* Count */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &FieldCapabilities{
@@ -72,7 +72,7 @@ func (m FieldCapabilities) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.File,
 		1:   m.MesgNum,
@@ -81,8 +81,12 @@ func (m FieldCapabilities) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/field_description_gen.go
+++ b/profile/mesgdef/field_description_gen.go
@@ -38,28 +38,29 @@ func NewFieldDescription(mesg proto.Message) *FieldDescription {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0:  basetype.Uint8Invalid,  /* DeveloperDataIndex */
-		1:  basetype.Uint8Invalid,  /* FieldDefinitionNumber */
-		2:  basetype.Uint8Invalid,  /* FitBaseTypeId */
-		3:  nil,                    /* FieldName */
-		4:  basetype.Uint8Invalid,  /* Array */
-		5:  basetype.StringInvalid, /* Components */
-		6:  basetype.Uint8Invalid,  /* Scale */
-		7:  basetype.Sint8Invalid,  /* Offset */
-		8:  nil,                    /* Units */
-		9:  basetype.StringInvalid, /* Bits */
-		10: basetype.StringInvalid, /* Accumulate */
-		13: basetype.Uint16Invalid, /* FitBaseUnitId */
-		14: basetype.Uint16Invalid, /* NativeMesgNum */
-		15: basetype.Uint8Invalid,  /* NativeFieldNum */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0:  nil, /* DeveloperDataIndex */
+		1:  nil, /* FieldDefinitionNumber */
+		2:  nil, /* FitBaseTypeId */
+		3:  nil, /* FieldName */
+		4:  nil, /* Array */
+		5:  nil, /* Components */
+		6:  nil, /* Scale */
+		7:  nil, /* Offset */
+		8:  nil, /* Units */
+		9:  nil, /* Bits */
+		10: nil, /* Accumulate */
+		13: nil, /* FitBaseUnitId */
+		14: nil, /* NativeMesgNum */
+		15: nil, /* NativeFieldNum */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &FieldDescription{
@@ -93,7 +94,7 @@ func (m FieldDescription) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0:  m.DeveloperDataIndex,
 		1:  m.FieldDefinitionNumber,
 		2:  m.FitBaseTypeId,
@@ -111,6 +112,11 @@ func (m FieldDescription) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
+
 }

--- a/profile/mesgdef/file_creator_gen.go
+++ b/profile/mesgdef/file_creator_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -30,16 +29,17 @@ func NewFileCreator(mesg proto.Message) *FileCreator {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0: basetype.Uint16Invalid, /* SoftwareVersion */
-		1: basetype.Uint8Invalid,  /* HardwareVersion */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0: nil, /* SoftwareVersion */
+		1: nil, /* HardwareVersion */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &FileCreator{
@@ -63,14 +63,18 @@ func (m FileCreator) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0: m.SoftwareVersion,
 		1: m.HardwareVersion,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/file_id_gen.go
+++ b/profile/mesgdef/file_id_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,21 +30,22 @@ func NewFileId(mesg proto.Message) *FileId {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0: basetype.EnumInvalid,    /* Type */
-		1: basetype.Uint16Invalid,  /* Manufacturer */
-		2: basetype.Uint16Invalid,  /* Product */
-		3: basetype.Uint32zInvalid, /* SerialNumber */
-		4: basetype.Uint32Invalid,  /* TimeCreated */
-		5: basetype.Uint16Invalid,  /* Number */
-		8: basetype.StringInvalid,  /* ProductName */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0: nil, /* Type */
+		1: nil, /* Manufacturer */
+		2: nil, /* Product */
+		3: nil, /* SerialNumber */
+		4: nil, /* TimeCreated */
+		5: nil, /* Number */
+		8: nil, /* ProductName */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &FileId{
@@ -72,7 +72,7 @@ func (m FileId) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0: m.Type,
 		1: m.Manufacturer,
 		2: m.Product,
@@ -83,6 +83,11 @@ func (m FileId) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
+
 }

--- a/profile/mesgdef/goal_gen.go
+++ b/profile/mesgdef/goal_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -41,27 +40,28 @@ func NewGoal(mesg proto.Message) *Goal {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.EnumInvalid,   /* Sport */
-		1:   basetype.EnumInvalid,   /* SubSport */
-		2:   basetype.Uint32Invalid, /* StartDate */
-		3:   basetype.Uint32Invalid, /* EndDate */
-		4:   basetype.EnumInvalid,   /* Type */
-		5:   basetype.Uint32Invalid, /* Value */
-		6:   false,                  /* Repeat */
-		7:   basetype.Uint32Invalid, /* TargetValue */
-		8:   basetype.EnumInvalid,   /* Recurrence */
-		9:   basetype.Uint16Invalid, /* RecurrenceValue */
-		10:  false,                  /* Enabled */
-		11:  basetype.EnumInvalid,   /* Source */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* Sport */
+		1:   nil, /* SubSport */
+		2:   nil, /* StartDate */
+		3:   nil, /* EndDate */
+		4:   nil, /* Type */
+		5:   nil, /* Value */
+		6:   nil, /* Repeat */
+		7:   nil, /* TargetValue */
+		8:   nil, /* Recurrence */
+		9:   nil, /* RecurrenceValue */
+		10:  nil, /* Enabled */
+		11:  nil, /* Source */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Goal{
@@ -96,7 +96,7 @@ func (m Goal) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.Sport,
 		1:   m.SubSport,
@@ -113,8 +113,12 @@ func (m Goal) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/gyroscope_data_gen.go
+++ b/profile/mesgdef/gyroscope_data_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -37,23 +36,24 @@ func NewGyroscopeData(mesg proto.Message) *GyroscopeData {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* TimestampMs */
-		1:   nil,                    /* SampleTimeOffset */
-		2:   nil,                    /* GyroX */
-		3:   nil,                    /* GyroY */
-		4:   nil,                    /* GyroZ */
-		5:   nil,                    /* CalibratedGyroX */
-		6:   nil,                    /* CalibratedGyroY */
-		7:   nil,                    /* CalibratedGyroZ */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* TimestampMs */
+		1:   nil, /* SampleTimeOffset */
+		2:   nil, /* GyroX */
+		3:   nil, /* GyroY */
+		4:   nil, /* GyroZ */
+		5:   nil, /* CalibratedGyroX */
+		6:   nil, /* CalibratedGyroY */
+		7:   nil, /* CalibratedGyroZ */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &GyroscopeData{
@@ -84,7 +84,7 @@ func (m GyroscopeData) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.TimestampMs,
 		1:   m.SampleTimeOffset,
@@ -97,8 +97,12 @@ func (m GyroscopeData) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/hr_gen.go
+++ b/profile/mesgdef/hr_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -34,20 +33,21 @@ func NewHr(mesg proto.Message) *Hr {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* FractionalTimestamp */
-		1:   basetype.Uint8Invalid,  /* Time256 */
-		6:   nil,                    /* FilteredBpm */
-		9:   nil,                    /* EventTimestamp */
-		10:  nil,                    /* EventTimestamp12 */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* FractionalTimestamp */
+		1:   nil, /* Time256 */
+		6:   nil, /* FilteredBpm */
+		9:   nil, /* EventTimestamp */
+		10:  nil, /* EventTimestamp12 */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Hr{
@@ -75,7 +75,7 @@ func (m Hr) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.FractionalTimestamp,
 		1:   m.Time256,
@@ -85,8 +85,12 @@ func (m Hr) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/hrv_gen.go
+++ b/profile/mesgdef/hrv_gen.go
@@ -28,15 +28,16 @@ func NewHrv(mesg proto.Message) *Hrv {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
 		0: nil, /* Time */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Hrv{
@@ -59,13 +60,17 @@ func (m Hrv) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0: m.Time,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/hrv_value_gen.go
+++ b/profile/mesgdef/hrv_value_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -30,16 +29,17 @@ func NewHrvValue(mesg proto.Message) *HrvValue {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* Value */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* Value */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &HrvValue{
@@ -63,14 +63,18 @@ func (m HrvValue) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.Value,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/jump_gen.go
+++ b/profile/mesgdef/jump_gen.go
@@ -9,10 +9,8 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
-	"math"
 )
 
 // Jump is a Jump message.
@@ -39,24 +37,25 @@ func NewJump(mesg proto.Message) *Jump {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid,                        /* Timestamp */
-		0:   math.Float32frombits(basetype.Float32Invalid), /* Distance */
-		1:   math.Float32frombits(basetype.Float32Invalid), /* Height */
-		2:   basetype.Uint8Invalid,                         /* Rotations */
-		3:   math.Float32frombits(basetype.Float32Invalid), /* HangTime */
-		4:   math.Float32frombits(basetype.Float32Invalid), /* Score */
-		5:   basetype.Sint32Invalid,                        /* PositionLat */
-		6:   basetype.Sint32Invalid,                        /* PositionLong */
-		7:   basetype.Uint16Invalid,                        /* Speed */
-		8:   basetype.Uint32Invalid,                        /* EnhancedSpeed */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* Distance */
+		1:   nil, /* Height */
+		2:   nil, /* Rotations */
+		3:   nil, /* HangTime */
+		4:   nil, /* Score */
+		5:   nil, /* PositionLat */
+		6:   nil, /* PositionLong */
+		7:   nil, /* Speed */
+		8:   nil, /* EnhancedSpeed */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Jump{
@@ -88,7 +87,7 @@ func (m Jump) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.Distance,
 		1:   m.Height,
@@ -102,8 +101,12 @@ func (m Jump) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/lap_gen.go
+++ b/profile/mesgdef/lap_gen.go
@@ -9,10 +9,8 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
-	"math"
 )
 
 // Lap is a Lap message.
@@ -152,137 +150,138 @@ func NewLap(mesg proto.Message) *Lap {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid,                        /* MessageIndex */
-		253: basetype.Uint32Invalid,                        /* Timestamp */
-		0:   basetype.EnumInvalid,                          /* Event */
-		1:   basetype.EnumInvalid,                          /* EventType */
-		2:   basetype.Uint32Invalid,                        /* StartTime */
-		3:   basetype.Sint32Invalid,                        /* StartPositionLat */
-		4:   basetype.Sint32Invalid,                        /* StartPositionLong */
-		5:   basetype.Sint32Invalid,                        /* EndPositionLat */
-		6:   basetype.Sint32Invalid,                        /* EndPositionLong */
-		7:   basetype.Uint32Invalid,                        /* TotalElapsedTime */
-		8:   basetype.Uint32Invalid,                        /* TotalTimerTime */
-		9:   basetype.Uint32Invalid,                        /* TotalDistance */
-		10:  basetype.Uint32Invalid,                        /* TotalCycles */
-		11:  basetype.Uint16Invalid,                        /* TotalCalories */
-		12:  basetype.Uint16Invalid,                        /* TotalFatCalories */
-		13:  basetype.Uint16Invalid,                        /* AvgSpeed */
-		14:  basetype.Uint16Invalid,                        /* MaxSpeed */
-		15:  basetype.Uint8Invalid,                         /* AvgHeartRate */
-		16:  basetype.Uint8Invalid,                         /* MaxHeartRate */
-		17:  basetype.Uint8Invalid,                         /* AvgCadence */
-		18:  basetype.Uint8Invalid,                         /* MaxCadence */
-		19:  basetype.Uint16Invalid,                        /* AvgPower */
-		20:  basetype.Uint16Invalid,                        /* MaxPower */
-		21:  basetype.Uint16Invalid,                        /* TotalAscent */
-		22:  basetype.Uint16Invalid,                        /* TotalDescent */
-		23:  basetype.EnumInvalid,                          /* Intensity */
-		24:  basetype.EnumInvalid,                          /* LapTrigger */
-		25:  basetype.EnumInvalid,                          /* Sport */
-		26:  basetype.Uint8Invalid,                         /* EventGroup */
-		32:  basetype.Uint16Invalid,                        /* NumLengths */
-		33:  basetype.Uint16Invalid,                        /* NormalizedPower */
-		34:  basetype.Uint16Invalid,                        /* LeftRightBalance */
-		35:  basetype.Uint16Invalid,                        /* FirstLengthIndex */
-		37:  basetype.Uint16Invalid,                        /* AvgStrokeDistance */
-		38:  basetype.EnumInvalid,                          /* SwimStroke */
-		39:  basetype.EnumInvalid,                          /* SubSport */
-		40:  basetype.Uint16Invalid,                        /* NumActiveLengths */
-		41:  basetype.Uint32Invalid,                        /* TotalWork */
-		42:  basetype.Uint16Invalid,                        /* AvgAltitude */
-		43:  basetype.Uint16Invalid,                        /* MaxAltitude */
-		44:  basetype.Uint8Invalid,                         /* GpsAccuracy */
-		45:  basetype.Sint16Invalid,                        /* AvgGrade */
-		46:  basetype.Sint16Invalid,                        /* AvgPosGrade */
-		47:  basetype.Sint16Invalid,                        /* AvgNegGrade */
-		48:  basetype.Sint16Invalid,                        /* MaxPosGrade */
-		49:  basetype.Sint16Invalid,                        /* MaxNegGrade */
-		50:  basetype.Sint8Invalid,                         /* AvgTemperature */
-		51:  basetype.Sint8Invalid,                         /* MaxTemperature */
-		52:  basetype.Uint32Invalid,                        /* TotalMovingTime */
-		53:  basetype.Sint16Invalid,                        /* AvgPosVerticalSpeed */
-		54:  basetype.Sint16Invalid,                        /* AvgNegVerticalSpeed */
-		55:  basetype.Sint16Invalid,                        /* MaxPosVerticalSpeed */
-		56:  basetype.Sint16Invalid,                        /* MaxNegVerticalSpeed */
-		57:  nil,                                           /* TimeInHrZone */
-		58:  nil,                                           /* TimeInSpeedZone */
-		59:  nil,                                           /* TimeInCadenceZone */
-		60:  nil,                                           /* TimeInPowerZone */
-		61:  basetype.Uint16Invalid,                        /* RepetitionNum */
-		62:  basetype.Uint16Invalid,                        /* MinAltitude */
-		63:  basetype.Uint8Invalid,                         /* MinHeartRate */
-		71:  basetype.Uint16Invalid,                        /* WktStepIndex */
-		74:  basetype.Uint16Invalid,                        /* OpponentScore */
-		75:  nil,                                           /* StrokeCount */
-		76:  nil,                                           /* ZoneCount */
-		77:  basetype.Uint16Invalid,                        /* AvgVerticalOscillation */
-		78:  basetype.Uint16Invalid,                        /* AvgStanceTimePercent */
-		79:  basetype.Uint16Invalid,                        /* AvgStanceTime */
-		80:  basetype.Uint8Invalid,                         /* AvgFractionalCadence */
-		81:  basetype.Uint8Invalid,                         /* MaxFractionalCadence */
-		82:  basetype.Uint8Invalid,                         /* TotalFractionalCycles */
-		83:  basetype.Uint16Invalid,                        /* PlayerScore */
-		84:  nil,                                           /* AvgTotalHemoglobinConc */
-		85:  nil,                                           /* MinTotalHemoglobinConc */
-		86:  nil,                                           /* MaxTotalHemoglobinConc */
-		87:  nil,                                           /* AvgSaturatedHemoglobinPercent */
-		88:  nil,                                           /* MinSaturatedHemoglobinPercent */
-		89:  nil,                                           /* MaxSaturatedHemoglobinPercent */
-		91:  basetype.Uint8Invalid,                         /* AvgLeftTorqueEffectiveness */
-		92:  basetype.Uint8Invalid,                         /* AvgRightTorqueEffectiveness */
-		93:  basetype.Uint8Invalid,                         /* AvgLeftPedalSmoothness */
-		94:  basetype.Uint8Invalid,                         /* AvgRightPedalSmoothness */
-		95:  basetype.Uint8Invalid,                         /* AvgCombinedPedalSmoothness */
-		98:  basetype.Uint32Invalid,                        /* TimeStanding */
-		99:  basetype.Uint16Invalid,                        /* StandCount */
-		100: basetype.Sint8Invalid,                         /* AvgLeftPco */
-		101: basetype.Sint8Invalid,                         /* AvgRightPco */
-		102: nil,                                           /* AvgLeftPowerPhase */
-		103: nil,                                           /* AvgLeftPowerPhasePeak */
-		104: nil,                                           /* AvgRightPowerPhase */
-		105: nil,                                           /* AvgRightPowerPhasePeak */
-		106: nil,                                           /* AvgPowerPosition */
-		107: nil,                                           /* MaxPowerPosition */
-		108: nil,                                           /* AvgCadencePosition */
-		109: nil,                                           /* MaxCadencePosition */
-		110: basetype.Uint32Invalid,                        /* EnhancedAvgSpeed */
-		111: basetype.Uint32Invalid,                        /* EnhancedMaxSpeed */
-		112: basetype.Uint32Invalid,                        /* EnhancedAvgAltitude */
-		113: basetype.Uint32Invalid,                        /* EnhancedMinAltitude */
-		114: basetype.Uint32Invalid,                        /* EnhancedMaxAltitude */
-		115: basetype.Uint16Invalid,                        /* AvgLevMotorPower */
-		116: basetype.Uint16Invalid,                        /* MaxLevMotorPower */
-		117: basetype.Uint8Invalid,                         /* LevBatteryConsumption */
-		118: basetype.Uint16Invalid,                        /* AvgVerticalRatio */
-		119: basetype.Uint16Invalid,                        /* AvgStanceTimeBalance */
-		120: basetype.Uint16Invalid,                        /* AvgStepLength */
-		121: basetype.Uint16Invalid,                        /* AvgVam */
-		122: basetype.Uint32Invalid,                        /* AvgDepth */
-		123: basetype.Uint32Invalid,                        /* MaxDepth */
-		124: basetype.Sint8Invalid,                         /* MinTemperature */
-		136: basetype.Uint16Invalid,                        /* EnhancedAvgRespirationRate */
-		137: basetype.Uint16Invalid,                        /* EnhancedMaxRespirationRate */
-		147: basetype.Uint8Invalid,                         /* AvgRespirationRate */
-		148: basetype.Uint8Invalid,                         /* MaxRespirationRate */
-		149: math.Float32frombits(basetype.Float32Invalid), /* TotalGrit */
-		150: math.Float32frombits(basetype.Float32Invalid), /* TotalFlow */
-		151: basetype.Uint16Invalid,                        /* JumpCount */
-		153: math.Float32frombits(basetype.Float32Invalid), /* AvgGrit */
-		154: math.Float32frombits(basetype.Float32Invalid), /* AvgFlow */
-		156: basetype.Uint8Invalid,                         /* TotalFractionalAscent */
-		157: basetype.Uint8Invalid,                         /* TotalFractionalDescent */
-		158: basetype.Uint16Invalid,                        /* AvgCoreTemperature */
-		159: basetype.Uint16Invalid,                        /* MinCoreTemperature */
-		160: basetype.Uint16Invalid,                        /* MaxCoreTemperature */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		253: nil, /* Timestamp */
+		0:   nil, /* Event */
+		1:   nil, /* EventType */
+		2:   nil, /* StartTime */
+		3:   nil, /* StartPositionLat */
+		4:   nil, /* StartPositionLong */
+		5:   nil, /* EndPositionLat */
+		6:   nil, /* EndPositionLong */
+		7:   nil, /* TotalElapsedTime */
+		8:   nil, /* TotalTimerTime */
+		9:   nil, /* TotalDistance */
+		10:  nil, /* TotalCycles */
+		11:  nil, /* TotalCalories */
+		12:  nil, /* TotalFatCalories */
+		13:  nil, /* AvgSpeed */
+		14:  nil, /* MaxSpeed */
+		15:  nil, /* AvgHeartRate */
+		16:  nil, /* MaxHeartRate */
+		17:  nil, /* AvgCadence */
+		18:  nil, /* MaxCadence */
+		19:  nil, /* AvgPower */
+		20:  nil, /* MaxPower */
+		21:  nil, /* TotalAscent */
+		22:  nil, /* TotalDescent */
+		23:  nil, /* Intensity */
+		24:  nil, /* LapTrigger */
+		25:  nil, /* Sport */
+		26:  nil, /* EventGroup */
+		32:  nil, /* NumLengths */
+		33:  nil, /* NormalizedPower */
+		34:  nil, /* LeftRightBalance */
+		35:  nil, /* FirstLengthIndex */
+		37:  nil, /* AvgStrokeDistance */
+		38:  nil, /* SwimStroke */
+		39:  nil, /* SubSport */
+		40:  nil, /* NumActiveLengths */
+		41:  nil, /* TotalWork */
+		42:  nil, /* AvgAltitude */
+		43:  nil, /* MaxAltitude */
+		44:  nil, /* GpsAccuracy */
+		45:  nil, /* AvgGrade */
+		46:  nil, /* AvgPosGrade */
+		47:  nil, /* AvgNegGrade */
+		48:  nil, /* MaxPosGrade */
+		49:  nil, /* MaxNegGrade */
+		50:  nil, /* AvgTemperature */
+		51:  nil, /* MaxTemperature */
+		52:  nil, /* TotalMovingTime */
+		53:  nil, /* AvgPosVerticalSpeed */
+		54:  nil, /* AvgNegVerticalSpeed */
+		55:  nil, /* MaxPosVerticalSpeed */
+		56:  nil, /* MaxNegVerticalSpeed */
+		57:  nil, /* TimeInHrZone */
+		58:  nil, /* TimeInSpeedZone */
+		59:  nil, /* TimeInCadenceZone */
+		60:  nil, /* TimeInPowerZone */
+		61:  nil, /* RepetitionNum */
+		62:  nil, /* MinAltitude */
+		63:  nil, /* MinHeartRate */
+		71:  nil, /* WktStepIndex */
+		74:  nil, /* OpponentScore */
+		75:  nil, /* StrokeCount */
+		76:  nil, /* ZoneCount */
+		77:  nil, /* AvgVerticalOscillation */
+		78:  nil, /* AvgStanceTimePercent */
+		79:  nil, /* AvgStanceTime */
+		80:  nil, /* AvgFractionalCadence */
+		81:  nil, /* MaxFractionalCadence */
+		82:  nil, /* TotalFractionalCycles */
+		83:  nil, /* PlayerScore */
+		84:  nil, /* AvgTotalHemoglobinConc */
+		85:  nil, /* MinTotalHemoglobinConc */
+		86:  nil, /* MaxTotalHemoglobinConc */
+		87:  nil, /* AvgSaturatedHemoglobinPercent */
+		88:  nil, /* MinSaturatedHemoglobinPercent */
+		89:  nil, /* MaxSaturatedHemoglobinPercent */
+		91:  nil, /* AvgLeftTorqueEffectiveness */
+		92:  nil, /* AvgRightTorqueEffectiveness */
+		93:  nil, /* AvgLeftPedalSmoothness */
+		94:  nil, /* AvgRightPedalSmoothness */
+		95:  nil, /* AvgCombinedPedalSmoothness */
+		98:  nil, /* TimeStanding */
+		99:  nil, /* StandCount */
+		100: nil, /* AvgLeftPco */
+		101: nil, /* AvgRightPco */
+		102: nil, /* AvgLeftPowerPhase */
+		103: nil, /* AvgLeftPowerPhasePeak */
+		104: nil, /* AvgRightPowerPhase */
+		105: nil, /* AvgRightPowerPhasePeak */
+		106: nil, /* AvgPowerPosition */
+		107: nil, /* MaxPowerPosition */
+		108: nil, /* AvgCadencePosition */
+		109: nil, /* MaxCadencePosition */
+		110: nil, /* EnhancedAvgSpeed */
+		111: nil, /* EnhancedMaxSpeed */
+		112: nil, /* EnhancedAvgAltitude */
+		113: nil, /* EnhancedMinAltitude */
+		114: nil, /* EnhancedMaxAltitude */
+		115: nil, /* AvgLevMotorPower */
+		116: nil, /* MaxLevMotorPower */
+		117: nil, /* LevBatteryConsumption */
+		118: nil, /* AvgVerticalRatio */
+		119: nil, /* AvgStanceTimeBalance */
+		120: nil, /* AvgStepLength */
+		121: nil, /* AvgVam */
+		122: nil, /* AvgDepth */
+		123: nil, /* MaxDepth */
+		124: nil, /* MinTemperature */
+		136: nil, /* EnhancedAvgRespirationRate */
+		137: nil, /* EnhancedMaxRespirationRate */
+		147: nil, /* AvgRespirationRate */
+		148: nil, /* MaxRespirationRate */
+		149: nil, /* TotalGrit */
+		150: nil, /* TotalFlow */
+		151: nil, /* JumpCount */
+		153: nil, /* AvgGrit */
+		154: nil, /* AvgFlow */
+		156: nil, /* TotalFractionalAscent */
+		157: nil, /* TotalFractionalDescent */
+		158: nil, /* AvgCoreTemperature */
+		159: nil, /* MinCoreTemperature */
+		160: nil, /* MaxCoreTemperature */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Lap{
@@ -427,7 +426,7 @@ func (m Lap) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		253: m.Timestamp,
 		0:   m.Event,
@@ -554,8 +553,12 @@ func (m Lap) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/length_gen.go
+++ b/profile/mesgdef/length_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -50,36 +49,37 @@ func NewLength(mesg proto.Message) *Length {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.EnumInvalid,   /* Event */
-		1:   basetype.EnumInvalid,   /* EventType */
-		2:   basetype.Uint32Invalid, /* StartTime */
-		3:   basetype.Uint32Invalid, /* TotalElapsedTime */
-		4:   basetype.Uint32Invalid, /* TotalTimerTime */
-		5:   basetype.Uint16Invalid, /* TotalStrokes */
-		6:   basetype.Uint16Invalid, /* AvgSpeed */
-		7:   basetype.EnumInvalid,   /* SwimStroke */
-		9:   basetype.Uint8Invalid,  /* AvgSwimmingCadence */
-		10:  basetype.Uint8Invalid,  /* EventGroup */
-		11:  basetype.Uint16Invalid, /* TotalCalories */
-		12:  basetype.EnumInvalid,   /* LengthType */
-		18:  basetype.Uint16Invalid, /* PlayerScore */
-		19:  basetype.Uint16Invalid, /* OpponentScore */
-		20:  nil,                    /* StrokeCount */
-		21:  nil,                    /* ZoneCount */
-		22:  basetype.Uint16Invalid, /* EnhancedAvgRespirationRate */
-		23:  basetype.Uint16Invalid, /* EnhancedMaxRespirationRate */
-		24:  basetype.Uint8Invalid,  /* AvgRespirationRate */
-		25:  basetype.Uint8Invalid,  /* MaxRespirationRate */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		253: nil, /* Timestamp */
+		0:   nil, /* Event */
+		1:   nil, /* EventType */
+		2:   nil, /* StartTime */
+		3:   nil, /* TotalElapsedTime */
+		4:   nil, /* TotalTimerTime */
+		5:   nil, /* TotalStrokes */
+		6:   nil, /* AvgSpeed */
+		7:   nil, /* SwimStroke */
+		9:   nil, /* AvgSwimmingCadence */
+		10:  nil, /* EventGroup */
+		11:  nil, /* TotalCalories */
+		12:  nil, /* LengthType */
+		18:  nil, /* PlayerScore */
+		19:  nil, /* OpponentScore */
+		20:  nil, /* StrokeCount */
+		21:  nil, /* ZoneCount */
+		22:  nil, /* EnhancedAvgRespirationRate */
+		23:  nil, /* EnhancedMaxRespirationRate */
+		24:  nil, /* AvgRespirationRate */
+		25:  nil, /* MaxRespirationRate */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Length{
@@ -123,7 +123,7 @@ func (m Length) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		253: m.Timestamp,
 		0:   m.Event,
@@ -149,8 +149,12 @@ func (m Length) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/magnetometer_data_gen.go
+++ b/profile/mesgdef/magnetometer_data_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -37,23 +36,24 @@ func NewMagnetometerData(mesg proto.Message) *MagnetometerData {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* TimestampMs */
-		1:   nil,                    /* SampleTimeOffset */
-		2:   nil,                    /* MagX */
-		3:   nil,                    /* MagY */
-		4:   nil,                    /* MagZ */
-		5:   nil,                    /* CalibratedMagX */
-		6:   nil,                    /* CalibratedMagY */
-		7:   nil,                    /* CalibratedMagZ */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* TimestampMs */
+		1:   nil, /* SampleTimeOffset */
+		2:   nil, /* MagX */
+		3:   nil, /* MagY */
+		4:   nil, /* MagZ */
+		5:   nil, /* CalibratedMagX */
+		6:   nil, /* CalibratedMagY */
+		7:   nil, /* CalibratedMagZ */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &MagnetometerData{
@@ -84,7 +84,7 @@ func (m MagnetometerData) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.TimestampMs,
 		1:   m.SampleTimeOffset,
@@ -97,8 +97,12 @@ func (m MagnetometerData) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/max_met_data_gen.go
+++ b/profile/mesgdef/max_met_data_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -36,22 +35,23 @@ func NewMaxMetData(mesg proto.Message) *MaxMetData {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0:  basetype.Uint32Invalid, /* UpdateTime */
-		2:  basetype.Uint16Invalid, /* Vo2Max */
-		5:  basetype.EnumInvalid,   /* Sport */
-		6:  basetype.EnumInvalid,   /* SubSport */
-		8:  basetype.EnumInvalid,   /* MaxMetCategory */
-		9:  false,                  /* CalibratedData */
-		12: basetype.EnumInvalid,   /* HrSource */
-		13: basetype.EnumInvalid,   /* SpeedSource */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0:  nil, /* UpdateTime */
+		2:  nil, /* Vo2Max */
+		5:  nil, /* Sport */
+		6:  nil, /* SubSport */
+		8:  nil, /* MaxMetCategory */
+		9:  nil, /* CalibratedData */
+		12: nil, /* HrSource */
+		13: nil, /* SpeedSource */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &MaxMetData{
@@ -81,7 +81,7 @@ func (m MaxMetData) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0:  m.UpdateTime,
 		2:  m.Vo2Max,
 		5:  m.Sport,
@@ -93,8 +93,12 @@ func (m MaxMetData) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/mesg_capabilities_gen.go
+++ b/profile/mesgdef/mesg_capabilities_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -33,19 +32,20 @@ func NewMesgCapabilities(mesg proto.Message) *MesgCapabilities {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.EnumInvalid,   /* File */
-		1:   basetype.Uint16Invalid, /* MesgNum */
-		2:   basetype.EnumInvalid,   /* CountType */
-		3:   basetype.Uint16Invalid, /* Count */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* File */
+		1:   nil, /* MesgNum */
+		2:   nil, /* CountType */
+		3:   nil, /* Count */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &MesgCapabilities{
@@ -72,7 +72,7 @@ func (m MesgCapabilities) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.File,
 		1:   m.MesgNum,
@@ -81,8 +81,12 @@ func (m MesgCapabilities) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/met_zone_gen.go
+++ b/profile/mesgdef/met_zone_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -32,18 +31,19 @@ func NewMetZone(mesg proto.Message) *MetZone {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		1:   basetype.Uint8Invalid,  /* HighBpm */
-		2:   basetype.Uint16Invalid, /* Calories */
-		3:   basetype.Uint8Invalid,  /* FatCalories */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		1:   nil, /* HighBpm */
+		2:   nil, /* Calories */
+		3:   nil, /* FatCalories */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &MetZone{
@@ -69,7 +69,7 @@ func (m MetZone) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		1:   m.HighBpm,
 		2:   m.Calories,
@@ -77,8 +77,12 @@ func (m MetZone) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/monitoring_gen.go
+++ b/profile/mesgdef/monitoring_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -57,43 +56,44 @@ func NewMonitoring(mesg proto.Message) *Monitoring {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint8Invalid,  /* DeviceIndex */
-		1:   basetype.Uint16Invalid, /* Calories */
-		2:   basetype.Uint32Invalid, /* Distance */
-		3:   basetype.Uint32Invalid, /* Cycles */
-		4:   basetype.Uint32Invalid, /* ActiveTime */
-		5:   basetype.EnumInvalid,   /* ActivityType */
-		6:   basetype.EnumInvalid,   /* ActivitySubtype */
-		7:   basetype.EnumInvalid,   /* ActivityLevel */
-		8:   basetype.Uint16Invalid, /* Distance16 */
-		9:   basetype.Uint16Invalid, /* Cycles16 */
-		10:  basetype.Uint16Invalid, /* ActiveTime16 */
-		11:  basetype.Uint32Invalid, /* LocalTimestamp */
-		12:  basetype.Sint16Invalid, /* Temperature */
-		14:  basetype.Sint16Invalid, /* TemperatureMin */
-		15:  basetype.Sint16Invalid, /* TemperatureMax */
-		16:  nil,                    /* ActivityTime */
-		19:  basetype.Uint16Invalid, /* ActiveCalories */
-		24:  basetype.ByteInvalid,   /* CurrentActivityTypeIntensity */
-		25:  basetype.Uint8Invalid,  /* TimestampMin8 */
-		26:  basetype.Uint16Invalid, /* Timestamp16 */
-		27:  basetype.Uint8Invalid,  /* HeartRate */
-		28:  basetype.Uint8Invalid,  /* Intensity */
-		29:  basetype.Uint16Invalid, /* DurationMin */
-		30:  basetype.Uint32Invalid, /* Duration */
-		31:  basetype.Uint32Invalid, /* Ascent */
-		32:  basetype.Uint32Invalid, /* Descent */
-		33:  basetype.Uint16Invalid, /* ModerateActivityMinutes */
-		34:  basetype.Uint16Invalid, /* VigorousActivityMinutes */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* DeviceIndex */
+		1:   nil, /* Calories */
+		2:   nil, /* Distance */
+		3:   nil, /* Cycles */
+		4:   nil, /* ActiveTime */
+		5:   nil, /* ActivityType */
+		6:   nil, /* ActivitySubtype */
+		7:   nil, /* ActivityLevel */
+		8:   nil, /* Distance16 */
+		9:   nil, /* Cycles16 */
+		10:  nil, /* ActiveTime16 */
+		11:  nil, /* LocalTimestamp */
+		12:  nil, /* Temperature */
+		14:  nil, /* TemperatureMin */
+		15:  nil, /* TemperatureMax */
+		16:  nil, /* ActivityTime */
+		19:  nil, /* ActiveCalories */
+		24:  nil, /* CurrentActivityTypeIntensity */
+		25:  nil, /* TimestampMin8 */
+		26:  nil, /* Timestamp16 */
+		27:  nil, /* HeartRate */
+		28:  nil, /* Intensity */
+		29:  nil, /* DurationMin */
+		30:  nil, /* Duration */
+		31:  nil, /* Ascent */
+		32:  nil, /* Descent */
+		33:  nil, /* ModerateActivityMinutes */
+		34:  nil, /* VigorousActivityMinutes */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Monitoring{
@@ -144,7 +144,7 @@ func (m Monitoring) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.DeviceIndex,
 		1:   m.Calories,
@@ -177,8 +177,12 @@ func (m Monitoring) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/monitoring_hr_data_gen.go
+++ b/profile/mesgdef/monitoring_hr_data_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewMonitoringHrData(mesg proto.Message) *MonitoringHrData {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint8Invalid,  /* RestingHeartRate */
-		1:   basetype.Uint8Invalid,  /* CurrentDayRestingHeartRate */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* RestingHeartRate */
+		1:   nil, /* CurrentDayRestingHeartRate */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &MonitoringHrData{
@@ -66,15 +66,19 @@ func (m MonitoringHrData) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.RestingHeartRate,
 		1:   m.CurrentDayRestingHeartRate,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/nmea_sentence_gen.go
+++ b/profile/mesgdef/nmea_sentence_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewNmeaSentence(mesg proto.Message) *NmeaSentence {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* TimestampMs */
-		1:   basetype.StringInvalid, /* Sentence */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* TimestampMs */
+		1:   nil, /* Sentence */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &NmeaSentence{
@@ -66,15 +66,19 @@ func (m NmeaSentence) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.TimestampMs,
 		1:   m.Sentence,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/ohr_settings_gen.go
+++ b/profile/mesgdef/ohr_settings_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -30,16 +29,17 @@ func NewOhrSettings(mesg proto.Message) *OhrSettings {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.EnumInvalid,   /* Enabled */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* Enabled */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &OhrSettings{
@@ -63,14 +63,18 @@ func (m OhrSettings) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.Enabled,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/power_zone_gen.go
+++ b/profile/mesgdef/power_zone_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewPowerZone(mesg proto.Message) *PowerZone {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		1:   basetype.Uint16Invalid, /* HighValue */
-		2:   basetype.StringInvalid, /* Name */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		1:   nil, /* HighValue */
+		2:   nil, /* Name */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &PowerZone{
@@ -66,15 +66,19 @@ func (m PowerZone) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		1:   m.HighValue,
 		2:   m.Name,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/record_gen.go
+++ b/profile/mesgdef/record_gen.go
@@ -9,10 +9,8 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
-	"math"
 )
 
 // Record is a Record message.
@@ -113,98 +111,99 @@ func NewRecord(mesg proto.Message) *Record {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid,                        /* Timestamp */
-		0:   basetype.Sint32Invalid,                        /* PositionLat */
-		1:   basetype.Sint32Invalid,                        /* PositionLong */
-		2:   basetype.Uint16Invalid,                        /* Altitude */
-		3:   basetype.Uint8Invalid,                         /* HeartRate */
-		4:   basetype.Uint8Invalid,                         /* Cadence */
-		5:   basetype.Uint32Invalid,                        /* Distance */
-		6:   basetype.Uint16Invalid,                        /* Speed */
-		7:   basetype.Uint16Invalid,                        /* Power */
-		8:   nil,                                           /* CompressedSpeedDistance */
-		9:   basetype.Sint16Invalid,                        /* Grade */
-		10:  basetype.Uint8Invalid,                         /* Resistance */
-		11:  basetype.Sint32Invalid,                        /* TimeFromCourse */
-		12:  basetype.Uint8Invalid,                         /* CycleLength */
-		13:  basetype.Sint8Invalid,                         /* Temperature */
-		17:  nil,                                           /* Speed1S */
-		18:  basetype.Uint8Invalid,                         /* Cycles */
-		19:  basetype.Uint32Invalid,                        /* TotalCycles */
-		28:  basetype.Uint16Invalid,                        /* CompressedAccumulatedPower */
-		29:  basetype.Uint32Invalid,                        /* AccumulatedPower */
-		30:  basetype.Uint8Invalid,                         /* LeftRightBalance */
-		31:  basetype.Uint8Invalid,                         /* GpsAccuracy */
-		32:  basetype.Sint16Invalid,                        /* VerticalSpeed */
-		33:  basetype.Uint16Invalid,                        /* Calories */
-		39:  basetype.Uint16Invalid,                        /* VerticalOscillation */
-		40:  basetype.Uint16Invalid,                        /* StanceTimePercent */
-		41:  basetype.Uint16Invalid,                        /* StanceTime */
-		42:  basetype.EnumInvalid,                          /* ActivityType */
-		43:  basetype.Uint8Invalid,                         /* LeftTorqueEffectiveness */
-		44:  basetype.Uint8Invalid,                         /* RightTorqueEffectiveness */
-		45:  basetype.Uint8Invalid,                         /* LeftPedalSmoothness */
-		46:  basetype.Uint8Invalid,                         /* RightPedalSmoothness */
-		47:  basetype.Uint8Invalid,                         /* CombinedPedalSmoothness */
-		48:  basetype.Uint8Invalid,                         /* Time128 */
-		49:  basetype.EnumInvalid,                          /* StrokeType */
-		50:  basetype.Uint8Invalid,                         /* Zone */
-		51:  basetype.Uint16Invalid,                        /* BallSpeed */
-		52:  basetype.Uint16Invalid,                        /* Cadence256 */
-		53:  basetype.Uint8Invalid,                         /* FractionalCadence */
-		54:  basetype.Uint16Invalid,                        /* TotalHemoglobinConc */
-		55:  basetype.Uint16Invalid,                        /* TotalHemoglobinConcMin */
-		56:  basetype.Uint16Invalid,                        /* TotalHemoglobinConcMax */
-		57:  basetype.Uint16Invalid,                        /* SaturatedHemoglobinPercent */
-		58:  basetype.Uint16Invalid,                        /* SaturatedHemoglobinPercentMin */
-		59:  basetype.Uint16Invalid,                        /* SaturatedHemoglobinPercentMax */
-		62:  basetype.Uint8Invalid,                         /* DeviceIndex */
-		67:  basetype.Sint8Invalid,                         /* LeftPco */
-		68:  basetype.Sint8Invalid,                         /* RightPco */
-		69:  nil,                                           /* LeftPowerPhase */
-		70:  nil,                                           /* LeftPowerPhasePeak */
-		71:  nil,                                           /* RightPowerPhase */
-		72:  nil,                                           /* RightPowerPhasePeak */
-		73:  basetype.Uint32Invalid,                        /* EnhancedSpeed */
-		78:  basetype.Uint32Invalid,                        /* EnhancedAltitude */
-		81:  basetype.Uint8Invalid,                         /* BatterySoc */
-		82:  basetype.Uint16Invalid,                        /* MotorPower */
-		83:  basetype.Uint16Invalid,                        /* VerticalRatio */
-		84:  basetype.Uint16Invalid,                        /* StanceTimeBalance */
-		85:  basetype.Uint16Invalid,                        /* StepLength */
-		87:  basetype.Uint16Invalid,                        /* CycleLength16 */
-		91:  basetype.Uint32Invalid,                        /* AbsolutePressure */
-		92:  basetype.Uint32Invalid,                        /* Depth */
-		93:  basetype.Uint32Invalid,                        /* NextStopDepth */
-		94:  basetype.Uint32Invalid,                        /* NextStopTime */
-		95:  basetype.Uint32Invalid,                        /* TimeToSurface */
-		96:  basetype.Uint32Invalid,                        /* NdlTime */
-		97:  basetype.Uint8Invalid,                         /* CnsLoad */
-		98:  basetype.Uint16Invalid,                        /* N2Load */
-		99:  basetype.Uint8Invalid,                         /* RespirationRate */
-		108: basetype.Uint16Invalid,                        /* EnhancedRespirationRate */
-		114: math.Float32frombits(basetype.Float32Invalid), /* Grit */
-		115: math.Float32frombits(basetype.Float32Invalid), /* Flow */
-		116: basetype.Uint16Invalid,                        /* CurrentStress */
-		117: basetype.Uint16Invalid,                        /* EbikeTravelRange */
-		118: basetype.Uint8Invalid,                         /* EbikeBatteryLevel */
-		119: basetype.Uint8Invalid,                         /* EbikeAssistMode */
-		120: basetype.Uint8Invalid,                         /* EbikeAssistLevelPercent */
-		123: basetype.Uint32Invalid,                        /* AirTimeRemaining */
-		124: basetype.Uint16Invalid,                        /* PressureSac */
-		125: basetype.Uint16Invalid,                        /* VolumeSac */
-		126: basetype.Uint16Invalid,                        /* Rmv */
-		127: basetype.Sint32Invalid,                        /* AscentRate */
-		129: basetype.Uint8Invalid,                         /* Po2 */
-		139: basetype.Uint16Invalid,                        /* CoreTemperature */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* PositionLat */
+		1:   nil, /* PositionLong */
+		2:   nil, /* Altitude */
+		3:   nil, /* HeartRate */
+		4:   nil, /* Cadence */
+		5:   nil, /* Distance */
+		6:   nil, /* Speed */
+		7:   nil, /* Power */
+		8:   nil, /* CompressedSpeedDistance */
+		9:   nil, /* Grade */
+		10:  nil, /* Resistance */
+		11:  nil, /* TimeFromCourse */
+		12:  nil, /* CycleLength */
+		13:  nil, /* Temperature */
+		17:  nil, /* Speed1S */
+		18:  nil, /* Cycles */
+		19:  nil, /* TotalCycles */
+		28:  nil, /* CompressedAccumulatedPower */
+		29:  nil, /* AccumulatedPower */
+		30:  nil, /* LeftRightBalance */
+		31:  nil, /* GpsAccuracy */
+		32:  nil, /* VerticalSpeed */
+		33:  nil, /* Calories */
+		39:  nil, /* VerticalOscillation */
+		40:  nil, /* StanceTimePercent */
+		41:  nil, /* StanceTime */
+		42:  nil, /* ActivityType */
+		43:  nil, /* LeftTorqueEffectiveness */
+		44:  nil, /* RightTorqueEffectiveness */
+		45:  nil, /* LeftPedalSmoothness */
+		46:  nil, /* RightPedalSmoothness */
+		47:  nil, /* CombinedPedalSmoothness */
+		48:  nil, /* Time128 */
+		49:  nil, /* StrokeType */
+		50:  nil, /* Zone */
+		51:  nil, /* BallSpeed */
+		52:  nil, /* Cadence256 */
+		53:  nil, /* FractionalCadence */
+		54:  nil, /* TotalHemoglobinConc */
+		55:  nil, /* TotalHemoglobinConcMin */
+		56:  nil, /* TotalHemoglobinConcMax */
+		57:  nil, /* SaturatedHemoglobinPercent */
+		58:  nil, /* SaturatedHemoglobinPercentMin */
+		59:  nil, /* SaturatedHemoglobinPercentMax */
+		62:  nil, /* DeviceIndex */
+		67:  nil, /* LeftPco */
+		68:  nil, /* RightPco */
+		69:  nil, /* LeftPowerPhase */
+		70:  nil, /* LeftPowerPhasePeak */
+		71:  nil, /* RightPowerPhase */
+		72:  nil, /* RightPowerPhasePeak */
+		73:  nil, /* EnhancedSpeed */
+		78:  nil, /* EnhancedAltitude */
+		81:  nil, /* BatterySoc */
+		82:  nil, /* MotorPower */
+		83:  nil, /* VerticalRatio */
+		84:  nil, /* StanceTimeBalance */
+		85:  nil, /* StepLength */
+		87:  nil, /* CycleLength16 */
+		91:  nil, /* AbsolutePressure */
+		92:  nil, /* Depth */
+		93:  nil, /* NextStopDepth */
+		94:  nil, /* NextStopTime */
+		95:  nil, /* TimeToSurface */
+		96:  nil, /* NdlTime */
+		97:  nil, /* CnsLoad */
+		98:  nil, /* N2Load */
+		99:  nil, /* RespirationRate */
+		108: nil, /* EnhancedRespirationRate */
+		114: nil, /* Grit */
+		115: nil, /* Flow */
+		116: nil, /* CurrentStress */
+		117: nil, /* EbikeTravelRange */
+		118: nil, /* EbikeBatteryLevel */
+		119: nil, /* EbikeAssistMode */
+		120: nil, /* EbikeAssistLevelPercent */
+		123: nil, /* AirTimeRemaining */
+		124: nil, /* PressureSac */
+		125: nil, /* VolumeSac */
+		126: nil, /* Rmv */
+		127: nil, /* AscentRate */
+		129: nil, /* Po2 */
+		139: nil, /* CoreTemperature */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Record{
@@ -310,7 +309,7 @@ func (m Record) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.PositionLat,
 		1:   m.PositionLong,
@@ -398,8 +397,12 @@ func (m Record) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/respiration_rate_gen.go
+++ b/profile/mesgdef/respiration_rate_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -30,16 +29,17 @@ func NewRespirationRate(mesg proto.Message) *RespirationRate {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Sint16Invalid, /* RespirationRate */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* RespirationRate */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &RespirationRate{
@@ -63,14 +63,18 @@ func (m RespirationRate) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.RespirationRate,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/sdm_profile_gen.go
+++ b/profile/mesgdef/sdm_profile_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -36,22 +35,23 @@ func NewSdmProfile(mesg proto.Message) *SdmProfile {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid,  /* MessageIndex */
-		0:   false,                   /* Enabled */
-		1:   basetype.Uint16zInvalid, /* SdmAntId */
-		2:   basetype.Uint16Invalid,  /* SdmCalFactor */
-		3:   basetype.Uint32Invalid,  /* Odometer */
-		4:   false,                   /* SpeedSource */
-		5:   basetype.Uint8zInvalid,  /* SdmAntIdTransType */
-		7:   basetype.Uint8Invalid,   /* OdometerRollover */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* Enabled */
+		1:   nil, /* SdmAntId */
+		2:   nil, /* SdmCalFactor */
+		3:   nil, /* Odometer */
+		4:   nil, /* SpeedSource */
+		5:   nil, /* SdmAntIdTransType */
+		7:   nil, /* OdometerRollover */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &SdmProfile{
@@ -81,7 +81,7 @@ func (m SdmProfile) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.Enabled,
 		1:   m.SdmAntId,
@@ -93,8 +93,12 @@ func (m SdmProfile) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/segment_id_gen.go
+++ b/profile/mesgdef/segment_id_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -37,23 +36,24 @@ func NewSegmentId(mesg proto.Message) *SegmentId {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0: basetype.StringInvalid, /* Name */
-		1: basetype.StringInvalid, /* Uuid */
-		2: basetype.EnumInvalid,   /* Sport */
-		3: false,                  /* Enabled */
-		4: basetype.Uint32Invalid, /* UserProfilePrimaryKey */
-		5: basetype.Uint32Invalid, /* DeviceId */
-		6: basetype.Uint8Invalid,  /* DefaultRaceLeader */
-		7: basetype.EnumInvalid,   /* DeleteStatus */
-		8: basetype.EnumInvalid,   /* SelectionType */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0: nil, /* Name */
+		1: nil, /* Uuid */
+		2: nil, /* Sport */
+		3: nil, /* Enabled */
+		4: nil, /* UserProfilePrimaryKey */
+		5: nil, /* DeviceId */
+		6: nil, /* DefaultRaceLeader */
+		7: nil, /* DeleteStatus */
+		8: nil, /* SelectionType */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &SegmentId{
@@ -84,7 +84,7 @@ func (m SegmentId) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0: m.Name,
 		1: m.Uuid,
 		2: m.Sport,
@@ -97,8 +97,12 @@ func (m SegmentId) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/segment_lap_gen.go
+++ b/profile/mesgdef/segment_lap_gen.go
@@ -9,10 +9,8 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
-	"math"
 )
 
 // SegmentLap is a SegmentLap message.
@@ -124,109 +122,110 @@ func NewSegmentLap(mesg proto.Message) *SegmentLap {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid,                        /* MessageIndex */
-		253: basetype.Uint32Invalid,                        /* Timestamp */
-		0:   basetype.EnumInvalid,                          /* Event */
-		1:   basetype.EnumInvalid,                          /* EventType */
-		2:   basetype.Uint32Invalid,                        /* StartTime */
-		3:   basetype.Sint32Invalid,                        /* StartPositionLat */
-		4:   basetype.Sint32Invalid,                        /* StartPositionLong */
-		5:   basetype.Sint32Invalid,                        /* EndPositionLat */
-		6:   basetype.Sint32Invalid,                        /* EndPositionLong */
-		7:   basetype.Uint32Invalid,                        /* TotalElapsedTime */
-		8:   basetype.Uint32Invalid,                        /* TotalTimerTime */
-		9:   basetype.Uint32Invalid,                        /* TotalDistance */
-		10:  basetype.Uint32Invalid,                        /* TotalCycles */
-		11:  basetype.Uint16Invalid,                        /* TotalCalories */
-		12:  basetype.Uint16Invalid,                        /* TotalFatCalories */
-		13:  basetype.Uint16Invalid,                        /* AvgSpeed */
-		14:  basetype.Uint16Invalid,                        /* MaxSpeed */
-		15:  basetype.Uint8Invalid,                         /* AvgHeartRate */
-		16:  basetype.Uint8Invalid,                         /* MaxHeartRate */
-		17:  basetype.Uint8Invalid,                         /* AvgCadence */
-		18:  basetype.Uint8Invalid,                         /* MaxCadence */
-		19:  basetype.Uint16Invalid,                        /* AvgPower */
-		20:  basetype.Uint16Invalid,                        /* MaxPower */
-		21:  basetype.Uint16Invalid,                        /* TotalAscent */
-		22:  basetype.Uint16Invalid,                        /* TotalDescent */
-		23:  basetype.EnumInvalid,                          /* Sport */
-		24:  basetype.Uint8Invalid,                         /* EventGroup */
-		25:  basetype.Sint32Invalid,                        /* NecLat */
-		26:  basetype.Sint32Invalid,                        /* NecLong */
-		27:  basetype.Sint32Invalid,                        /* SwcLat */
-		28:  basetype.Sint32Invalid,                        /* SwcLong */
-		29:  basetype.StringInvalid,                        /* Name */
-		30:  basetype.Uint16Invalid,                        /* NormalizedPower */
-		31:  basetype.Uint16Invalid,                        /* LeftRightBalance */
-		32:  basetype.EnumInvalid,                          /* SubSport */
-		33:  basetype.Uint32Invalid,                        /* TotalWork */
-		34:  basetype.Uint16Invalid,                        /* AvgAltitude */
-		35:  basetype.Uint16Invalid,                        /* MaxAltitude */
-		36:  basetype.Uint8Invalid,                         /* GpsAccuracy */
-		37:  basetype.Sint16Invalid,                        /* AvgGrade */
-		38:  basetype.Sint16Invalid,                        /* AvgPosGrade */
-		39:  basetype.Sint16Invalid,                        /* AvgNegGrade */
-		40:  basetype.Sint16Invalid,                        /* MaxPosGrade */
-		41:  basetype.Sint16Invalid,                        /* MaxNegGrade */
-		42:  basetype.Sint8Invalid,                         /* AvgTemperature */
-		43:  basetype.Sint8Invalid,                         /* MaxTemperature */
-		44:  basetype.Uint32Invalid,                        /* TotalMovingTime */
-		45:  basetype.Sint16Invalid,                        /* AvgPosVerticalSpeed */
-		46:  basetype.Sint16Invalid,                        /* AvgNegVerticalSpeed */
-		47:  basetype.Sint16Invalid,                        /* MaxPosVerticalSpeed */
-		48:  basetype.Sint16Invalid,                        /* MaxNegVerticalSpeed */
-		49:  nil,                                           /* TimeInHrZone */
-		50:  nil,                                           /* TimeInSpeedZone */
-		51:  nil,                                           /* TimeInCadenceZone */
-		52:  nil,                                           /* TimeInPowerZone */
-		53:  basetype.Uint16Invalid,                        /* RepetitionNum */
-		54:  basetype.Uint16Invalid,                        /* MinAltitude */
-		55:  basetype.Uint8Invalid,                         /* MinHeartRate */
-		56:  basetype.Uint32Invalid,                        /* ActiveTime */
-		57:  basetype.Uint16Invalid,                        /* WktStepIndex */
-		58:  basetype.EnumInvalid,                          /* SportEvent */
-		59:  basetype.Uint8Invalid,                         /* AvgLeftTorqueEffectiveness */
-		60:  basetype.Uint8Invalid,                         /* AvgRightTorqueEffectiveness */
-		61:  basetype.Uint8Invalid,                         /* AvgLeftPedalSmoothness */
-		62:  basetype.Uint8Invalid,                         /* AvgRightPedalSmoothness */
-		63:  basetype.Uint8Invalid,                         /* AvgCombinedPedalSmoothness */
-		64:  basetype.EnumInvalid,                          /* Status */
-		65:  basetype.StringInvalid,                        /* Uuid */
-		66:  basetype.Uint8Invalid,                         /* AvgFractionalCadence */
-		67:  basetype.Uint8Invalid,                         /* MaxFractionalCadence */
-		68:  basetype.Uint8Invalid,                         /* TotalFractionalCycles */
-		69:  basetype.Uint16Invalid,                        /* FrontGearShiftCount */
-		70:  basetype.Uint16Invalid,                        /* RearGearShiftCount */
-		71:  basetype.Uint32Invalid,                        /* TimeStanding */
-		72:  basetype.Uint16Invalid,                        /* StandCount */
-		73:  basetype.Sint8Invalid,                         /* AvgLeftPco */
-		74:  basetype.Sint8Invalid,                         /* AvgRightPco */
-		75:  nil,                                           /* AvgLeftPowerPhase */
-		76:  nil,                                           /* AvgLeftPowerPhasePeak */
-		77:  nil,                                           /* AvgRightPowerPhase */
-		78:  nil,                                           /* AvgRightPowerPhasePeak */
-		79:  nil,                                           /* AvgPowerPosition */
-		80:  nil,                                           /* MaxPowerPosition */
-		81:  nil,                                           /* AvgCadencePosition */
-		82:  nil,                                           /* MaxCadencePosition */
-		83:  basetype.Uint16Invalid,                        /* Manufacturer */
-		84:  math.Float32frombits(basetype.Float32Invalid), /* TotalGrit */
-		85:  math.Float32frombits(basetype.Float32Invalid), /* TotalFlow */
-		86:  math.Float32frombits(basetype.Float32Invalid), /* AvgGrit */
-		87:  math.Float32frombits(basetype.Float32Invalid), /* AvgFlow */
-		89:  basetype.Uint8Invalid,                         /* TotalFractionalAscent */
-		90:  basetype.Uint8Invalid,                         /* TotalFractionalDescent */
-		91:  basetype.Uint32Invalid,                        /* EnhancedAvgAltitude */
-		92:  basetype.Uint32Invalid,                        /* EnhancedMaxAltitude */
-		93:  basetype.Uint32Invalid,                        /* EnhancedMinAltitude */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		253: nil, /* Timestamp */
+		0:   nil, /* Event */
+		1:   nil, /* EventType */
+		2:   nil, /* StartTime */
+		3:   nil, /* StartPositionLat */
+		4:   nil, /* StartPositionLong */
+		5:   nil, /* EndPositionLat */
+		6:   nil, /* EndPositionLong */
+		7:   nil, /* TotalElapsedTime */
+		8:   nil, /* TotalTimerTime */
+		9:   nil, /* TotalDistance */
+		10:  nil, /* TotalCycles */
+		11:  nil, /* TotalCalories */
+		12:  nil, /* TotalFatCalories */
+		13:  nil, /* AvgSpeed */
+		14:  nil, /* MaxSpeed */
+		15:  nil, /* AvgHeartRate */
+		16:  nil, /* MaxHeartRate */
+		17:  nil, /* AvgCadence */
+		18:  nil, /* MaxCadence */
+		19:  nil, /* AvgPower */
+		20:  nil, /* MaxPower */
+		21:  nil, /* TotalAscent */
+		22:  nil, /* TotalDescent */
+		23:  nil, /* Sport */
+		24:  nil, /* EventGroup */
+		25:  nil, /* NecLat */
+		26:  nil, /* NecLong */
+		27:  nil, /* SwcLat */
+		28:  nil, /* SwcLong */
+		29:  nil, /* Name */
+		30:  nil, /* NormalizedPower */
+		31:  nil, /* LeftRightBalance */
+		32:  nil, /* SubSport */
+		33:  nil, /* TotalWork */
+		34:  nil, /* AvgAltitude */
+		35:  nil, /* MaxAltitude */
+		36:  nil, /* GpsAccuracy */
+		37:  nil, /* AvgGrade */
+		38:  nil, /* AvgPosGrade */
+		39:  nil, /* AvgNegGrade */
+		40:  nil, /* MaxPosGrade */
+		41:  nil, /* MaxNegGrade */
+		42:  nil, /* AvgTemperature */
+		43:  nil, /* MaxTemperature */
+		44:  nil, /* TotalMovingTime */
+		45:  nil, /* AvgPosVerticalSpeed */
+		46:  nil, /* AvgNegVerticalSpeed */
+		47:  nil, /* MaxPosVerticalSpeed */
+		48:  nil, /* MaxNegVerticalSpeed */
+		49:  nil, /* TimeInHrZone */
+		50:  nil, /* TimeInSpeedZone */
+		51:  nil, /* TimeInCadenceZone */
+		52:  nil, /* TimeInPowerZone */
+		53:  nil, /* RepetitionNum */
+		54:  nil, /* MinAltitude */
+		55:  nil, /* MinHeartRate */
+		56:  nil, /* ActiveTime */
+		57:  nil, /* WktStepIndex */
+		58:  nil, /* SportEvent */
+		59:  nil, /* AvgLeftTorqueEffectiveness */
+		60:  nil, /* AvgRightTorqueEffectiveness */
+		61:  nil, /* AvgLeftPedalSmoothness */
+		62:  nil, /* AvgRightPedalSmoothness */
+		63:  nil, /* AvgCombinedPedalSmoothness */
+		64:  nil, /* Status */
+		65:  nil, /* Uuid */
+		66:  nil, /* AvgFractionalCadence */
+		67:  nil, /* MaxFractionalCadence */
+		68:  nil, /* TotalFractionalCycles */
+		69:  nil, /* FrontGearShiftCount */
+		70:  nil, /* RearGearShiftCount */
+		71:  nil, /* TimeStanding */
+		72:  nil, /* StandCount */
+		73:  nil, /* AvgLeftPco */
+		74:  nil, /* AvgRightPco */
+		75:  nil, /* AvgLeftPowerPhase */
+		76:  nil, /* AvgLeftPowerPhasePeak */
+		77:  nil, /* AvgRightPowerPhase */
+		78:  nil, /* AvgRightPowerPhasePeak */
+		79:  nil, /* AvgPowerPosition */
+		80:  nil, /* MaxPowerPosition */
+		81:  nil, /* AvgCadencePosition */
+		82:  nil, /* MaxCadencePosition */
+		83:  nil, /* Manufacturer */
+		84:  nil, /* TotalGrit */
+		85:  nil, /* TotalFlow */
+		86:  nil, /* AvgGrit */
+		87:  nil, /* AvgFlow */
+		89:  nil, /* TotalFractionalAscent */
+		90:  nil, /* TotalFractionalDescent */
+		91:  nil, /* EnhancedAvgAltitude */
+		92:  nil, /* EnhancedMaxAltitude */
+		93:  nil, /* EnhancedMinAltitude */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &SegmentLap{
@@ -343,7 +342,7 @@ func (m SegmentLap) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		253: m.Timestamp,
 		0:   m.Event,
@@ -442,8 +441,12 @@ func (m SegmentLap) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/segment_point_gen.go
+++ b/profile/mesgdef/segment_point_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -35,21 +34,22 @@ func NewSegmentPoint(mesg proto.Message) *SegmentPoint {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		1:   basetype.Sint32Invalid, /* PositionLat */
-		2:   basetype.Sint32Invalid, /* PositionLong */
-		3:   basetype.Uint32Invalid, /* Distance */
-		4:   basetype.Uint16Invalid, /* Altitude */
-		5:   nil,                    /* LeaderTime */
-		6:   basetype.Uint32Invalid, /* EnhancedAltitude */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		1:   nil, /* PositionLat */
+		2:   nil, /* PositionLong */
+		3:   nil, /* Distance */
+		4:   nil, /* Altitude */
+		5:   nil, /* LeaderTime */
+		6:   nil, /* EnhancedAltitude */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &SegmentPoint{
@@ -78,7 +78,7 @@ func (m SegmentPoint) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		1:   m.PositionLat,
 		2:   m.PositionLong,
@@ -89,8 +89,12 @@ func (m SegmentPoint) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/session_gen.go
+++ b/profile/mesgdef/session_gen.go
@@ -9,10 +9,8 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
-	"math"
 )
 
 // Session is a Session message.
@@ -183,168 +181,169 @@ func NewSession(mesg proto.Message) *Session {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid,                        /* MessageIndex */
-		253: basetype.Uint32Invalid,                        /* Timestamp */
-		0:   basetype.EnumInvalid,                          /* Event */
-		1:   basetype.EnumInvalid,                          /* EventType */
-		2:   basetype.Uint32Invalid,                        /* StartTime */
-		3:   basetype.Sint32Invalid,                        /* StartPositionLat */
-		4:   basetype.Sint32Invalid,                        /* StartPositionLong */
-		5:   basetype.EnumInvalid,                          /* Sport */
-		6:   basetype.EnumInvalid,                          /* SubSport */
-		7:   basetype.Uint32Invalid,                        /* TotalElapsedTime */
-		8:   basetype.Uint32Invalid,                        /* TotalTimerTime */
-		9:   basetype.Uint32Invalid,                        /* TotalDistance */
-		10:  basetype.Uint32Invalid,                        /* TotalCycles */
-		11:  basetype.Uint16Invalid,                        /* TotalCalories */
-		13:  basetype.Uint16Invalid,                        /* TotalFatCalories */
-		14:  basetype.Uint16Invalid,                        /* AvgSpeed */
-		15:  basetype.Uint16Invalid,                        /* MaxSpeed */
-		16:  basetype.Uint8Invalid,                         /* AvgHeartRate */
-		17:  basetype.Uint8Invalid,                         /* MaxHeartRate */
-		18:  basetype.Uint8Invalid,                         /* AvgCadence */
-		19:  basetype.Uint8Invalid,                         /* MaxCadence */
-		20:  basetype.Uint16Invalid,                        /* AvgPower */
-		21:  basetype.Uint16Invalid,                        /* MaxPower */
-		22:  basetype.Uint16Invalid,                        /* TotalAscent */
-		23:  basetype.Uint16Invalid,                        /* TotalDescent */
-		24:  basetype.Uint8Invalid,                         /* TotalTrainingEffect */
-		25:  basetype.Uint16Invalid,                        /* FirstLapIndex */
-		26:  basetype.Uint16Invalid,                        /* NumLaps */
-		27:  basetype.Uint8Invalid,                         /* EventGroup */
-		28:  basetype.EnumInvalid,                          /* Trigger */
-		29:  basetype.Sint32Invalid,                        /* NecLat */
-		30:  basetype.Sint32Invalid,                        /* NecLong */
-		31:  basetype.Sint32Invalid,                        /* SwcLat */
-		32:  basetype.Sint32Invalid,                        /* SwcLong */
-		33:  basetype.Uint16Invalid,                        /* NumLengths */
-		34:  basetype.Uint16Invalid,                        /* NormalizedPower */
-		35:  basetype.Uint16Invalid,                        /* TrainingStressScore */
-		36:  basetype.Uint16Invalid,                        /* IntensityFactor */
-		37:  basetype.Uint16Invalid,                        /* LeftRightBalance */
-		38:  basetype.Sint32Invalid,                        /* EndPositionLat */
-		39:  basetype.Sint32Invalid,                        /* EndPositionLong */
-		41:  basetype.Uint32Invalid,                        /* AvgStrokeCount */
-		42:  basetype.Uint16Invalid,                        /* AvgStrokeDistance */
-		43:  basetype.EnumInvalid,                          /* SwimStroke */
-		44:  basetype.Uint16Invalid,                        /* PoolLength */
-		45:  basetype.Uint16Invalid,                        /* ThresholdPower */
-		46:  basetype.EnumInvalid,                          /* PoolLengthUnit */
-		47:  basetype.Uint16Invalid,                        /* NumActiveLengths */
-		48:  basetype.Uint32Invalid,                        /* TotalWork */
-		49:  basetype.Uint16Invalid,                        /* AvgAltitude */
-		50:  basetype.Uint16Invalid,                        /* MaxAltitude */
-		51:  basetype.Uint8Invalid,                         /* GpsAccuracy */
-		52:  basetype.Sint16Invalid,                        /* AvgGrade */
-		53:  basetype.Sint16Invalid,                        /* AvgPosGrade */
-		54:  basetype.Sint16Invalid,                        /* AvgNegGrade */
-		55:  basetype.Sint16Invalid,                        /* MaxPosGrade */
-		56:  basetype.Sint16Invalid,                        /* MaxNegGrade */
-		57:  basetype.Sint8Invalid,                         /* AvgTemperature */
-		58:  basetype.Sint8Invalid,                         /* MaxTemperature */
-		59:  basetype.Uint32Invalid,                        /* TotalMovingTime */
-		60:  basetype.Sint16Invalid,                        /* AvgPosVerticalSpeed */
-		61:  basetype.Sint16Invalid,                        /* AvgNegVerticalSpeed */
-		62:  basetype.Sint16Invalid,                        /* MaxPosVerticalSpeed */
-		63:  basetype.Sint16Invalid,                        /* MaxNegVerticalSpeed */
-		64:  basetype.Uint8Invalid,                         /* MinHeartRate */
-		65:  nil,                                           /* TimeInHrZone */
-		66:  nil,                                           /* TimeInSpeedZone */
-		67:  nil,                                           /* TimeInCadenceZone */
-		68:  nil,                                           /* TimeInPowerZone */
-		69:  basetype.Uint32Invalid,                        /* AvgLapTime */
-		70:  basetype.Uint16Invalid,                        /* BestLapIndex */
-		71:  basetype.Uint16Invalid,                        /* MinAltitude */
-		82:  basetype.Uint16Invalid,                        /* PlayerScore */
-		83:  basetype.Uint16Invalid,                        /* OpponentScore */
-		84:  basetype.StringInvalid,                        /* OpponentName */
-		85:  nil,                                           /* StrokeCount */
-		86:  nil,                                           /* ZoneCount */
-		87:  basetype.Uint16Invalid,                        /* MaxBallSpeed */
-		88:  basetype.Uint16Invalid,                        /* AvgBallSpeed */
-		89:  basetype.Uint16Invalid,                        /* AvgVerticalOscillation */
-		90:  basetype.Uint16Invalid,                        /* AvgStanceTimePercent */
-		91:  basetype.Uint16Invalid,                        /* AvgStanceTime */
-		92:  basetype.Uint8Invalid,                         /* AvgFractionalCadence */
-		93:  basetype.Uint8Invalid,                         /* MaxFractionalCadence */
-		94:  basetype.Uint8Invalid,                         /* TotalFractionalCycles */
-		95:  nil,                                           /* AvgTotalHemoglobinConc */
-		96:  nil,                                           /* MinTotalHemoglobinConc */
-		97:  nil,                                           /* MaxTotalHemoglobinConc */
-		98:  nil,                                           /* AvgSaturatedHemoglobinPercent */
-		99:  nil,                                           /* MinSaturatedHemoglobinPercent */
-		100: nil,                                           /* MaxSaturatedHemoglobinPercent */
-		101: basetype.Uint8Invalid,                         /* AvgLeftTorqueEffectiveness */
-		102: basetype.Uint8Invalid,                         /* AvgRightTorqueEffectiveness */
-		103: basetype.Uint8Invalid,                         /* AvgLeftPedalSmoothness */
-		104: basetype.Uint8Invalid,                         /* AvgRightPedalSmoothness */
-		105: basetype.Uint8Invalid,                         /* AvgCombinedPedalSmoothness */
-		110: basetype.StringInvalid,                        /* SportProfileName */
-		111: basetype.Uint8Invalid,                         /* SportIndex */
-		112: basetype.Uint32Invalid,                        /* TimeStanding */
-		113: basetype.Uint16Invalid,                        /* StandCount */
-		114: basetype.Sint8Invalid,                         /* AvgLeftPco */
-		115: basetype.Sint8Invalid,                         /* AvgRightPco */
-		116: nil,                                           /* AvgLeftPowerPhase */
-		117: nil,                                           /* AvgLeftPowerPhasePeak */
-		118: nil,                                           /* AvgRightPowerPhase */
-		119: nil,                                           /* AvgRightPowerPhasePeak */
-		120: nil,                                           /* AvgPowerPosition */
-		121: nil,                                           /* MaxPowerPosition */
-		122: nil,                                           /* AvgCadencePosition */
-		123: nil,                                           /* MaxCadencePosition */
-		124: basetype.Uint32Invalid,                        /* EnhancedAvgSpeed */
-		125: basetype.Uint32Invalid,                        /* EnhancedMaxSpeed */
-		126: basetype.Uint32Invalid,                        /* EnhancedAvgAltitude */
-		127: basetype.Uint32Invalid,                        /* EnhancedMinAltitude */
-		128: basetype.Uint32Invalid,                        /* EnhancedMaxAltitude */
-		129: basetype.Uint16Invalid,                        /* AvgLevMotorPower */
-		130: basetype.Uint16Invalid,                        /* MaxLevMotorPower */
-		131: basetype.Uint8Invalid,                         /* LevBatteryConsumption */
-		132: basetype.Uint16Invalid,                        /* AvgVerticalRatio */
-		133: basetype.Uint16Invalid,                        /* AvgStanceTimeBalance */
-		134: basetype.Uint16Invalid,                        /* AvgStepLength */
-		137: basetype.Uint8Invalid,                         /* TotalAnaerobicTrainingEffect */
-		139: basetype.Uint16Invalid,                        /* AvgVam */
-		140: basetype.Uint32Invalid,                        /* AvgDepth */
-		141: basetype.Uint32Invalid,                        /* MaxDepth */
-		142: basetype.Uint32Invalid,                        /* SurfaceInterval */
-		143: basetype.Uint8Invalid,                         /* StartCns */
-		144: basetype.Uint8Invalid,                         /* EndCns */
-		145: basetype.Uint16Invalid,                        /* StartN2 */
-		146: basetype.Uint16Invalid,                        /* EndN2 */
-		147: basetype.Uint8Invalid,                         /* AvgRespirationRate */
-		148: basetype.Uint8Invalid,                         /* MaxRespirationRate */
-		149: basetype.Uint8Invalid,                         /* MinRespirationRate */
-		150: basetype.Sint8Invalid,                         /* MinTemperature */
-		155: basetype.Uint16Invalid,                        /* O2Toxicity */
-		156: basetype.Uint32Invalid,                        /* DiveNumber */
-		168: basetype.Sint32Invalid,                        /* TrainingLoadPeak */
-		169: basetype.Uint16Invalid,                        /* EnhancedAvgRespirationRate */
-		170: basetype.Uint16Invalid,                        /* EnhancedMaxRespirationRate */
-		180: basetype.Uint16Invalid,                        /* EnhancedMinRespirationRate */
-		181: math.Float32frombits(basetype.Float32Invalid), /* TotalGrit */
-		182: math.Float32frombits(basetype.Float32Invalid), /* TotalFlow */
-		183: basetype.Uint16Invalid,                        /* JumpCount */
-		186: math.Float32frombits(basetype.Float32Invalid), /* AvgGrit */
-		187: math.Float32frombits(basetype.Float32Invalid), /* AvgFlow */
-		194: basetype.Uint8Invalid,                         /* AvgSpo2 */
-		195: basetype.Uint8Invalid,                         /* AvgStress */
-		197: basetype.Uint8Invalid,                         /* SdrrHrv */
-		198: basetype.Uint8Invalid,                         /* RmssdHrv */
-		199: basetype.Uint8Invalid,                         /* TotalFractionalAscent */
-		200: basetype.Uint8Invalid,                         /* TotalFractionalDescent */
-		208: basetype.Uint16Invalid,                        /* AvgCoreTemperature */
-		209: basetype.Uint16Invalid,                        /* MinCoreTemperature */
-		210: basetype.Uint16Invalid,                        /* MaxCoreTemperature */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		253: nil, /* Timestamp */
+		0:   nil, /* Event */
+		1:   nil, /* EventType */
+		2:   nil, /* StartTime */
+		3:   nil, /* StartPositionLat */
+		4:   nil, /* StartPositionLong */
+		5:   nil, /* Sport */
+		6:   nil, /* SubSport */
+		7:   nil, /* TotalElapsedTime */
+		8:   nil, /* TotalTimerTime */
+		9:   nil, /* TotalDistance */
+		10:  nil, /* TotalCycles */
+		11:  nil, /* TotalCalories */
+		13:  nil, /* TotalFatCalories */
+		14:  nil, /* AvgSpeed */
+		15:  nil, /* MaxSpeed */
+		16:  nil, /* AvgHeartRate */
+		17:  nil, /* MaxHeartRate */
+		18:  nil, /* AvgCadence */
+		19:  nil, /* MaxCadence */
+		20:  nil, /* AvgPower */
+		21:  nil, /* MaxPower */
+		22:  nil, /* TotalAscent */
+		23:  nil, /* TotalDescent */
+		24:  nil, /* TotalTrainingEffect */
+		25:  nil, /* FirstLapIndex */
+		26:  nil, /* NumLaps */
+		27:  nil, /* EventGroup */
+		28:  nil, /* Trigger */
+		29:  nil, /* NecLat */
+		30:  nil, /* NecLong */
+		31:  nil, /* SwcLat */
+		32:  nil, /* SwcLong */
+		33:  nil, /* NumLengths */
+		34:  nil, /* NormalizedPower */
+		35:  nil, /* TrainingStressScore */
+		36:  nil, /* IntensityFactor */
+		37:  nil, /* LeftRightBalance */
+		38:  nil, /* EndPositionLat */
+		39:  nil, /* EndPositionLong */
+		41:  nil, /* AvgStrokeCount */
+		42:  nil, /* AvgStrokeDistance */
+		43:  nil, /* SwimStroke */
+		44:  nil, /* PoolLength */
+		45:  nil, /* ThresholdPower */
+		46:  nil, /* PoolLengthUnit */
+		47:  nil, /* NumActiveLengths */
+		48:  nil, /* TotalWork */
+		49:  nil, /* AvgAltitude */
+		50:  nil, /* MaxAltitude */
+		51:  nil, /* GpsAccuracy */
+		52:  nil, /* AvgGrade */
+		53:  nil, /* AvgPosGrade */
+		54:  nil, /* AvgNegGrade */
+		55:  nil, /* MaxPosGrade */
+		56:  nil, /* MaxNegGrade */
+		57:  nil, /* AvgTemperature */
+		58:  nil, /* MaxTemperature */
+		59:  nil, /* TotalMovingTime */
+		60:  nil, /* AvgPosVerticalSpeed */
+		61:  nil, /* AvgNegVerticalSpeed */
+		62:  nil, /* MaxPosVerticalSpeed */
+		63:  nil, /* MaxNegVerticalSpeed */
+		64:  nil, /* MinHeartRate */
+		65:  nil, /* TimeInHrZone */
+		66:  nil, /* TimeInSpeedZone */
+		67:  nil, /* TimeInCadenceZone */
+		68:  nil, /* TimeInPowerZone */
+		69:  nil, /* AvgLapTime */
+		70:  nil, /* BestLapIndex */
+		71:  nil, /* MinAltitude */
+		82:  nil, /* PlayerScore */
+		83:  nil, /* OpponentScore */
+		84:  nil, /* OpponentName */
+		85:  nil, /* StrokeCount */
+		86:  nil, /* ZoneCount */
+		87:  nil, /* MaxBallSpeed */
+		88:  nil, /* AvgBallSpeed */
+		89:  nil, /* AvgVerticalOscillation */
+		90:  nil, /* AvgStanceTimePercent */
+		91:  nil, /* AvgStanceTime */
+		92:  nil, /* AvgFractionalCadence */
+		93:  nil, /* MaxFractionalCadence */
+		94:  nil, /* TotalFractionalCycles */
+		95:  nil, /* AvgTotalHemoglobinConc */
+		96:  nil, /* MinTotalHemoglobinConc */
+		97:  nil, /* MaxTotalHemoglobinConc */
+		98:  nil, /* AvgSaturatedHemoglobinPercent */
+		99:  nil, /* MinSaturatedHemoglobinPercent */
+		100: nil, /* MaxSaturatedHemoglobinPercent */
+		101: nil, /* AvgLeftTorqueEffectiveness */
+		102: nil, /* AvgRightTorqueEffectiveness */
+		103: nil, /* AvgLeftPedalSmoothness */
+		104: nil, /* AvgRightPedalSmoothness */
+		105: nil, /* AvgCombinedPedalSmoothness */
+		110: nil, /* SportProfileName */
+		111: nil, /* SportIndex */
+		112: nil, /* TimeStanding */
+		113: nil, /* StandCount */
+		114: nil, /* AvgLeftPco */
+		115: nil, /* AvgRightPco */
+		116: nil, /* AvgLeftPowerPhase */
+		117: nil, /* AvgLeftPowerPhasePeak */
+		118: nil, /* AvgRightPowerPhase */
+		119: nil, /* AvgRightPowerPhasePeak */
+		120: nil, /* AvgPowerPosition */
+		121: nil, /* MaxPowerPosition */
+		122: nil, /* AvgCadencePosition */
+		123: nil, /* MaxCadencePosition */
+		124: nil, /* EnhancedAvgSpeed */
+		125: nil, /* EnhancedMaxSpeed */
+		126: nil, /* EnhancedAvgAltitude */
+		127: nil, /* EnhancedMinAltitude */
+		128: nil, /* EnhancedMaxAltitude */
+		129: nil, /* AvgLevMotorPower */
+		130: nil, /* MaxLevMotorPower */
+		131: nil, /* LevBatteryConsumption */
+		132: nil, /* AvgVerticalRatio */
+		133: nil, /* AvgStanceTimeBalance */
+		134: nil, /* AvgStepLength */
+		137: nil, /* TotalAnaerobicTrainingEffect */
+		139: nil, /* AvgVam */
+		140: nil, /* AvgDepth */
+		141: nil, /* MaxDepth */
+		142: nil, /* SurfaceInterval */
+		143: nil, /* StartCns */
+		144: nil, /* EndCns */
+		145: nil, /* StartN2 */
+		146: nil, /* EndN2 */
+		147: nil, /* AvgRespirationRate */
+		148: nil, /* MaxRespirationRate */
+		149: nil, /* MinRespirationRate */
+		150: nil, /* MinTemperature */
+		155: nil, /* O2Toxicity */
+		156: nil, /* DiveNumber */
+		168: nil, /* TrainingLoadPeak */
+		169: nil, /* EnhancedAvgRespirationRate */
+		170: nil, /* EnhancedMaxRespirationRate */
+		180: nil, /* EnhancedMinRespirationRate */
+		181: nil, /* TotalGrit */
+		182: nil, /* TotalFlow */
+		183: nil, /* JumpCount */
+		186: nil, /* AvgGrit */
+		187: nil, /* AvgFlow */
+		194: nil, /* AvgSpo2 */
+		195: nil, /* AvgStress */
+		197: nil, /* SdrrHrv */
+		198: nil, /* RmssdHrv */
+		199: nil, /* TotalFractionalAscent */
+		200: nil, /* TotalFractionalDescent */
+		208: nil, /* AvgCoreTemperature */
+		209: nil, /* MinCoreTemperature */
+		210: nil, /* MaxCoreTemperature */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Session{
@@ -520,7 +519,7 @@ func (m Session) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		253: m.Timestamp,
 		0:   m.Event,
@@ -678,8 +677,12 @@ func (m Session) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/slave_device_gen.go
+++ b/profile/mesgdef/slave_device_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -30,16 +29,17 @@ func NewSlaveDevice(mesg proto.Message) *SlaveDevice {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0: basetype.Uint16Invalid, /* Manufacturer */
-		1: basetype.Uint16Invalid, /* Product */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0: nil, /* Manufacturer */
+		1: nil, /* Product */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &SlaveDevice{
@@ -63,14 +63,18 @@ func (m SlaveDevice) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0: m.Manufacturer,
 		1: m.Product,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/sleep_assessment_gen.go
+++ b/profile/mesgdef/sleep_assessment_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -42,28 +41,29 @@ func NewSleepAssessment(mesg proto.Message) *SleepAssessment {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0:  basetype.Uint8Invalid,  /* CombinedAwakeScore */
-		1:  basetype.Uint8Invalid,  /* AwakeTimeScore */
-		2:  basetype.Uint8Invalid,  /* AwakeningsCountScore */
-		3:  basetype.Uint8Invalid,  /* DeepSleepScore */
-		4:  basetype.Uint8Invalid,  /* SleepDurationScore */
-		5:  basetype.Uint8Invalid,  /* LightSleepScore */
-		6:  basetype.Uint8Invalid,  /* OverallSleepScore */
-		7:  basetype.Uint8Invalid,  /* SleepQualityScore */
-		8:  basetype.Uint8Invalid,  /* SleepRecoveryScore */
-		9:  basetype.Uint8Invalid,  /* RemSleepScore */
-		10: basetype.Uint8Invalid,  /* SleepRestlessnessScore */
-		11: basetype.Uint8Invalid,  /* AwakeningsCount */
-		14: basetype.Uint8Invalid,  /* InterruptionsScore */
-		15: basetype.Uint16Invalid, /* AverageStressDuringSleep */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0:  nil, /* CombinedAwakeScore */
+		1:  nil, /* AwakeTimeScore */
+		2:  nil, /* AwakeningsCountScore */
+		3:  nil, /* DeepSleepScore */
+		4:  nil, /* SleepDurationScore */
+		5:  nil, /* LightSleepScore */
+		6:  nil, /* OverallSleepScore */
+		7:  nil, /* SleepQualityScore */
+		8:  nil, /* SleepRecoveryScore */
+		9:  nil, /* RemSleepScore */
+		10: nil, /* SleepRestlessnessScore */
+		11: nil, /* AwakeningsCount */
+		14: nil, /* InterruptionsScore */
+		15: nil, /* AverageStressDuringSleep */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &SleepAssessment{
@@ -99,7 +99,7 @@ func (m SleepAssessment) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0:  m.CombinedAwakeScore,
 		1:  m.AwakeTimeScore,
 		2:  m.AwakeningsCountScore,
@@ -117,8 +117,12 @@ func (m SleepAssessment) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/sleep_level_gen.go
+++ b/profile/mesgdef/sleep_level_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -30,16 +29,17 @@ func NewSleepLevel(mesg proto.Message) *SleepLevel {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.EnumInvalid,   /* SleepLevel */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* SleepLevel */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &SleepLevel{
@@ -63,14 +63,18 @@ func (m SleepLevel) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.SleepLevel,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/speed_zone_gen.go
+++ b/profile/mesgdef/speed_zone_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewSpeedZone(mesg proto.Message) *SpeedZone {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.Uint16Invalid, /* HighValue */
-		1:   basetype.StringInvalid, /* Name */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* HighValue */
+		1:   nil, /* Name */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &SpeedZone{
@@ -66,15 +66,19 @@ func (m SpeedZone) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.HighValue,
 		1:   m.Name,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/split_gen.go
+++ b/profile/mesgdef/split_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -47,33 +46,34 @@ func NewSplit(mesg proto.Message) *Split {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.EnumInvalid,   /* SplitType */
-		1:   basetype.Uint32Invalid, /* TotalElapsedTime */
-		2:   basetype.Uint32Invalid, /* TotalTimerTime */
-		3:   basetype.Uint32Invalid, /* TotalDistance */
-		4:   basetype.Uint32Invalid, /* AvgSpeed */
-		9:   basetype.Uint32Invalid, /* StartTime */
-		13:  basetype.Uint16Invalid, /* TotalAscent */
-		14:  basetype.Uint16Invalid, /* TotalDescent */
-		21:  basetype.Sint32Invalid, /* StartPositionLat */
-		22:  basetype.Sint32Invalid, /* StartPositionLong */
-		23:  basetype.Sint32Invalid, /* EndPositionLat */
-		24:  basetype.Sint32Invalid, /* EndPositionLong */
-		25:  basetype.Uint32Invalid, /* MaxSpeed */
-		26:  basetype.Sint32Invalid, /* AvgVertSpeed */
-		27:  basetype.Uint32Invalid, /* EndTime */
-		28:  basetype.Uint32Invalid, /* TotalCalories */
-		74:  basetype.Uint32Invalid, /* StartElevation */
-		110: basetype.Uint32Invalid, /* TotalMovingTime */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* SplitType */
+		1:   nil, /* TotalElapsedTime */
+		2:   nil, /* TotalTimerTime */
+		3:   nil, /* TotalDistance */
+		4:   nil, /* AvgSpeed */
+		9:   nil, /* StartTime */
+		13:  nil, /* TotalAscent */
+		14:  nil, /* TotalDescent */
+		21:  nil, /* StartPositionLat */
+		22:  nil, /* StartPositionLong */
+		23:  nil, /* EndPositionLat */
+		24:  nil, /* EndPositionLong */
+		25:  nil, /* MaxSpeed */
+		26:  nil, /* AvgVertSpeed */
+		27:  nil, /* EndTime */
+		28:  nil, /* TotalCalories */
+		74:  nil, /* StartElevation */
+		110: nil, /* TotalMovingTime */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Split{
@@ -114,7 +114,7 @@ func (m Split) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.SplitType,
 		1:   m.TotalElapsedTime,
@@ -137,8 +137,12 @@ func (m Split) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/split_summary_gen.go
+++ b/profile/mesgdef/split_summary_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -42,28 +41,29 @@ func NewSplitSummary(mesg proto.Message) *SplitSummary {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.EnumInvalid,   /* SplitType */
-		3:   basetype.Uint16Invalid, /* NumSplits */
-		4:   basetype.Uint32Invalid, /* TotalTimerTime */
-		5:   basetype.Uint32Invalid, /* TotalDistance */
-		6:   basetype.Uint32Invalid, /* AvgSpeed */
-		7:   basetype.Uint32Invalid, /* MaxSpeed */
-		8:   basetype.Uint16Invalid, /* TotalAscent */
-		9:   basetype.Uint16Invalid, /* TotalDescent */
-		10:  basetype.Uint8Invalid,  /* AvgHeartRate */
-		11:  basetype.Uint8Invalid,  /* MaxHeartRate */
-		12:  basetype.Sint32Invalid, /* AvgVertSpeed */
-		13:  basetype.Uint32Invalid, /* TotalCalories */
-		77:  basetype.Uint32Invalid, /* TotalMovingTime */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* SplitType */
+		3:   nil, /* NumSplits */
+		4:   nil, /* TotalTimerTime */
+		5:   nil, /* TotalDistance */
+		6:   nil, /* AvgSpeed */
+		7:   nil, /* MaxSpeed */
+		8:   nil, /* TotalAscent */
+		9:   nil, /* TotalDescent */
+		10:  nil, /* AvgHeartRate */
+		11:  nil, /* MaxHeartRate */
+		12:  nil, /* AvgVertSpeed */
+		13:  nil, /* TotalCalories */
+		77:  nil, /* TotalMovingTime */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &SplitSummary{
@@ -99,7 +99,7 @@ func (m SplitSummary) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.SplitType,
 		3:   m.NumSplits,
@@ -117,8 +117,12 @@ func (m SplitSummary) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/spo2_data_gen.go
+++ b/profile/mesgdef/spo2_data_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -32,18 +31,19 @@ func NewSpo2Data(mesg proto.Message) *Spo2Data {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint8Invalid,  /* ReadingSpo2 */
-		1:   basetype.Uint8Invalid,  /* ReadingConfidence */
-		2:   basetype.EnumInvalid,   /* Mode */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* ReadingSpo2 */
+		1:   nil, /* ReadingConfidence */
+		2:   nil, /* Mode */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Spo2Data{
@@ -69,7 +69,7 @@ func (m Spo2Data) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.ReadingSpo2,
 		1:   m.ReadingConfidence,
@@ -77,8 +77,12 @@ func (m Spo2Data) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/sport_gen.go
+++ b/profile/mesgdef/sport_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewSport(mesg proto.Message) *Sport {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0: basetype.EnumInvalid,   /* Sport */
-		1: basetype.EnumInvalid,   /* SubSport */
-		3: basetype.StringInvalid, /* Name */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0: nil, /* Sport */
+		1: nil, /* SubSport */
+		3: nil, /* Name */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Sport{
@@ -66,15 +66,19 @@ func (m Sport) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0: m.Sport,
 		1: m.SubSport,
 		3: m.Name,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/stress_level_gen.go
+++ b/profile/mesgdef/stress_level_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -30,16 +29,17 @@ func NewStressLevel(mesg proto.Message) *StressLevel {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0: basetype.Sint16Invalid, /* StressLevelValue */
-		1: basetype.Uint32Invalid, /* StressLevelTime */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0: nil, /* StressLevelValue */
+		1: nil, /* StressLevelTime */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &StressLevel{
@@ -63,14 +63,18 @@ func (m StressLevel) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0: m.StressLevelValue,
 		1: m.StressLevelTime,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/tank_update_gen.go
+++ b/profile/mesgdef/tank_update_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewTankUpdate(mesg proto.Message) *TankUpdate {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid,  /* Timestamp */
-		0:   basetype.Uint32zInvalid, /* Sensor */
-		1:   basetype.Uint16Invalid,  /* Pressure */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* Sensor */
+		1:   nil, /* Pressure */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &TankUpdate{
@@ -66,15 +66,19 @@ func (m TankUpdate) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.Sensor,
 		1:   m.Pressure,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/three_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/three_d_sensor_calibration_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -35,21 +34,22 @@ func NewThreeDSensorCalibration(mesg proto.Message) *ThreeDSensorCalibration {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.EnumInvalid,   /* SensorType */
-		1:   basetype.Uint32Invalid, /* CalibrationFactor */
-		2:   basetype.Uint32Invalid, /* CalibrationDivisor */
-		3:   basetype.Uint32Invalid, /* LevelShift */
-		4:   nil,                    /* OffsetCal */
-		5:   nil,                    /* OrientationMatrix */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* SensorType */
+		1:   nil, /* CalibrationFactor */
+		2:   nil, /* CalibrationDivisor */
+		3:   nil, /* LevelShift */
+		4:   nil, /* OffsetCal */
+		5:   nil, /* OrientationMatrix */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &ThreeDSensorCalibration{
@@ -78,7 +78,7 @@ func (m ThreeDSensorCalibration) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.SensorType,
 		1:   m.CalibrationFactor,
@@ -89,8 +89,12 @@ func (m ThreeDSensorCalibration) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/time_in_zone_gen.go
+++ b/profile/mesgdef/time_in_zone_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -45,31 +44,32 @@ func NewTimeInZone(mesg proto.Message) *TimeInZone {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* ReferenceMesg */
-		1:   basetype.Uint16Invalid, /* ReferenceIndex */
-		2:   nil,                    /* TimeInHrZone */
-		3:   nil,                    /* TimeInSpeedZone */
-		4:   nil,                    /* TimeInCadenceZone */
-		5:   nil,                    /* TimeInPowerZone */
-		6:   nil,                    /* HrZoneHighBoundary */
-		7:   nil,                    /* SpeedZoneHighBoundary */
-		8:   nil,                    /* CadenceZoneHighBondary */
-		9:   nil,                    /* PowerZoneHighBoundary */
-		10:  basetype.EnumInvalid,   /* HrCalcType */
-		11:  basetype.Uint8Invalid,  /* MaxHeartRate */
-		12:  basetype.Uint8Invalid,  /* RestingHeartRate */
-		13:  basetype.Uint8Invalid,  /* ThresholdHeartRate */
-		14:  basetype.EnumInvalid,   /* PwrCalcType */
-		15:  basetype.Uint16Invalid, /* FunctionalThresholdPower */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* ReferenceMesg */
+		1:   nil, /* ReferenceIndex */
+		2:   nil, /* TimeInHrZone */
+		3:   nil, /* TimeInSpeedZone */
+		4:   nil, /* TimeInCadenceZone */
+		5:   nil, /* TimeInPowerZone */
+		6:   nil, /* HrZoneHighBoundary */
+		7:   nil, /* SpeedZoneHighBoundary */
+		8:   nil, /* CadenceZoneHighBondary */
+		9:   nil, /* PowerZoneHighBoundary */
+		10:  nil, /* HrCalcType */
+		11:  nil, /* MaxHeartRate */
+		12:  nil, /* RestingHeartRate */
+		13:  nil, /* ThresholdHeartRate */
+		14:  nil, /* PwrCalcType */
+		15:  nil, /* FunctionalThresholdPower */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &TimeInZone{
@@ -108,7 +108,7 @@ func (m TimeInZone) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.ReferenceMesg,
 		1:   m.ReferenceIndex,
@@ -129,8 +129,12 @@ func (m TimeInZone) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/timestamp_correlation_gen.go
+++ b/profile/mesgdef/timestamp_correlation_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -35,21 +34,22 @@ func NewTimestampCorrelation(mesg proto.Message) *TimestampCorrelation {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* FractionalTimestamp */
-		1:   basetype.Uint32Invalid, /* SystemTimestamp */
-		2:   basetype.Uint16Invalid, /* FractionalSystemTimestamp */
-		3:   basetype.Uint32Invalid, /* LocalTimestamp */
-		4:   basetype.Uint16Invalid, /* TimestampMs */
-		5:   basetype.Uint16Invalid, /* SystemTimestampMs */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* FractionalTimestamp */
+		1:   nil, /* SystemTimestamp */
+		2:   nil, /* FractionalSystemTimestamp */
+		3:   nil, /* LocalTimestamp */
+		4:   nil, /* TimestampMs */
+		5:   nil, /* SystemTimestampMs */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &TimestampCorrelation{
@@ -78,7 +78,7 @@ func (m TimestampCorrelation) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.FractionalTimestamp,
 		1:   m.SystemTimestamp,
@@ -89,8 +89,12 @@ func (m TimestampCorrelation) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/user_profile_gen.go
+++ b/profile/mesgdef/user_profile_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -57,43 +56,44 @@ func NewUserProfile(mesg proto.Message) *UserProfile {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.StringInvalid, /* FriendlyName */
-		1:   basetype.EnumInvalid,   /* Gender */
-		2:   basetype.Uint8Invalid,  /* Age */
-		3:   basetype.Uint8Invalid,  /* Height */
-		4:   basetype.Uint16Invalid, /* Weight */
-		5:   basetype.EnumInvalid,   /* Language */
-		6:   basetype.EnumInvalid,   /* ElevSetting */
-		7:   basetype.EnumInvalid,   /* WeightSetting */
-		8:   basetype.Uint8Invalid,  /* RestingHeartRate */
-		9:   basetype.Uint8Invalid,  /* DefaultMaxRunningHeartRate */
-		10:  basetype.Uint8Invalid,  /* DefaultMaxBikingHeartRate */
-		11:  basetype.Uint8Invalid,  /* DefaultMaxHeartRate */
-		12:  basetype.EnumInvalid,   /* HrSetting */
-		13:  basetype.EnumInvalid,   /* SpeedSetting */
-		14:  basetype.EnumInvalid,   /* DistSetting */
-		16:  basetype.EnumInvalid,   /* PowerSetting */
-		17:  basetype.EnumInvalid,   /* ActivityClass */
-		18:  basetype.EnumInvalid,   /* PositionSetting */
-		21:  basetype.EnumInvalid,   /* TemperatureSetting */
-		22:  basetype.Uint16Invalid, /* LocalId */
-		23:  nil,                    /* GlobalId */
-		28:  basetype.Uint32Invalid, /* WakeTime */
-		29:  basetype.Uint32Invalid, /* SleepTime */
-		30:  basetype.EnumInvalid,   /* HeightSetting */
-		31:  basetype.Uint16Invalid, /* UserRunningStepLength */
-		32:  basetype.Uint16Invalid, /* UserWalkingStepLength */
-		47:  basetype.EnumInvalid,   /* DepthSetting */
-		49:  basetype.Uint32Invalid, /* DiveCount */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* FriendlyName */
+		1:   nil, /* Gender */
+		2:   nil, /* Age */
+		3:   nil, /* Height */
+		4:   nil, /* Weight */
+		5:   nil, /* Language */
+		6:   nil, /* ElevSetting */
+		7:   nil, /* WeightSetting */
+		8:   nil, /* RestingHeartRate */
+		9:   nil, /* DefaultMaxRunningHeartRate */
+		10:  nil, /* DefaultMaxBikingHeartRate */
+		11:  nil, /* DefaultMaxHeartRate */
+		12:  nil, /* HrSetting */
+		13:  nil, /* SpeedSetting */
+		14:  nil, /* DistSetting */
+		16:  nil, /* PowerSetting */
+		17:  nil, /* ActivityClass */
+		18:  nil, /* PositionSetting */
+		21:  nil, /* TemperatureSetting */
+		22:  nil, /* LocalId */
+		23:  nil, /* GlobalId */
+		28:  nil, /* WakeTime */
+		29:  nil, /* SleepTime */
+		30:  nil, /* HeightSetting */
+		31:  nil, /* UserRunningStepLength */
+		32:  nil, /* UserWalkingStepLength */
+		47:  nil, /* DepthSetting */
+		49:  nil, /* DiveCount */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &UserProfile{
@@ -144,7 +144,7 @@ func (m UserProfile) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.FriendlyName,
 		1:   m.Gender,
@@ -177,8 +177,12 @@ func (m UserProfile) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/video_clip_gen.go
+++ b/profile/mesgdef/video_clip_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -35,21 +34,22 @@ func NewVideoClip(mesg proto.Message) *VideoClip {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0: basetype.Uint16Invalid, /* ClipNumber */
-		1: basetype.Uint32Invalid, /* StartTimestamp */
-		2: basetype.Uint16Invalid, /* StartTimestampMs */
-		3: basetype.Uint32Invalid, /* EndTimestamp */
-		4: basetype.Uint16Invalid, /* EndTimestampMs */
-		6: basetype.Uint32Invalid, /* ClipStart */
-		7: basetype.Uint32Invalid, /* ClipEnd */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0: nil, /* ClipNumber */
+		1: nil, /* StartTimestamp */
+		2: nil, /* StartTimestampMs */
+		3: nil, /* EndTimestamp */
+		4: nil, /* EndTimestampMs */
+		6: nil, /* ClipStart */
+		7: nil, /* ClipEnd */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &VideoClip{
@@ -78,7 +78,7 @@ func (m VideoClip) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0: m.ClipNumber,
 		1: m.StartTimestamp,
 		2: m.StartTimestampMs,
@@ -89,8 +89,12 @@ func (m VideoClip) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/video_description_gen.go
+++ b/profile/mesgdef/video_description_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewVideoDescription(mesg proto.Message) *VideoDescription {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.Uint16Invalid, /* MessageCount */
-		1:   basetype.StringInvalid, /* Text */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* MessageCount */
+		1:   nil, /* Text */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &VideoDescription{
@@ -66,15 +66,19 @@ func (m VideoDescription) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.MessageCount,
 		1:   m.Text,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/video_frame_gen.go
+++ b/profile/mesgdef/video_frame_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewVideoFrame(mesg proto.Message) *VideoFrame {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* TimestampMs */
-		1:   basetype.Uint32Invalid, /* FrameNumber */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* TimestampMs */
+		1:   nil, /* FrameNumber */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &VideoFrame{
@@ -66,15 +66,19 @@ func (m VideoFrame) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.TimestampMs,
 		1:   m.FrameNumber,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/video_gen.go
+++ b/profile/mesgdef/video_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewVideo(mesg proto.Message) *Video {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		0: basetype.StringInvalid, /* Url */
-		1: basetype.StringInvalid, /* HostingProvider */
-		2: basetype.Uint32Invalid, /* Duration */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		0: nil, /* Url */
+		1: nil, /* HostingProvider */
+		2: nil, /* Duration */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &Video{
@@ -66,15 +66,19 @@ func (m Video) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		0: m.Url,
 		1: m.HostingProvider,
 		2: m.Duration,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/video_title_gen.go
+++ b/profile/mesgdef/video_title_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewVideoTitle(mesg proto.Message) *VideoTitle {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.Uint16Invalid, /* MessageCount */
-		1:   basetype.StringInvalid, /* Text */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* MessageCount */
+		1:   nil, /* Text */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &VideoTitle{
@@ -66,15 +66,19 @@ func (m VideoTitle) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.MessageCount,
 		1:   m.Text,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/watchface_settings_gen.go
+++ b/profile/mesgdef/watchface_settings_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -31,17 +30,18 @@ func NewWatchfaceSettings(mesg proto.Message) *WatchfaceSettings {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.EnumInvalid,   /* Mode */
-		1:   basetype.ByteInvalid,   /* Layout */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* Mode */
+		1:   nil, /* Layout */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &WatchfaceSettings{
@@ -66,15 +66,19 @@ func (m WatchfaceSettings) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.Mode,
 		1:   m.Layout,
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/weather_conditions_gen.go
+++ b/profile/mesgdef/weather_conditions_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -44,30 +43,31 @@ func NewWeatherConditions(mesg proto.Message) *WeatherConditions {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.EnumInvalid,   /* WeatherReport */
-		1:   basetype.Sint8Invalid,  /* Temperature */
-		2:   basetype.EnumInvalid,   /* Condition */
-		3:   basetype.Uint16Invalid, /* WindDirection */
-		4:   basetype.Uint16Invalid, /* WindSpeed */
-		5:   basetype.Uint8Invalid,  /* PrecipitationProbability */
-		6:   basetype.Sint8Invalid,  /* TemperatureFeelsLike */
-		7:   basetype.Uint8Invalid,  /* RelativeHumidity */
-		8:   basetype.StringInvalid, /* Location */
-		9:   basetype.Uint32Invalid, /* ObservedAtTime */
-		10:  basetype.Sint32Invalid, /* ObservedLocationLat */
-		11:  basetype.Sint32Invalid, /* ObservedLocationLong */
-		12:  basetype.EnumInvalid,   /* DayOfWeek */
-		13:  basetype.Sint8Invalid,  /* HighTemperature */
-		14:  basetype.Sint8Invalid,  /* LowTemperature */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* WeatherReport */
+		1:   nil, /* Temperature */
+		2:   nil, /* Condition */
+		3:   nil, /* WindDirection */
+		4:   nil, /* WindSpeed */
+		5:   nil, /* PrecipitationProbability */
+		6:   nil, /* TemperatureFeelsLike */
+		7:   nil, /* RelativeHumidity */
+		8:   nil, /* Location */
+		9:   nil, /* ObservedAtTime */
+		10:  nil, /* ObservedLocationLat */
+		11:  nil, /* ObservedLocationLong */
+		12:  nil, /* DayOfWeek */
+		13:  nil, /* HighTemperature */
+		14:  nil, /* LowTemperature */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &WeatherConditions{
@@ -105,7 +105,7 @@ func (m WeatherConditions) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.WeatherReport,
 		1:   m.Temperature,
@@ -125,8 +125,12 @@ func (m WeatherConditions) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/weight_scale_gen.go
+++ b/profile/mesgdef/weight_scale_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -42,28 +41,29 @@ func NewWeightScale(mesg proto.Message) *WeightScale {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		253: basetype.Uint32Invalid, /* Timestamp */
-		0:   basetype.Uint16Invalid, /* Weight */
-		1:   basetype.Uint16Invalid, /* PercentFat */
-		2:   basetype.Uint16Invalid, /* PercentHydration */
-		3:   basetype.Uint16Invalid, /* VisceralFatMass */
-		4:   basetype.Uint16Invalid, /* BoneMass */
-		5:   basetype.Uint16Invalid, /* MuscleMass */
-		7:   basetype.Uint16Invalid, /* BasalMet */
-		8:   basetype.Uint8Invalid,  /* PhysiqueRating */
-		9:   basetype.Uint16Invalid, /* ActiveMet */
-		10:  basetype.Uint8Invalid,  /* MetabolicAge */
-		11:  basetype.Uint8Invalid,  /* VisceralFatRating */
-		12:  basetype.Uint16Invalid, /* UserProfileIndex */
-		13:  basetype.Uint16Invalid, /* Bmi */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		253: nil, /* Timestamp */
+		0:   nil, /* Weight */
+		1:   nil, /* PercentFat */
+		2:   nil, /* PercentHydration */
+		3:   nil, /* VisceralFatMass */
+		4:   nil, /* BoneMass */
+		5:   nil, /* MuscleMass */
+		7:   nil, /* BasalMet */
+		8:   nil, /* PhysiqueRating */
+		9:   nil, /* ActiveMet */
+		10:  nil, /* MetabolicAge */
+		11:  nil, /* VisceralFatRating */
+		12:  nil, /* UserProfileIndex */
+		13:  nil, /* Bmi */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &WeightScale{
@@ -99,7 +99,7 @@ func (m WeightScale) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		253: m.Timestamp,
 		0:   m.Weight,
 		1:   m.PercentFat,
@@ -117,8 +117,12 @@ func (m WeightScale) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/workout_session_gen.go
+++ b/profile/mesgdef/workout_session_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -35,21 +34,22 @@ func NewWorkoutSession(mesg proto.Message) *WorkoutSession {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.EnumInvalid,   /* Sport */
-		1:   basetype.EnumInvalid,   /* SubSport */
-		2:   basetype.Uint16Invalid, /* NumValidSteps */
-		3:   basetype.Uint16Invalid, /* FirstStepIndex */
-		4:   basetype.Uint16Invalid, /* PoolLength */
-		5:   basetype.EnumInvalid,   /* PoolLengthUnit */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* Sport */
+		1:   nil, /* SubSport */
+		2:   nil, /* NumValidSteps */
+		3:   nil, /* FirstStepIndex */
+		4:   nil, /* PoolLength */
+		5:   nil, /* PoolLengthUnit */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &WorkoutSession{
@@ -78,7 +78,7 @@ func (m WorkoutSession) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.Sport,
 		1:   m.SubSport,
@@ -89,8 +89,12 @@ func (m WorkoutSession) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/workout_step_gen.go
+++ b/profile/mesgdef/workout_step_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -47,33 +46,34 @@ func NewWorkoutStep(mesg proto.Message) *WorkoutStep {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		254: basetype.Uint16Invalid, /* MessageIndex */
-		0:   basetype.StringInvalid, /* WktStepName */
-		1:   basetype.EnumInvalid,   /* DurationType */
-		2:   basetype.Uint32Invalid, /* DurationValue */
-		3:   basetype.EnumInvalid,   /* TargetType */
-		4:   basetype.Uint32Invalid, /* TargetValue */
-		5:   basetype.Uint32Invalid, /* CustomTargetValueLow */
-		6:   basetype.Uint32Invalid, /* CustomTargetValueHigh */
-		7:   basetype.EnumInvalid,   /* Intensity */
-		8:   basetype.StringInvalid, /* Notes */
-		9:   basetype.EnumInvalid,   /* Equipment */
-		10:  basetype.Uint16Invalid, /* ExerciseCategory */
-		11:  basetype.Uint16Invalid, /* ExerciseName */
-		12:  basetype.Uint16Invalid, /* ExerciseWeight */
-		13:  basetype.Uint16Invalid, /* WeightDisplayUnit */
-		19:  basetype.EnumInvalid,   /* SecondaryTargetType */
-		20:  basetype.Uint32Invalid, /* SecondaryTargetValue */
-		21:  basetype.Uint32Invalid, /* SecondaryCustomTargetValueLow */
-		22:  basetype.Uint32Invalid, /* SecondaryCustomTargetValueHigh */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		254: nil, /* MessageIndex */
+		0:   nil, /* WktStepName */
+		1:   nil, /* DurationType */
+		2:   nil, /* DurationValue */
+		3:   nil, /* TargetType */
+		4:   nil, /* TargetValue */
+		5:   nil, /* CustomTargetValueLow */
+		6:   nil, /* CustomTargetValueHigh */
+		7:   nil, /* Intensity */
+		8:   nil, /* Notes */
+		9:   nil, /* Equipment */
+		10:  nil, /* ExerciseCategory */
+		11:  nil, /* ExerciseName */
+		12:  nil, /* ExerciseWeight */
+		13:  nil, /* WeightDisplayUnit */
+		19:  nil, /* SecondaryTargetType */
+		20:  nil, /* SecondaryTargetValue */
+		21:  nil, /* SecondaryCustomTargetValueLow */
+		22:  nil, /* SecondaryCustomTargetValueHigh */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &WorkoutStep{
@@ -114,7 +114,7 @@ func (m WorkoutStep) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		254: m.MessageIndex,
 		0:   m.WktStepName,
 		1:   m.DurationType,
@@ -137,8 +137,12 @@ func (m WorkoutStep) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }

--- a/profile/mesgdef/zones_target_gen.go
+++ b/profile/mesgdef/zones_target_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -33,19 +32,20 @@ func NewZonesTarget(mesg proto.Message) *ZonesTarget {
 		return nil
 	}
 
-	vals := [256]any{ // Mark all values as invalid, replace only when specified.
-		1: basetype.Uint8Invalid,  /* MaxHeartRate */
-		2: basetype.Uint8Invalid,  /* ThresholdHeartRate */
-		3: basetype.Uint16Invalid, /* FunctionalThresholdPower */
-		5: basetype.EnumInvalid,   /* HrCalcType */
-		7: basetype.EnumInvalid,   /* PwrCalcType */
+	vals := [...]any{ // nil value will be converted to its corresponding invalid value by typeconv.
+		1: nil, /* MaxHeartRate */
+		2: nil, /* ThresholdHeartRate */
+		3: nil, /* FunctionalThresholdPower */
+		5: nil, /* HrCalcType */
+		7: nil, /* PwrCalcType */
 	}
 
 	for i := range mesg.Fields {
-		if mesg.Fields[i].Value == nil {
-			continue // keep the invalid value
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
 		}
-		vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
+		vals[field.Num] = field.Value
 	}
 
 	return &ZonesTarget{
@@ -72,7 +72,7 @@ func (m ZonesTarget) PutMessage(mesg *proto.Message) {
 		return
 	}
 
-	vals := [256]any{
+	vals := [...]any{
 		1: m.MaxHeartRate,
 		2: m.ThresholdHeartRate,
 		3: m.FunctionalThresholdPower,
@@ -81,8 +81,12 @@ func (m ZonesTarget) PutMessage(mesg *proto.Message) {
 	}
 
 	for i := range mesg.Fields {
-		mesg.Fields[i].Value = vals[mesg.Fields[i].Num]
+		field := &mesg.Fields[i]
+		if field.Num >= byte(len(vals)) {
+			continue
+		}
+		field.Value = vals[field.Num]
 	}
-	mesg.DeveloperFields = m.DeveloperFields
 
+	mesg.DeveloperFields = m.DeveloperFields
 }


### PR DESCRIPTION
- We no longer need to predefine invalid values as typeconv will create it for us when the value is nil
- Only create array as needed ([...]any{}) than fixed array ([256]any{}), this reduce memory allocation and improve performance.