### PR TITLE
feat!: update filedef implementation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -104,7 +104,9 @@ func main() {
 
     // The listener will receive every decoded message from the decoder as soon as it is decoded,
     // The Activity Listener will transform the messages into an Activity File.
-    al := filedef.NewListener(filedef.NewActivity())
+    al := filedef.NewListener[filedef.Activity]()
+    defer al.Close() // release channel used by listener
+
     dec := decoder.New(bufio.NewReader(f),
         decoder.WithMesgListener(al), // Add activity listener to the decoder
         decoder.WithBroadcastOnly(),  // Direct the decoder to only broadcast the messages without retaining them.
@@ -171,7 +173,9 @@ func main() {
     }
     defer f.Close()
 
-    al := filedef.NewListener(filedef.NewActivity())
+    al := filedef.NewListener[filedef.Activity]()
+    defer al.Close() // release channel used by listener
+
     dec := decoder.New(bufio.NewReader(f),
         decoder.WithMesgListener(al),
         decoder.WithBroadcastOnly(),
@@ -188,7 +192,6 @@ func main() {
     // File Type: activity
 
     if fileId.Type != typedef.FileActivity {
-        _ = al.File() // Note: It is recommended to call this method to release the listener's channel.
         return // Let's stop.
     }
 
@@ -347,7 +350,7 @@ func main() {
 
 ### Encode Common File Types
 
-Currently, only Activity Files are supported. Please note that this feature is still under development and has not been tested yet.
+Please note that this feature is still under development and has not been fully tested yet.
 
 ```go
     ...

--- a/profile/filedef/course.go
+++ b/profile/filedef/course.go
@@ -5,13 +5,21 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
 )
 
-type CourseFile struct {
+// Course is a common file type used as points of courses to assist with on- and off-road navigation,
+// to provide turn by turn directions, or with virtual training applications to simulate real-world activities.
+//
+// Please note since we group the same mesgdef types in a slice, we lose the arrival order of the messages.
+// But for messages that have timestamp, we can reconstruct the messages by timestamp order.
+//
+// ref: https://developer.garmin.com/fit/file-types/course/
+type Course struct {
 	FileId  *mesgdef.FileId
 	Course  *mesgdef.Course
 	Lap     *mesgdef.Lap
@@ -24,10 +32,15 @@ type CourseFile struct {
 	// Developer Data Lookup
 	DeveloperDataIds  []*mesgdef.DeveloperDataId
 	FieldDescriptions []*mesgdef.FieldDescription
+
+	// Messages not related to Course
+	UnrelatedMessages []proto.Message
 }
 
-func NewCourseFile(mesgs ...proto.Message) (f *CourseFile, ok bool) {
-	f = &CourseFile{}
+var _ File = &Course{}
+
+func NewCourse(mesgs ...proto.Message) (f *Course, ok bool) {
+	f = &Course{}
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
@@ -39,7 +52,7 @@ func NewCourseFile(mesgs ...proto.Message) (f *CourseFile, ok bool) {
 	return f, true
 }
 
-func (f *CourseFile) Add(mesg proto.Message) {
+func (f *Course) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
 		f.FileId = mesgdef.NewFileId(mesg)
@@ -57,5 +70,54 @@ func (f *CourseFile) Add(mesg proto.Message) {
 		f.DeveloperDataIds = append(f.DeveloperDataIds, mesgdef.NewDeveloperDataId(mesg))
 	case mesgnum.FieldDescription:
 		f.FieldDescriptions = append(f.FieldDescriptions, mesgdef.NewFieldDescription(mesg))
+	default:
+		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
+}
+
+func (f *Course) ToFit(fac Factory) proto.Fit {
+	if fac == nil {
+		fac = factory.StandardFactory()
+	}
+
+	size := 3 /* non slice fields */
+
+	size += len(f.Records) + len(f.Events) + len(f.CoursePoints) +
+		len(f.DeveloperDataIds) + len(f.FieldDescriptions) + len(f.UnrelatedMessages)
+
+	fit := proto.Fit{
+		Messages: make([]proto.Message, 0, size),
+	}
+
+	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
+	if f.FileId != nil {
+		mesg := fac.CreateMesg(mesgnum.FileId)
+		f.FileId.PutMessage(&mesg)
+		fit.Messages = append(fit.Messages, mesg)
+	}
+
+	PutMessages(fac, &fit.Messages, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	PutMessages(fac, &fit.Messages, mesgnum.FieldDescription, f.FieldDescriptions)
+
+	if f.Course != nil {
+		mesg := fac.CreateMesg(mesgnum.Course)
+		f.Course.PutMessage(&mesg)
+		fit.Messages = append(fit.Messages, mesg)
+	}
+
+	if f.Lap != nil {
+		mesg := fac.CreateMesg(mesgnum.Lap)
+		f.Lap.PutMessage(&mesg)
+		fit.Messages = append(fit.Messages, mesg)
+	}
+
+	PutMessages(fac, &fit.Messages, mesgnum.Record, f.Records)
+	PutMessages(fac, &fit.Messages, mesgnum.Event, f.Events)
+	PutMessages(fac, &fit.Messages, mesgnum.CoursePoint, f.CoursePoints)
+
+	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
+
+	SortMessagesByTimestamp(fit.Messages)
+
+	return fit
 }


### PR DESCRIPTION
- Course and Workout to proto.Fit convertion is now implemented

BREAKING CHANGES:
- `filedef.NewListener` is no longer receiving a pointer to the file, instead we only need to specify the file in generic constraint e.g.  `filedef.NewListener[filedef.Activity]()`