### PR TITLE
perf: improve validate mesg sec/op delta by -72%

### DIFF
--- a/encoder/validator_test.go
+++ b/encoder/validator_test.go
@@ -415,3 +415,35 @@ func BenchmarkIsValueTypeAligned(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkValidate(b *testing.B) {
+	b.StopTimer()
+	mesgValidator := NewMessageValidator()
+	mesg := factory.CreateMesgOnly(mesgnum.Record).WithFields(
+		factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed).WithValue(uint16(1000)),
+		factory.CreateField(mesgnum.Record, fieldnum.RecordAltitude).WithValue(uint16(10000)),
+		func() proto.Field {
+			field := factory.CreateField(mesgnum.Record, fieldnum.RecordEnhancedSpeed)
+			field.IsExpandedField = true
+			field.Value = uint32(1000)
+			return field
+		}(),
+		func() proto.Field {
+			field := factory.CreateField(mesgnum.Record, fieldnum.RecordEnhancedSpeed)
+			field.IsExpandedField = true
+			field.Value = uint32(1000)
+			return field
+		}(),
+		func() proto.Field {
+			field := factory.CreateField(mesgnum.Record, fieldnum.RecordEnhancedSpeed)
+			field.IsExpandedField = true
+			field.Value = uint32(1000)
+			return field
+		}(),
+	)
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = mesgValidator.Validate(&mesg)
+	}
+}


### PR DESCRIPTION
- remove the need to allocate new slices improve the performance by an order of magnitude.

```
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/encoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
           │   old.txt    │               new.txt               │
           │    sec/op    │   sec/op     vs base                │
Validate-4   147.70n ± 3%   40.28n ± 0%  -72.73% (p=0.000 n=10)

           │  old.txt   │              new.txt               │
           │    B/op    │   B/op     vs base                 │
Validate-4   64.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

           │  old.txt   │               new.txt               │
           │ allocs/op  │ allocs/op   vs base                 │
Validate-4   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```
