### PR TITLE
fix: miss on encoder validate invalid value checking

### DIFF
--- a/encoder/validator.go
+++ b/encoder/validator.go
@@ -431,11 +431,11 @@ func hasValidValue(val any) bool {
 					invalidcounter++
 				}
 			default: // not supported
-				return false
+				return true // unknown type, let it be swept by isValueTypeAligned
 			}
 		}
 		return invalidcounter != rv.Len()
 	default: // not supported
-		return false
+		return true // unknown type, let it be swept by isValueTypeAligned
 	}
 }


### PR DESCRIPTION
In previous test, we did not check the size of the fields after validation and it turned out that value like `int`, `uint` and `struct{}` was silently skipped making it a false-negative. We should have returned an error to user but we kept encoding the FIT file with missing those message's fields.