### PR TITLE
perf: improve proto marshaler

### DIFF
--- a/proto/marshaler_test.go
+++ b/proto/marshaler_test.go
@@ -9,8 +9,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
+	"github.com/muktihari/fit/profile/untyped/fieldnum"
+	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
 )
 
@@ -135,15 +138,6 @@ func TestMessageDefinitionMarshaler(t *testing.T) {
 	}
 }
 
-func TestDeveloperFieldDefinitionMarshaler(t *testing.T) {
-	f := proto.DeveloperFieldDefinition{Num: 0, Size: 1, DeveloperDataIndex: 0}
-	b, _ := f.MarshalBinary()
-	expected := []byte{0, 1, 0}
-	if diff := cmp.Diff(b, expected); diff != "" {
-		t.Fatal(diff)
-	}
-}
-
 func TestMessageMarshaler(t *testing.T) {
 	tt := []struct {
 		name string
@@ -239,5 +233,30 @@ func TestMessageMarshaler(t *testing.T) {
 				t.Fatal(diff)
 			}
 		})
+	}
+}
+
+func BenchmarkMarshalMessageDefinition(b *testing.B) {
+	b.StopTimer()
+	mesg := factory.CreateMesg(mesgnum.Record)
+	mesgDef := proto.CreateMessageDefinition(&mesg)
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = mesgDef.MarshalBinary()
+	}
+}
+
+func BenchmarkMarshalMessage(b *testing.B) {
+	b.StopTimer()
+	mesg := factory.CreateMesg(mesgnum.Record).WithFieldValues(map[byte]any{
+		fieldnum.RecordPositionLat:  int32(1000),
+		fieldnum.RecordPositionLong: int32(1000),
+		fieldnum.RecordSpeed:        uint16(1000),
+	})
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = mesg.MarshalBinary()
 	}
 }


### PR DESCRIPTION
Context: `MarshalBinary()`

- **Message Definition**: Reduce bytes alloc by directly append to `b`. For this case, there is no benefit on using `sync.Pool` since the bytes size is known at front, using `sync.Pool` will only add overhead.
- **Message**: Use `sync.Pool` to reduce memory usage and alloc since the method might be called thousands times, there is not much different in sec/op but memory usage is way reduced

```sh
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/proto
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                           │   old.txt    │               new.txt                │
                           │    sec/op    │    sec/op     vs base                │
MarshalMessageDefinition-4   731.2n ± 39%   242.2n ± 77%  -66.88% (p=0.000 n=10)
MarshalMessage-4             2.913µ ± 25%   2.724µ ± 23%        ~ (p=0.123 n=10)
geomean                      1.459µ         812.1n        -44.35%

                           │  old.txt   │               new.txt                │
                           │    B/op    │    B/op     vs base                  │
MarshalMessageDefinition-4   290.0 ± 0%   290.0 ± 0%        ~ (p=1.000 n=10) ¹
MarshalMessage-4             628.0 ± 0%   180.0 ± 0%  -71.34% (p=0.000 n=10)
geomean                      426.8        228.5       -46.46%
¹ all samples are equal

                           │  old.txt   │               new.txt               │
                           │ allocs/op  │ allocs/op   vs base                 │
MarshalMessageDefinition-4   2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
MarshalMessage-4             81.00 ± 0%   78.00 ± 0%  -3.70% (p=0.000 n=10)
geomean                      12.73        12.49       -1.87%
¹ all samples are equal
```