### PR TITLE
perf: reduce decoder malloc & reuse existing vars

### DIFF
--- a/decoder/accumulator.go
+++ b/decoder/accumulator.go
@@ -13,7 +13,7 @@ type Accumulator struct {
 }
 
 func NewAccumulator() *Accumulator {
-	return &Accumulator{AccumulatedValues: make([]AccumulatedValue, 0)}
+	return &Accumulator{} // No need to make AccumulatedValues as it will be created on append anyway.
 }
 
 func (a *Accumulator) Collect(mesgNum typedef.MesgNum, destFieldNum byte, value int64) {
@@ -42,6 +42,8 @@ func (a *Accumulator) Accumulate(mesgNum typedef.MesgNum, destFieldNum byte, val
 	}
 	return value
 }
+
+func (a *Accumulator) Reset() { a.AccumulatedValues = a.AccumulatedValues[:0] }
 
 type AccumulatedValue struct {
 	MesgNum      typedef.MesgNum

--- a/decoder/accumulator_test.go
+++ b/decoder/accumulator_test.go
@@ -85,3 +85,18 @@ func TestCollect(t *testing.T) {
 		})
 	}
 }
+
+func TestReset(t *testing.T) {
+	accumu := NewAccumulator()
+	accumu.Collect(mesgnum.Record, fieldnum.RecordSpeed, 1000)
+
+	if len(accumu.AccumulatedValues) != 1 {
+		t.Fatalf("expected AccumulatedValues is 1, got: %d", len(accumu.AccumulatedValues))
+	}
+
+	accumu.Reset()
+
+	if len(accumu.AccumulatedValues) != 0 {
+		t.Fatalf("expected AccumulatedValues is 0 after reset, got: %d", len(accumu.AccumulatedValues))
+	}
+}

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -416,7 +416,6 @@ func TestNext(t *testing.T) {
 
 	// Test Begin
 	dec := New(r)
-	prevAccumulator := dec.accumulator
 
 	if !dec.Next() {
 		t.Fatalf("should have next, return false")
@@ -427,14 +426,17 @@ func TestNext(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Manually add accumulated value
+	dec.accumulator.Collect(mesgnum.Record, fieldnum.RecordSpeed, 1000)
+
 	// Check whether after decode, fields are reset and next sequence is retrieved.
 
 	if !dec.Next() {
 		t.Fatalf("should have next, return false")
 	}
 
-	if prevAccumulator == dec.accumulator {
-		t.Fatalf("expected new accumulator got same")
+	if len(dec.accumulator.AccumulatedValues) != 0 {
+		t.Fatalf("expected accumulator's AccumulatedValues is 0, got: %d", len(dec.accumulator.AccumulatedValues))
 	}
 
 	if dec.crc16.Sum16() != 0 { // not necessary since reset every decode header anyway, but let's just add it

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/hash/crc16"
 	"github.com/muktihari/fit/profile"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
@@ -608,7 +607,6 @@ func TestEncodeMessage(t *testing.T) {
 				{
 					FieldBase: &proto.FieldBase{
 						Name: factory.NameUnknown,
-						Size: basetype.Sint64.Size(),
 						Type: profile.Sint64, // int64 type is ilegal for protocol v1.0
 					},
 					Value: int64(1234),
@@ -627,7 +625,6 @@ func TestEncodeMessage(t *testing.T) {
 				{
 					FieldBase: &proto.FieldBase{
 						Name: factory.NameUnknown,
-						Size: basetype.Sint64.Size(),
 						Type: profile.Sint64, // int64 type is ilegal for protocol v1.0
 					},
 					Value: int64(1234),

--- a/encoder/validator.go
+++ b/encoder/validator.go
@@ -18,7 +18,6 @@ import (
 )
 
 var (
-	ErrSizeZero                = errors.New("size is zero")
 	ErrValueTypeMismatch       = errors.New("value type mismatch")
 	ErrNoFields                = errors.New("no fields")
 	ErrMissingDeveloperDataId  = errors.New("missing developer data id")
@@ -86,11 +85,6 @@ func (v *messageValidator) Validate(mesg *proto.Message) error {
 			mesg.Fields = append(mesg.Fields[:i], mesg.Fields[i+1:]...)
 			i--
 			continue
-		}
-
-		if field.Size == 0 {
-			return fmt.Errorf("size could not be zero for fieldIndex: %d fieldNum: %d, fieldName: %s: %w",
-				i, field.Num, field.Name, ErrSizeZero)
 		}
 
 		if v.options.omitInvalidValues && !hasValidValue(field.Value) {

--- a/encoder/validator_test.go
+++ b/encoder/validator_test.go
@@ -122,19 +122,6 @@ func TestMessageValidatorValidate(t *testing.T) {
 			sizes: []int{1},
 		},
 		{
-			name: "mesg contain field with invalid size",
-			mesgs: []proto.Message{
-				factory.CreateMesgOnly(mesgnum.Record).WithFields(
-					proto.Field{
-						FieldBase: &proto.FieldBase{
-							Size: 0,
-						},
-					},
-				),
-			},
-			errs: []error{ErrSizeZero},
-		},
-		{
 			name: "mesg contain field with scaled value",
 			mesgs: []proto.Message{
 				factory.CreateMesgOnly(mesgnum.Record).WithFields(

--- a/factory/factory_gen.go
+++ b/factory/factory_gen.go
@@ -160,9 +160,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "type",
 					Num:        0,
-					Type:       profile.File, /* basetype.Enum */
+					Type:       profile.File, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -176,9 +175,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "manufacturer",
 					Num:        1,
-					Type:       profile.Manufacturer, /* basetype.Uint16 */
+					Type:       profile.Manufacturer, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -192,9 +190,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "product",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -224,9 +221,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "serial_number",
 					Num:        3,
-					Type:       profile.Uint32z, /* basetype.Uint32z */
+					Type:       profile.Uint32z, /* basetype.Uint32z (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -240,9 +236,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_created",
 					Num:        4,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -256,9 +251,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "number",
 					Num:        5,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -272,9 +266,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "product_name",
 					Num:        8,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -293,9 +286,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "software_version",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -309,9 +301,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "hardware_version",
 					Num:        1,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -330,9 +321,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -346,9 +336,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "fractional_timestamp",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      32768,
 					Offset:     0,
@@ -362,9 +351,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "system_timestamp",
 					Num:        1,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -378,9 +366,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "fractional_system_timestamp",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      32768,
 					Offset:     0,
@@ -394,9 +381,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "local_timestamp",
 					Num:        3,
-					Type:       profile.LocalDateTime, /* basetype.Uint32 */
+					Type:       profile.LocalDateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -410,9 +396,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_ms",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -426,9 +411,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "system_timestamp_ms",
 					Num:        5,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -447,9 +431,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -463,9 +446,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "version",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -479,9 +461,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "part_number",
 					Num:        5,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -500,9 +481,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "manufacturer",
 					Num:        0,
-					Type:       profile.Manufacturer, /* basetype.Uint16 */
+					Type:       profile.Manufacturer, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -516,9 +496,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "product",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -553,9 +532,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "languages",
 					Num:        0,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      true,           /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -569,9 +547,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sports",
 					Num:        1,
-					Type:       profile.SportBits0, /* basetype.Uint8z */
+					Type:       profile.SportBits0, /* basetype.Uint8z (size: 1) */
 					Array:      true,               /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -585,9 +562,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "workouts_supported",
 					Num:        21,
-					Type:       profile.WorkoutCapabilities, /* basetype.Uint32z */
+					Type:       profile.WorkoutCapabilities, /* basetype.Uint32z (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -601,9 +577,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "connectivity_supported",
 					Num:        23,
-					Type:       profile.ConnectivityCapabilities, /* basetype.Uint32z */
+					Type:       profile.ConnectivityCapabilities, /* basetype.Uint32z (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -622,9 +597,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -638,9 +612,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "type",
 					Num:        0,
-					Type:       profile.File, /* basetype.Enum */
+					Type:       profile.File, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -654,9 +627,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "flags",
 					Num:        1,
-					Type:       profile.FileFlags, /* basetype.Uint8z */
+					Type:       profile.FileFlags, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -670,9 +642,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "directory",
 					Num:        2,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -686,9 +657,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_count",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -702,9 +672,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_size",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -723,9 +692,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -739,9 +707,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "file",
 					Num:        0,
-					Type:       profile.File, /* basetype.Enum */
+					Type:       profile.File, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -755,9 +722,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mesg_num",
 					Num:        1,
-					Type:       profile.MesgNum, /* basetype.Uint16 */
+					Type:       profile.MesgNum, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -771,9 +737,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "count_type",
 					Num:        2,
-					Type:       profile.MesgCount, /* basetype.Enum */
+					Type:       profile.MesgCount, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -787,9 +752,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "count",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -827,9 +791,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -843,9 +806,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "file",
 					Num:        0,
-					Type:       profile.File, /* basetype.Enum */
+					Type:       profile.File, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -859,9 +821,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mesg_num",
 					Num:        1,
-					Type:       profile.MesgNum, /* basetype.Uint16 */
+					Type:       profile.MesgNum, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -875,9 +836,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "field_num",
 					Num:        2,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -891,9 +851,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "count",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -912,9 +871,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "active_time_zone",
 					Num:        0,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -928,9 +886,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "utc_offset",
 					Num:        1,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -944,9 +901,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_offset",
 					Num:        2,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -960,9 +916,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_mode",
 					Num:        4,
-					Type:       profile.TimeMode, /* basetype.Enum */
+					Type:       profile.TimeMode, /* basetype.Enum (size: 1) */
 					Array:      true,             /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -976,9 +931,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_zone_offset",
 					Num:        5,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      4,
 					Offset:     0,
@@ -992,9 +946,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "backlight_mode",
 					Num:        12,
-					Type:       profile.BacklightMode, /* basetype.Enum */
+					Type:       profile.BacklightMode, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1008,9 +961,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "activity_tracker_enabled",
 					Num:        36,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1024,9 +976,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "clock_time",
 					Num:        39,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1040,9 +991,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pages_enabled",
 					Num:        40,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1056,9 +1006,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "move_alert_enabled",
 					Num:        46,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1072,9 +1021,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "date_mode",
 					Num:        47,
-					Type:       profile.DateMode, /* basetype.Enum */
+					Type:       profile.DateMode, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1088,9 +1036,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "display_orientation",
 					Num:        55,
-					Type:       profile.DisplayOrientation, /* basetype.Enum */
+					Type:       profile.DisplayOrientation, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1104,9 +1051,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mounting_side",
 					Num:        56,
-					Type:       profile.Side, /* basetype.Enum */
+					Type:       profile.Side, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1120,9 +1066,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "default_page",
 					Num:        57,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1136,9 +1081,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "autosync_min_steps",
 					Num:        58,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1152,9 +1096,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "autosync_min_time",
 					Num:        59,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1168,9 +1111,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "lactate_threshold_autodetect_enabled",
 					Num:        80,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1184,9 +1126,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ble_auto_upload_enabled",
 					Num:        86,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1200,9 +1141,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "auto_sync_frequency",
 					Num:        89,
-					Type:       profile.AutoSyncFrequency, /* basetype.Enum */
+					Type:       profile.AutoSyncFrequency, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1216,9 +1156,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "auto_activity_detect",
 					Num:        90,
-					Type:       profile.AutoActivityDetect, /* basetype.Uint32 */
+					Type:       profile.AutoActivityDetect, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1232,9 +1171,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "number_of_screens",
 					Num:        94,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1248,9 +1186,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "smart_notification_display_orientation",
 					Num:        95,
-					Type:       profile.DisplayOrientation, /* basetype.Enum */
+					Type:       profile.DisplayOrientation, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1264,9 +1201,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "tap_interface",
 					Num:        134,
-					Type:       profile.Switch, /* basetype.Enum */
+					Type:       profile.Switch, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1280,9 +1216,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "tap_sensitivity",
 					Num:        174,
-					Type:       profile.TapSensitivity, /* basetype.Enum */
+					Type:       profile.TapSensitivity, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1301,9 +1236,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1317,9 +1251,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "friendly_name",
 					Num:        0,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1333,9 +1266,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gender",
 					Num:        1,
-					Type:       profile.Gender, /* basetype.Enum */
+					Type:       profile.Gender, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1349,9 +1281,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "age",
 					Num:        2,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1365,9 +1296,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "height",
 					Num:        3,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -1381,9 +1311,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "weight",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -1397,9 +1326,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "language",
 					Num:        5,
-					Type:       profile.Language, /* basetype.Enum */
+					Type:       profile.Language, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1413,9 +1341,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "elev_setting",
 					Num:        6,
-					Type:       profile.DisplayMeasure, /* basetype.Enum */
+					Type:       profile.DisplayMeasure, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1429,9 +1356,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "weight_setting",
 					Num:        7,
-					Type:       profile.DisplayMeasure, /* basetype.Enum */
+					Type:       profile.DisplayMeasure, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1445,9 +1371,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "resting_heart_rate",
 					Num:        8,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1461,9 +1386,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "default_max_running_heart_rate",
 					Num:        9,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1477,9 +1401,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "default_max_biking_heart_rate",
 					Num:        10,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1493,9 +1416,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "default_max_heart_rate",
 					Num:        11,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1509,9 +1431,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "hr_setting",
 					Num:        12,
-					Type:       profile.DisplayHeart, /* basetype.Enum */
+					Type:       profile.DisplayHeart, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1525,9 +1446,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "speed_setting",
 					Num:        13,
-					Type:       profile.DisplayMeasure, /* basetype.Enum */
+					Type:       profile.DisplayMeasure, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1541,9 +1461,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "dist_setting",
 					Num:        14,
-					Type:       profile.DisplayMeasure, /* basetype.Enum */
+					Type:       profile.DisplayMeasure, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1557,9 +1476,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "power_setting",
 					Num:        16,
-					Type:       profile.DisplayPower, /* basetype.Enum */
+					Type:       profile.DisplayPower, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1573,9 +1491,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "activity_class",
 					Num:        17,
-					Type:       profile.ActivityClass, /* basetype.Enum */
+					Type:       profile.ActivityClass, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1589,9 +1506,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_setting",
 					Num:        18,
-					Type:       profile.DisplayPosition, /* basetype.Enum */
+					Type:       profile.DisplayPosition, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1605,9 +1521,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "temperature_setting",
 					Num:        21,
-					Type:       profile.DisplayMeasure, /* basetype.Enum */
+					Type:       profile.DisplayMeasure, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1621,9 +1536,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "local_id",
 					Num:        22,
-					Type:       profile.UserLocalId, /* basetype.Uint16 */
+					Type:       profile.UserLocalId, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1637,9 +1551,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "global_id",
 					Num:        23,
-					Type:       profile.Byte, /* basetype.Byte */
+					Type:       profile.Byte, /* basetype.Byte (size: 1) */
 					Array:      true,         /* Array Size [6] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1653,9 +1566,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "wake_time",
 					Num:        28,
-					Type:       profile.LocaltimeIntoDay, /* basetype.Uint32 */
+					Type:       profile.LocaltimeIntoDay, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1669,9 +1581,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sleep_time",
 					Num:        29,
-					Type:       profile.LocaltimeIntoDay, /* basetype.Uint32 */
+					Type:       profile.LocaltimeIntoDay, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1685,9 +1596,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "height_setting",
 					Num:        30,
-					Type:       profile.DisplayMeasure, /* basetype.Enum */
+					Type:       profile.DisplayMeasure, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1701,9 +1611,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "user_running_step_length",
 					Num:        31,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -1717,9 +1626,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "user_walking_step_length",
 					Num:        32,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -1733,9 +1641,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "depth_setting",
 					Num:        47,
-					Type:       profile.DisplayMeasure, /* basetype.Enum */
+					Type:       profile.DisplayMeasure, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1749,9 +1656,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "dive_count",
 					Num:        49,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1770,9 +1676,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1786,9 +1691,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        0,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1802,9 +1706,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "hrm_ant_id",
 					Num:        1,
-					Type:       profile.Uint16z, /* basetype.Uint16z */
+					Type:       profile.Uint16z, /* basetype.Uint16z (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1818,9 +1721,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "log_hrv",
 					Num:        2,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1834,9 +1736,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "hrm_ant_id_trans_type",
 					Num:        3,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1855,9 +1756,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1871,9 +1771,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        0,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1887,9 +1786,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sdm_ant_id",
 					Num:        1,
-					Type:       profile.Uint16z, /* basetype.Uint16z */
+					Type:       profile.Uint16z, /* basetype.Uint16z (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1903,9 +1801,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sdm_cal_factor",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -1919,9 +1816,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "odometer",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -1935,9 +1831,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "speed_source",
 					Num:        4,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1951,9 +1846,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sdm_ant_id_trans_type",
 					Num:        5,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1967,9 +1861,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "odometer_rollover",
 					Num:        7,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -1988,9 +1881,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2004,9 +1896,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        0,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2020,9 +1911,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport",
 					Num:        1,
-					Type:       profile.Sport, /* basetype.Enum */
+					Type:       profile.Sport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2036,9 +1926,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sub_sport",
 					Num:        2,
-					Type:       profile.SubSport, /* basetype.Enum */
+					Type:       profile.SubSport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2052,9 +1941,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "odometer",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -2068,9 +1956,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bike_spd_ant_id",
 					Num:        4,
-					Type:       profile.Uint16z, /* basetype.Uint16z */
+					Type:       profile.Uint16z, /* basetype.Uint16z (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2084,9 +1971,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bike_cad_ant_id",
 					Num:        5,
-					Type:       profile.Uint16z, /* basetype.Uint16z */
+					Type:       profile.Uint16z, /* basetype.Uint16z (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2100,9 +1986,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bike_spdcad_ant_id",
 					Num:        6,
-					Type:       profile.Uint16z, /* basetype.Uint16z */
+					Type:       profile.Uint16z, /* basetype.Uint16z (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2116,9 +2001,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bike_power_ant_id",
 					Num:        7,
-					Type:       profile.Uint16z, /* basetype.Uint16z */
+					Type:       profile.Uint16z, /* basetype.Uint16z (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2132,9 +2016,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "custom_wheelsize",
 					Num:        8,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -2148,9 +2031,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "auto_wheelsize",
 					Num:        9,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -2164,9 +2046,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bike_weight",
 					Num:        10,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -2180,9 +2061,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "power_cal_factor",
 					Num:        11,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -2196,9 +2076,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "auto_wheel_cal",
 					Num:        12,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2212,9 +2091,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "auto_power_zero",
 					Num:        13,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2228,9 +2106,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "id",
 					Num:        14,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2244,9 +2121,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "spd_enabled",
 					Num:        15,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2260,9 +2136,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cad_enabled",
 					Num:        16,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2276,9 +2151,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "spdcad_enabled",
 					Num:        17,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2292,9 +2166,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "power_enabled",
 					Num:        18,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2308,9 +2181,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "crank_length",
 					Num:        19,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     -110,
@@ -2324,9 +2196,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        20,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2340,9 +2211,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bike_spd_ant_id_trans_type",
 					Num:        21,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2356,9 +2226,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bike_cad_ant_id_trans_type",
 					Num:        22,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2372,9 +2241,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bike_spdcad_ant_id_trans_type",
 					Num:        23,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2388,9 +2256,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bike_power_ant_id_trans_type",
 					Num:        24,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2404,9 +2271,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "odometer_rollover",
 					Num:        37,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2420,9 +2286,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "front_gear_num",
 					Num:        38,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2436,9 +2301,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "front_gear",
 					Num:        39,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      true,           /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2452,9 +2316,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "rear_gear_num",
 					Num:        40,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2468,9 +2331,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "rear_gear",
 					Num:        41,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      true,           /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2484,9 +2346,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "shimano_di2_enabled",
 					Num:        44,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2505,9 +2366,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bluetooth_enabled",
 					Num:        0,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2521,9 +2381,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bluetooth_le_enabled",
 					Num:        1,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2537,9 +2396,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ant_enabled",
 					Num:        2,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2553,9 +2411,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        3,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2569,9 +2426,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "live_tracking_enabled",
 					Num:        4,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2585,9 +2441,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "weather_conditions_enabled",
 					Num:        5,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2601,9 +2456,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "weather_alerts_enabled",
 					Num:        6,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2617,9 +2471,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "auto_activity_upload_enabled",
 					Num:        7,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2633,9 +2486,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "course_download_enabled",
 					Num:        8,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2649,9 +2501,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "workout_download_enabled",
 					Num:        9,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2665,9 +2516,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gps_ephemeris_download_enabled",
 					Num:        10,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2681,9 +2531,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "incident_detection_enabled",
 					Num:        11,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2697,9 +2546,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "grouptrack_enabled",
 					Num:        12,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2718,9 +2566,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2734,9 +2581,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mode",
 					Num:        0,
-					Type:       profile.WatchfaceMode, /* basetype.Enum */
+					Type:       profile.WatchfaceMode, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2750,9 +2596,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "layout",
 					Num:        1,
-					Type:       profile.Byte, /* basetype.Byte */
+					Type:       profile.Byte, /* basetype.Byte (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2784,9 +2629,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2800,9 +2644,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        0,
-					Type:       profile.Switch, /* basetype.Enum */
+					Type:       profile.Switch, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2821,9 +2664,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2837,9 +2679,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "reference_mesg",
 					Num:        0,
-					Type:       profile.MesgNum, /* basetype.Uint16 */
+					Type:       profile.MesgNum, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2853,9 +2694,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "reference_index",
 					Num:        1,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2869,9 +2709,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_hr_zone",
 					Num:        2,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -2885,9 +2724,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_speed_zone",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -2901,9 +2739,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_cadence_zone",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -2917,9 +2754,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_power_zone",
 					Num:        5,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -2933,9 +2769,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "hr_zone_high_boundary",
 					Num:        6,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2949,9 +2784,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "speed_zone_high_boundary",
 					Num:        7,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -2965,9 +2799,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cadence_zone_high_bondary",
 					Num:        8,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2981,9 +2814,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "power_zone_high_boundary",
 					Num:        9,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -2997,9 +2829,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "hr_calc_type",
 					Num:        10,
-					Type:       profile.HrZoneCalc, /* basetype.Enum */
+					Type:       profile.HrZoneCalc, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3013,9 +2844,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_heart_rate",
 					Num:        11,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3029,9 +2859,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "resting_heart_rate",
 					Num:        12,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3045,9 +2874,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "threshold_heart_rate",
 					Num:        13,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3061,9 +2889,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pwr_calc_type",
 					Num:        14,
-					Type:       profile.PwrZoneCalc, /* basetype.Enum */
+					Type:       profile.PwrZoneCalc, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3077,9 +2904,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "functional_threshold_power",
 					Num:        15,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3098,9 +2924,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_heart_rate",
 					Num:        1,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3114,9 +2939,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "threshold_heart_rate",
 					Num:        2,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3130,9 +2954,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "functional_threshold_power",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3146,9 +2969,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "hr_calc_type",
 					Num:        5,
-					Type:       profile.HrZoneCalc, /* basetype.Enum */
+					Type:       profile.HrZoneCalc, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3162,9 +2984,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pwr_calc_type",
 					Num:        7,
-					Type:       profile.PwrZoneCalc, /* basetype.Enum */
+					Type:       profile.PwrZoneCalc, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3183,9 +3004,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport",
 					Num:        0,
-					Type:       profile.Sport, /* basetype.Enum */
+					Type:       profile.Sport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3199,9 +3019,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sub_sport",
 					Num:        1,
-					Type:       profile.SubSport, /* basetype.Enum */
+					Type:       profile.SubSport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3215,9 +3034,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        3,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3236,9 +3054,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3252,9 +3069,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "high_bpm",
 					Num:        1,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3268,9 +3084,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        2,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3289,9 +3104,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3305,9 +3119,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "high_value",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -3321,9 +3134,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        1,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3342,9 +3154,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3358,9 +3169,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "high_value",
 					Num:        0,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3374,9 +3184,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        1,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3395,9 +3204,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3411,9 +3219,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "high_value",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3427,9 +3234,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        2,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3448,9 +3254,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3464,9 +3269,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "high_bpm",
 					Num:        1,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3480,9 +3284,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calories",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -3496,9 +3299,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "fat_calories",
 					Num:        3,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -3517,9 +3319,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3533,9 +3334,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3549,9 +3349,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        0,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3565,9 +3364,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "model",
 					Num:        1,
-					Type:       profile.TissueModelType, /* basetype.Enum */
+					Type:       profile.TissueModelType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3581,9 +3379,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gf_low",
 					Num:        2,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3597,9 +3394,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gf_high",
 					Num:        3,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3613,9 +3409,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "water_type",
 					Num:        4,
-					Type:       profile.WaterType, /* basetype.Enum */
+					Type:       profile.WaterType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3629,9 +3424,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "water_density",
 					Num:        5,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3645,9 +3439,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "po2_warn",
 					Num:        6,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -3661,9 +3454,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "po2_critical",
 					Num:        7,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -3677,9 +3469,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "po2_deco",
 					Num:        8,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -3693,9 +3484,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "safety_stop_enabled",
 					Num:        9,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3709,9 +3499,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bottom_depth",
 					Num:        10,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3725,9 +3514,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bottom_time",
 					Num:        11,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3741,9 +3529,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "apnea_countdown_enabled",
 					Num:        12,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3757,9 +3544,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "apnea_countdown_time",
 					Num:        13,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3773,9 +3559,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "backlight_mode",
 					Num:        14,
-					Type:       profile.DiveBacklightMode, /* basetype.Enum */
+					Type:       profile.DiveBacklightMode, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3789,9 +3574,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "backlight_brightness",
 					Num:        15,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3805,9 +3589,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "backlight_timeout",
 					Num:        16,
-					Type:       profile.BacklightTimeout, /* basetype.Uint8 */
+					Type:       profile.BacklightTimeout, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3821,9 +3604,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "repeat_dive_interval",
 					Num:        17,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3837,9 +3619,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "safety_stop_time",
 					Num:        18,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3853,9 +3634,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "heart_rate_source_type",
 					Num:        19,
-					Type:       profile.SourceType, /* basetype.Enum */
+					Type:       profile.SourceType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3869,9 +3649,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "heart_rate_source",
 					Num:        20,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3898,9 +3677,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "travel_gas",
 					Num:        21,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3914,9 +3692,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ccr_low_setpoint_switch_mode",
 					Num:        22,
-					Type:       profile.CcrSetpointSwitchMode, /* basetype.Enum */
+					Type:       profile.CcrSetpointSwitchMode, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3930,9 +3707,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ccr_low_setpoint",
 					Num:        23,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -3946,9 +3722,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ccr_low_setpoint_depth",
 					Num:        24,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -3962,9 +3737,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ccr_high_setpoint_switch_mode",
 					Num:        25,
-					Type:       profile.CcrSetpointSwitchMode, /* basetype.Enum */
+					Type:       profile.CcrSetpointSwitchMode, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -3978,9 +3752,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ccr_high_setpoint",
 					Num:        26,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -3994,9 +3767,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ccr_high_setpoint_depth",
 					Num:        27,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -4010,9 +3782,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gas_consumption_display",
 					Num:        29,
-					Type:       profile.GasConsumptionRateType, /* basetype.Enum */
+					Type:       profile.GasConsumptionRateType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4026,9 +3797,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "up_key_enabled",
 					Num:        30,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4042,9 +3812,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "dive_sounds",
 					Num:        35,
-					Type:       profile.Tone, /* basetype.Enum */
+					Type:       profile.Tone, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4058,9 +3827,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "last_stop_multiple",
 					Num:        36,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -4074,9 +3842,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "no_fly_time_mode",
 					Num:        37,
-					Type:       profile.NoFlyTimeMode, /* basetype.Enum */
+					Type:       profile.NoFlyTimeMode, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4095,9 +3862,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4111,9 +3877,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "depth",
 					Num:        0,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -4127,9 +3892,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time",
 					Num:        1,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4143,9 +3907,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        2,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4159,9 +3922,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "alarm_type",
 					Num:        3,
-					Type:       profile.DiveAlarmType, /* basetype.Enum */
+					Type:       profile.DiveAlarmType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4175,9 +3937,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sound",
 					Num:        4,
-					Type:       profile.Tone, /* basetype.Enum */
+					Type:       profile.Tone, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4191,9 +3952,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "dive_types",
 					Num:        5,
-					Type:       profile.SubSport, /* basetype.Enum */
+					Type:       profile.SubSport, /* basetype.Enum (size: 1) */
 					Array:      true,             /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4207,9 +3967,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "id",
 					Num:        6,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4223,9 +3982,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "popup_enabled",
 					Num:        7,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4239,9 +3997,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "trigger_on_descent",
 					Num:        8,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4255,9 +4012,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "trigger_on_ascent",
 					Num:        9,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4271,9 +4027,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "repeating",
 					Num:        10,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4287,9 +4042,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "speed",
 					Num:        11,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -4308,9 +4062,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4324,9 +4077,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "depth",
 					Num:        0,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -4340,9 +4092,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time",
 					Num:        1,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4356,9 +4107,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        2,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4372,9 +4122,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "alarm_type",
 					Num:        3,
-					Type:       profile.DiveAlarmType, /* basetype.Enum */
+					Type:       profile.DiveAlarmType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4388,9 +4137,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sound",
 					Num:        4,
-					Type:       profile.Tone, /* basetype.Enum */
+					Type:       profile.Tone, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4404,9 +4152,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "dive_types",
 					Num:        5,
-					Type:       profile.SubSport, /* basetype.Enum */
+					Type:       profile.SubSport, /* basetype.Enum (size: 1) */
 					Array:      true,             /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4420,9 +4167,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "id",
 					Num:        6,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4436,9 +4182,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "popup_enabled",
 					Num:        7,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4452,9 +4197,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "trigger_on_descent",
 					Num:        8,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4468,9 +4212,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "trigger_on_ascent",
 					Num:        9,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4484,9 +4227,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "repeating",
 					Num:        10,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4500,9 +4242,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "speed",
 					Num:        11,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -4521,9 +4262,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4537,9 +4277,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "helium_content",
 					Num:        0,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4553,9 +4292,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "oxygen_content",
 					Num:        1,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4569,9 +4307,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "status",
 					Num:        2,
-					Type:       profile.DiveGasStatus, /* basetype.Enum */
+					Type:       profile.DiveGasStatus, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4585,9 +4322,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mode",
 					Num:        3,
-					Type:       profile.DiveGasMode, /* basetype.Enum */
+					Type:       profile.DiveGasMode, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4606,9 +4342,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4622,9 +4357,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport",
 					Num:        0,
-					Type:       profile.Sport, /* basetype.Enum */
+					Type:       profile.Sport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4638,9 +4372,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sub_sport",
 					Num:        1,
-					Type:       profile.SubSport, /* basetype.Enum */
+					Type:       profile.SubSport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4654,9 +4387,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_date",
 					Num:        2,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4670,9 +4402,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_date",
 					Num:        3,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4686,9 +4417,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "type",
 					Num:        4,
-					Type:       profile.Goal, /* basetype.Enum */
+					Type:       profile.Goal, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4702,9 +4432,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "value",
 					Num:        5,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4718,9 +4447,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "repeat",
 					Num:        6,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4734,9 +4462,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "target_value",
 					Num:        7,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4750,9 +4477,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "recurrence",
 					Num:        8,
-					Type:       profile.GoalRecurrence, /* basetype.Enum */
+					Type:       profile.GoalRecurrence, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4766,9 +4492,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "recurrence_value",
 					Num:        9,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4782,9 +4507,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        10,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4798,9 +4522,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "source",
 					Num:        11,
-					Type:       profile.GoalSource, /* basetype.Enum */
+					Type:       profile.GoalSource, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4819,9 +4542,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4835,9 +4557,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_timer_time",
 					Num:        0,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -4851,9 +4572,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "num_sessions",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4867,9 +4587,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "type",
 					Num:        2,
-					Type:       profile.Activity, /* basetype.Enum */
+					Type:       profile.Activity, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4883,9 +4602,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event",
 					Num:        3,
-					Type:       profile.Event, /* basetype.Enum */
+					Type:       profile.Event, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4899,9 +4617,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_type",
 					Num:        4,
-					Type:       profile.EventType, /* basetype.Enum */
+					Type:       profile.EventType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4915,9 +4632,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "local_timestamp",
 					Num:        5,
-					Type:       profile.LocalDateTime, /* basetype.Uint32 */
+					Type:       profile.LocalDateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4931,9 +4647,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_group",
 					Num:        6,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4952,9 +4667,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4968,9 +4682,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -4984,9 +4697,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event",
 					Num:        0,
-					Type:       profile.Event, /* basetype.Enum */
+					Type:       profile.Event, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5000,9 +4712,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_type",
 					Num:        1,
-					Type:       profile.EventType, /* basetype.Enum */
+					Type:       profile.EventType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5016,9 +4727,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_time",
 					Num:        2,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5032,9 +4742,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_position_lat",
 					Num:        3,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5048,9 +4757,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_position_long",
 					Num:        4,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5064,9 +4772,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport",
 					Num:        5,
-					Type:       profile.Sport, /* basetype.Enum */
+					Type:       profile.Sport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5080,9 +4787,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sub_sport",
 					Num:        6,
-					Type:       profile.SubSport, /* basetype.Enum */
+					Type:       profile.SubSport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5096,9 +4802,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_elapsed_time",
 					Num:        7,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -5112,9 +4817,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_timer_time",
 					Num:        8,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -5128,9 +4832,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_distance",
 					Num:        9,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -5144,9 +4847,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_cycles",
 					Num:        10,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5177,9 +4879,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_calories",
 					Num:        11,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5193,9 +4894,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_fat_calories",
 					Num:        13,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5209,9 +4909,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "avg_speed",
 					Num:   14,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 124 /* enhanced_avg_speed */, Scale: 1000, Offset: 0, Accumulate: false, Bits: 16},
 					},
@@ -5227,9 +4926,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "max_speed",
 					Num:   15,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 125 /* enhanced_max_speed */, Scale: 1000, Offset: 0, Accumulate: false, Bits: 16},
 					},
@@ -5245,9 +4943,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_heart_rate",
 					Num:        16,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5261,9 +4958,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_heart_rate",
 					Num:        17,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5277,9 +4973,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_cadence",
 					Num:        18,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5300,9 +4995,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_cadence",
 					Num:        19,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5323,9 +5017,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_power",
 					Num:        20,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5339,9 +5032,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_power",
 					Num:        21,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5355,9 +5047,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_ascent",
 					Num:        22,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5371,9 +5062,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_descent",
 					Num:        23,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5387,9 +5077,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_training_effect",
 					Num:        24,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -5403,9 +5092,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "first_lap_index",
 					Num:        25,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5419,9 +5107,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "num_laps",
 					Num:        26,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5435,9 +5122,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_group",
 					Num:        27,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5451,9 +5137,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "trigger",
 					Num:        28,
-					Type:       profile.SessionTrigger, /* basetype.Enum */
+					Type:       profile.SessionTrigger, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5467,9 +5152,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "nec_lat",
 					Num:        29,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5483,9 +5167,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "nec_long",
 					Num:        30,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5499,9 +5182,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "swc_lat",
 					Num:        31,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5515,9 +5197,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "swc_long",
 					Num:        32,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5531,9 +5212,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "num_lengths",
 					Num:        33,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5547,9 +5227,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "normalized_power",
 					Num:        34,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5563,9 +5242,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "training_stress_score",
 					Num:        35,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -5579,9 +5257,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "intensity_factor",
 					Num:        36,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -5595,9 +5272,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "left_right_balance",
 					Num:        37,
-					Type:       profile.LeftRightBalance100, /* basetype.Uint16 */
+					Type:       profile.LeftRightBalance100, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5611,9 +5287,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_position_lat",
 					Num:        38,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5627,9 +5302,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_position_long",
 					Num:        39,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5643,9 +5317,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_stroke_count",
 					Num:        41,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -5659,9 +5332,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_stroke_distance",
 					Num:        42,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -5675,9 +5347,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "swim_stroke",
 					Num:        43,
-					Type:       profile.SwimStroke, /* basetype.Enum */
+					Type:       profile.SwimStroke, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5691,9 +5362,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pool_length",
 					Num:        44,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -5707,9 +5377,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "threshold_power",
 					Num:        45,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5723,9 +5392,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pool_length_unit",
 					Num:        46,
-					Type:       profile.DisplayMeasure, /* basetype.Enum */
+					Type:       profile.DisplayMeasure, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5739,9 +5407,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "num_active_lengths",
 					Num:        47,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5755,9 +5422,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_work",
 					Num:        48,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5771,9 +5437,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "avg_altitude",
 					Num:   49,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 126 /* enhanced_avg_altitude */, Scale: 5, Offset: 500, Accumulate: false, Bits: 16},
 					},
@@ -5789,9 +5454,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "max_altitude",
 					Num:   50,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 128 /* enhanced_max_altitude */, Scale: 5, Offset: 500, Accumulate: false, Bits: 16},
 					},
@@ -5807,9 +5471,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gps_accuracy",
 					Num:        51,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5823,9 +5486,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_grade",
 					Num:        52,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -5839,9 +5501,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_pos_grade",
 					Num:        53,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -5855,9 +5516,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_neg_grade",
 					Num:        54,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -5871,9 +5531,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_pos_grade",
 					Num:        55,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -5887,9 +5546,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_neg_grade",
 					Num:        56,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -5903,9 +5561,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_temperature",
 					Num:        57,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5919,9 +5576,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_temperature",
 					Num:        58,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -5935,9 +5591,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_moving_time",
 					Num:        59,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -5951,9 +5606,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_pos_vertical_speed",
 					Num:        60,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -5967,9 +5621,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_neg_vertical_speed",
 					Num:        61,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -5983,9 +5636,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_pos_vertical_speed",
 					Num:        62,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -5999,9 +5651,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_neg_vertical_speed",
 					Num:        63,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -6015,9 +5666,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "min_heart_rate",
 					Num:        64,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6031,9 +5681,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_hr_zone",
 					Num:        65,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -6047,9 +5696,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_speed_zone",
 					Num:        66,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -6063,9 +5711,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_cadence_zone",
 					Num:        67,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -6079,9 +5726,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_power_zone",
 					Num:        68,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -6095,9 +5741,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_lap_time",
 					Num:        69,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -6111,9 +5756,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "best_lap_index",
 					Num:        70,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6127,9 +5771,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "min_altitude",
 					Num:   71,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 127 /* enhanced_min_altitude */, Scale: 5, Offset: 500, Accumulate: false, Bits: 16},
 					},
@@ -6145,9 +5788,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "player_score",
 					Num:        82,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6161,9 +5803,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "opponent_score",
 					Num:        83,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6177,9 +5818,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "opponent_name",
 					Num:        84,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6193,9 +5833,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stroke_count",
 					Num:        85,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6209,9 +5848,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "zone_count",
 					Num:        86,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6225,9 +5863,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_ball_speed",
 					Num:        87,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -6241,9 +5878,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_ball_speed",
 					Num:        88,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -6257,9 +5893,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_vertical_oscillation",
 					Num:        89,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -6273,9 +5908,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_stance_time_percent",
 					Num:        90,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -6289,9 +5923,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_stance_time",
 					Num:        91,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -6305,9 +5938,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_fractional_cadence",
 					Num:        92,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -6321,9 +5953,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_fractional_cadence",
 					Num:        93,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -6337,9 +5968,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_fractional_cycles",
 					Num:        94,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -6353,9 +5983,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_total_hemoglobin_conc",
 					Num:        95,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -6369,9 +5998,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "min_total_hemoglobin_conc",
 					Num:        96,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -6385,9 +6013,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_total_hemoglobin_conc",
 					Num:        97,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -6401,9 +6028,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_saturated_hemoglobin_percent",
 					Num:        98,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -6417,9 +6043,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "min_saturated_hemoglobin_percent",
 					Num:        99,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -6433,9 +6058,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_saturated_hemoglobin_percent",
 					Num:        100,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -6449,9 +6073,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_torque_effectiveness",
 					Num:        101,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -6465,9 +6088,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_torque_effectiveness",
 					Num:        102,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -6481,9 +6103,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_pedal_smoothness",
 					Num:        103,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -6497,9 +6118,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_pedal_smoothness",
 					Num:        104,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -6513,9 +6133,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_combined_pedal_smoothness",
 					Num:        105,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -6529,9 +6148,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport_profile_name",
 					Num:        110,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6545,9 +6163,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport_index",
 					Num:        111,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6561,9 +6178,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_standing",
 					Num:        112,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -6577,9 +6193,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stand_count",
 					Num:        113,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6593,9 +6208,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_pco",
 					Num:        114,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6609,9 +6223,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_pco",
 					Num:        115,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6625,9 +6238,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_power_phase",
 					Num:        116,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -6641,9 +6253,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_power_phase_peak",
 					Num:        117,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -6657,9 +6268,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_power_phase",
 					Num:        118,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -6673,9 +6283,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_power_phase_peak",
 					Num:        119,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -6689,9 +6298,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_power_position",
 					Num:        120,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6705,9 +6313,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_power_position",
 					Num:        121,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6721,9 +6328,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_cadence_position",
 					Num:        122,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6737,9 +6343,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_cadence_position",
 					Num:        123,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6753,9 +6358,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_avg_speed",
 					Num:        124,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -6769,9 +6373,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_max_speed",
 					Num:        125,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -6785,9 +6388,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_avg_altitude",
 					Num:        126,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -6801,9 +6403,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_min_altitude",
 					Num:        127,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -6817,9 +6418,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_max_altitude",
 					Num:        128,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -6833,9 +6433,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_lev_motor_power",
 					Num:        129,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6849,9 +6448,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_lev_motor_power",
 					Num:        130,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -6865,9 +6463,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "lev_battery_consumption",
 					Num:        131,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -6881,9 +6478,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_vertical_ratio",
 					Num:        132,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -6897,9 +6493,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_stance_time_balance",
 					Num:        133,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -6913,9 +6508,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_step_length",
 					Num:        134,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -6929,9 +6523,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_anaerobic_training_effect",
 					Num:        137,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -6945,9 +6538,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_vam",
 					Num:        139,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -6961,9 +6553,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_depth",
 					Num:        140,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -6977,9 +6568,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_depth",
 					Num:        141,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -6993,9 +6583,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "surface_interval",
 					Num:        142,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7009,9 +6598,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_cns",
 					Num:        143,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7025,9 +6613,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_cns",
 					Num:        144,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7041,9 +6628,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_n2",
 					Num:        145,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7057,9 +6643,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_n2",
 					Num:        146,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7073,9 +6658,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "avg_respiration_rate",
 					Num:   147,
-					Type:  profile.Uint8, /* basetype.Uint8 */
+					Type:  profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 169 /* enhanced_avg_respiration_rate */, Scale: 1, Offset: 0, Accumulate: false, Bits: 8},
 					},
@@ -7091,9 +6675,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "max_respiration_rate",
 					Num:   148,
-					Type:  profile.Uint8, /* basetype.Uint8 */
+					Type:  profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 170 /* enhanced_max_respiration_rate */, Scale: 1, Offset: 0, Accumulate: false, Bits: 8},
 					},
@@ -7109,9 +6692,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "min_respiration_rate",
 					Num:   149,
-					Type:  profile.Uint8, /* basetype.Uint8 */
+					Type:  profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 180 /* enhanced_min_respiration_rate */, Scale: 1, Offset: 0, Accumulate: false, Bits: 8},
 					},
@@ -7127,9 +6709,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "min_temperature",
 					Num:        150,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7143,9 +6724,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "o2_toxicity",
 					Num:        155,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7159,9 +6739,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "dive_number",
 					Num:        156,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7175,9 +6754,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "training_load_peak",
 					Num:        168,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      65536,
 					Offset:     0,
@@ -7191,9 +6769,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_avg_respiration_rate",
 					Num:        169,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -7207,9 +6784,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_max_respiration_rate",
 					Num:        170,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -7223,9 +6799,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_min_respiration_rate",
 					Num:        180,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -7239,9 +6814,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_grit",
 					Num:        181,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7255,9 +6829,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_flow",
 					Num:        182,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7271,9 +6844,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "jump_count",
 					Num:        183,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7287,9 +6859,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_grit",
 					Num:        186,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7303,9 +6874,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_flow",
 					Num:        187,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7319,9 +6889,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_spo2",
 					Num:        194,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7335,9 +6904,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_stress",
 					Num:        195,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7351,9 +6919,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sdrr_hrv",
 					Num:        197,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7367,9 +6934,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "rmssd_hrv",
 					Num:        198,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7383,9 +6949,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_fractional_ascent",
 					Num:        199,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -7399,9 +6964,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_fractional_descent",
 					Num:        200,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -7415,9 +6979,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_core_temperature",
 					Num:        208,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -7431,9 +6994,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "min_core_temperature",
 					Num:        209,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -7447,9 +7009,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_core_temperature",
 					Num:        210,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -7468,9 +7029,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7484,9 +7044,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7500,9 +7059,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event",
 					Num:        0,
-					Type:       profile.Event, /* basetype.Enum */
+					Type:       profile.Event, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7516,9 +7074,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_type",
 					Num:        1,
-					Type:       profile.EventType, /* basetype.Enum */
+					Type:       profile.EventType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7532,9 +7089,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_time",
 					Num:        2,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7548,9 +7104,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_position_lat",
 					Num:        3,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7564,9 +7119,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_position_long",
 					Num:        4,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7580,9 +7134,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_position_lat",
 					Num:        5,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7596,9 +7149,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_position_long",
 					Num:        6,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7612,9 +7164,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_elapsed_time",
 					Num:        7,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -7628,9 +7179,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_timer_time",
 					Num:        8,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -7644,9 +7194,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_distance",
 					Num:        9,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -7660,9 +7209,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_cycles",
 					Num:        10,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7693,9 +7241,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_calories",
 					Num:        11,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7709,9 +7256,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_fat_calories",
 					Num:        12,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7725,9 +7271,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "avg_speed",
 					Num:   13,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 110 /* enhanced_avg_speed */, Scale: 1000, Offset: 0, Accumulate: false, Bits: 16},
 					},
@@ -7743,9 +7288,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "max_speed",
 					Num:   14,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 111 /* enhanced_max_speed */, Scale: 1000, Offset: 0, Accumulate: false, Bits: 16},
 					},
@@ -7761,9 +7305,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_heart_rate",
 					Num:        15,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7777,9 +7320,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_heart_rate",
 					Num:        16,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7793,9 +7335,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_cadence",
 					Num:        17,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7816,9 +7357,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_cadence",
 					Num:        18,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7839,9 +7379,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_power",
 					Num:        19,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7855,9 +7394,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_power",
 					Num:        20,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7871,9 +7409,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_ascent",
 					Num:        21,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7887,9 +7424,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_descent",
 					Num:        22,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7903,9 +7439,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "intensity",
 					Num:        23,
-					Type:       profile.Intensity, /* basetype.Enum */
+					Type:       profile.Intensity, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7919,9 +7454,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "lap_trigger",
 					Num:        24,
-					Type:       profile.LapTrigger, /* basetype.Enum */
+					Type:       profile.LapTrigger, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7935,9 +7469,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport",
 					Num:        25,
-					Type:       profile.Sport, /* basetype.Enum */
+					Type:       profile.Sport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7951,9 +7484,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_group",
 					Num:        26,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7967,9 +7499,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "num_lengths",
 					Num:        32,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7983,9 +7514,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "normalized_power",
 					Num:        33,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -7999,9 +7529,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "left_right_balance",
 					Num:        34,
-					Type:       profile.LeftRightBalance100, /* basetype.Uint16 */
+					Type:       profile.LeftRightBalance100, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8015,9 +7544,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "first_length_index",
 					Num:        35,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8031,9 +7559,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_stroke_distance",
 					Num:        37,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -8047,9 +7574,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "swim_stroke",
 					Num:        38,
-					Type:       profile.SwimStroke, /* basetype.Enum */
+					Type:       profile.SwimStroke, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8063,9 +7589,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sub_sport",
 					Num:        39,
-					Type:       profile.SubSport, /* basetype.Enum */
+					Type:       profile.SubSport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8079,9 +7604,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "num_active_lengths",
 					Num:        40,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8095,9 +7619,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_work",
 					Num:        41,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8111,9 +7634,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "avg_altitude",
 					Num:   42,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 112 /* enhanced_avg_altitude */, Scale: 5, Offset: 500, Accumulate: false, Bits: 16},
 					},
@@ -8129,9 +7651,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "max_altitude",
 					Num:   43,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 114 /* enhanced_max_altitude */, Scale: 5, Offset: 500, Accumulate: false, Bits: 16},
 					},
@@ -8147,9 +7668,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gps_accuracy",
 					Num:        44,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8163,9 +7683,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_grade",
 					Num:        45,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -8179,9 +7698,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_pos_grade",
 					Num:        46,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -8195,9 +7713,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_neg_grade",
 					Num:        47,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -8211,9 +7728,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_pos_grade",
 					Num:        48,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -8227,9 +7743,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_neg_grade",
 					Num:        49,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -8243,9 +7758,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_temperature",
 					Num:        50,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8259,9 +7773,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_temperature",
 					Num:        51,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8275,9 +7788,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_moving_time",
 					Num:        52,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -8291,9 +7803,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_pos_vertical_speed",
 					Num:        53,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -8307,9 +7818,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_neg_vertical_speed",
 					Num:        54,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -8323,9 +7833,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_pos_vertical_speed",
 					Num:        55,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -8339,9 +7848,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_neg_vertical_speed",
 					Num:        56,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -8355,9 +7863,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_hr_zone",
 					Num:        57,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -8371,9 +7878,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_speed_zone",
 					Num:        58,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -8387,9 +7893,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_cadence_zone",
 					Num:        59,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -8403,9 +7908,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_power_zone",
 					Num:        60,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -8419,9 +7923,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "repetition_num",
 					Num:        61,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8435,9 +7938,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "min_altitude",
 					Num:   62,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 113 /* enhanced_min_altitude */, Scale: 5, Offset: 500, Accumulate: false, Bits: 16},
 					},
@@ -8453,9 +7955,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "min_heart_rate",
 					Num:        63,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8469,9 +7970,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "wkt_step_index",
 					Num:        71,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8485,9 +7985,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "opponent_score",
 					Num:        74,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8501,9 +8000,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stroke_count",
 					Num:        75,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8517,9 +8015,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "zone_count",
 					Num:        76,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8533,9 +8030,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_vertical_oscillation",
 					Num:        77,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -8549,9 +8045,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_stance_time_percent",
 					Num:        78,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -8565,9 +8060,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_stance_time",
 					Num:        79,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -8581,9 +8075,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_fractional_cadence",
 					Num:        80,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -8597,9 +8090,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_fractional_cadence",
 					Num:        81,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -8613,9 +8105,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_fractional_cycles",
 					Num:        82,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -8629,9 +8120,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "player_score",
 					Num:        83,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8645,9 +8135,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_total_hemoglobin_conc",
 					Num:        84,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -8661,9 +8150,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "min_total_hemoglobin_conc",
 					Num:        85,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -8677,9 +8165,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_total_hemoglobin_conc",
 					Num:        86,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -8693,9 +8180,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_saturated_hemoglobin_percent",
 					Num:        87,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -8709,9 +8195,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "min_saturated_hemoglobin_percent",
 					Num:        88,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -8725,9 +8210,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_saturated_hemoglobin_percent",
 					Num:        89,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -8741,9 +8225,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_torque_effectiveness",
 					Num:        91,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -8757,9 +8240,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_torque_effectiveness",
 					Num:        92,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -8773,9 +8255,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_pedal_smoothness",
 					Num:        93,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -8789,9 +8270,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_pedal_smoothness",
 					Num:        94,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -8805,9 +8285,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_combined_pedal_smoothness",
 					Num:        95,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -8821,9 +8300,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_standing",
 					Num:        98,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -8837,9 +8315,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stand_count",
 					Num:        99,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8853,9 +8330,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_pco",
 					Num:        100,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8869,9 +8345,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_pco",
 					Num:        101,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8885,9 +8360,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_power_phase",
 					Num:        102,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -8901,9 +8375,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_power_phase_peak",
 					Num:        103,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -8917,9 +8390,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_power_phase",
 					Num:        104,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -8933,9 +8405,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_power_phase_peak",
 					Num:        105,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -8949,9 +8420,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_power_position",
 					Num:        106,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8965,9 +8435,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_power_position",
 					Num:        107,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8981,9 +8450,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_cadence_position",
 					Num:        108,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -8997,9 +8465,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_cadence_position",
 					Num:        109,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9013,9 +8480,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_avg_speed",
 					Num:        110,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -9029,9 +8495,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_max_speed",
 					Num:        111,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -9045,9 +8510,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_avg_altitude",
 					Num:        112,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -9061,9 +8525,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_min_altitude",
 					Num:        113,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -9077,9 +8540,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_max_altitude",
 					Num:        114,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -9093,9 +8555,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_lev_motor_power",
 					Num:        115,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9109,9 +8570,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_lev_motor_power",
 					Num:        116,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9125,9 +8585,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "lev_battery_consumption",
 					Num:        117,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -9141,9 +8600,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_vertical_ratio",
 					Num:        118,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -9157,9 +8615,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_stance_time_balance",
 					Num:        119,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -9173,9 +8630,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_step_length",
 					Num:        120,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -9189,9 +8645,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_vam",
 					Num:        121,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -9205,9 +8660,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_depth",
 					Num:        122,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -9221,9 +8675,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_depth",
 					Num:        123,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -9237,9 +8690,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "min_temperature",
 					Num:        124,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9253,9 +8705,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_avg_respiration_rate",
 					Num:        136,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -9269,9 +8720,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_max_respiration_rate",
 					Num:        137,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -9285,9 +8735,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "avg_respiration_rate",
 					Num:   147,
-					Type:  profile.Uint8, /* basetype.Uint8 */
+					Type:  profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 136 /* enhanced_avg_respiration_rate */, Scale: 1, Offset: 0, Accumulate: false, Bits: 8},
 					},
@@ -9303,9 +8752,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "max_respiration_rate",
 					Num:   148,
-					Type:  profile.Uint8, /* basetype.Uint8 */
+					Type:  profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 137 /* enhanced_max_respiration_rate */, Scale: 1, Offset: 0, Accumulate: false, Bits: 8},
 					},
@@ -9321,9 +8769,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_grit",
 					Num:        149,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9337,9 +8784,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_flow",
 					Num:        150,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9353,9 +8799,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "jump_count",
 					Num:        151,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9369,9 +8814,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_grit",
 					Num:        153,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9385,9 +8829,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_flow",
 					Num:        154,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9401,9 +8844,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_fractional_ascent",
 					Num:        156,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -9417,9 +8859,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_fractional_descent",
 					Num:        157,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -9433,9 +8874,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_core_temperature",
 					Num:        158,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -9449,9 +8889,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "min_core_temperature",
 					Num:        159,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -9465,9 +8904,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_core_temperature",
 					Num:        160,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -9486,9 +8924,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9502,9 +8939,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9518,9 +8954,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event",
 					Num:        0,
-					Type:       profile.Event, /* basetype.Enum */
+					Type:       profile.Event, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9534,9 +8969,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_type",
 					Num:        1,
-					Type:       profile.EventType, /* basetype.Enum */
+					Type:       profile.EventType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9550,9 +8984,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_time",
 					Num:        2,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9566,9 +8999,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_elapsed_time",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -9582,9 +9014,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_timer_time",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -9598,9 +9029,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_strokes",
 					Num:        5,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9614,9 +9044,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_speed",
 					Num:        6,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -9630,9 +9059,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "swim_stroke",
 					Num:        7,
-					Type:       profile.SwimStroke, /* basetype.Enum */
+					Type:       profile.SwimStroke, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9646,9 +9074,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_swimming_cadence",
 					Num:        9,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9662,9 +9089,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_group",
 					Num:        10,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9678,9 +9104,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_calories",
 					Num:        11,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9694,9 +9119,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "length_type",
 					Num:        12,
-					Type:       profile.LengthType, /* basetype.Enum */
+					Type:       profile.LengthType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9710,9 +9134,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "player_score",
 					Num:        18,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9726,9 +9149,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "opponent_score",
 					Num:        19,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9742,9 +9164,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stroke_count",
 					Num:        20,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9758,9 +9179,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "zone_count",
 					Num:        21,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9774,9 +9194,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_avg_respiration_rate",
 					Num:        22,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -9790,9 +9209,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_max_respiration_rate",
 					Num:        23,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -9806,9 +9224,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "avg_respiration_rate",
 					Num:   24,
-					Type:  profile.Uint8, /* basetype.Uint8 */
+					Type:  profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 22 /* enhanced_avg_respiration_rate */, Scale: 1, Offset: 0, Accumulate: false, Bits: 8},
 					},
@@ -9824,9 +9241,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "max_respiration_rate",
 					Num:   25,
-					Type:  profile.Uint8, /* basetype.Uint8 */
+					Type:  profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 23 /* enhanced_max_respiration_rate */, Scale: 1, Offset: 0, Accumulate: false, Bits: 8},
 					},
@@ -9847,9 +9263,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9863,9 +9278,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_lat",
 					Num:        0,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9879,9 +9293,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_long",
 					Num:        1,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9895,9 +9308,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "altitude",
 					Num:   2,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 78 /* enhanced_altitude */, Scale: 5, Offset: 500, Accumulate: false, Bits: 16},
 					},
@@ -9913,9 +9325,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "heart_rate",
 					Num:        3,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9929,9 +9340,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cadence",
 					Num:        4,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9945,9 +9355,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "distance",
 					Num:        5,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -9961,9 +9370,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "speed",
 					Num:   6,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 73 /* enhanced_speed */, Scale: 1000, Offset: 0, Accumulate: false, Bits: 16},
 					},
@@ -9979,9 +9387,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "power",
 					Num:        7,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -9995,9 +9402,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "compressed_speed_distance",
 					Num:   8,
-					Type:  profile.Byte, /* basetype.Byte */
+					Type:  profile.Byte, /* basetype.Byte (size: 1) */
 					Array: true,         /* Array Size [3] */
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 6 /* speed */, Scale: 100, Offset: 0, Accumulate: false, Bits: 12},
 						{FieldNum: 5 /* distance */, Scale: 16, Offset: 0, Accumulate: true, Bits: 12},
@@ -10014,9 +9420,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "grade",
 					Num:        9,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -10030,9 +9435,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "resistance",
 					Num:        10,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10046,9 +9450,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_from_course",
 					Num:        11,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -10062,9 +9465,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cycle_length",
 					Num:        12,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -10078,9 +9480,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "temperature",
 					Num:        13,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10094,9 +9495,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "speed_1s",
 					Num:        17,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      16,
 					Offset:     0,
@@ -10110,9 +9510,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "cycles",
 					Num:   18,
-					Type:  profile.Uint8, /* basetype.Uint8 */
+					Type:  profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 19 /* total_cycles */, Scale: 1, Offset: 0, Accumulate: true, Bits: 8},
 					},
@@ -10128,9 +9527,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_cycles",
 					Num:        19,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10144,9 +9542,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "compressed_accumulated_power",
 					Num:   28,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 29 /* accumulated_power */, Scale: 1, Offset: 0, Accumulate: true, Bits: 16},
 					},
@@ -10162,9 +9559,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "accumulated_power",
 					Num:        29,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10178,9 +9574,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "left_right_balance",
 					Num:        30,
-					Type:       profile.LeftRightBalance, /* basetype.Uint8 */
+					Type:       profile.LeftRightBalance, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10194,9 +9589,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gps_accuracy",
 					Num:        31,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10210,9 +9604,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "vertical_speed",
 					Num:        32,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -10226,9 +9619,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calories",
 					Num:        33,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10242,9 +9634,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "vertical_oscillation",
 					Num:        39,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -10258,9 +9649,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stance_time_percent",
 					Num:        40,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -10274,9 +9664,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stance_time",
 					Num:        41,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -10290,9 +9679,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "activity_type",
 					Num:        42,
-					Type:       profile.ActivityType, /* basetype.Enum */
+					Type:       profile.ActivityType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10306,9 +9694,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "left_torque_effectiveness",
 					Num:        43,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -10322,9 +9709,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "right_torque_effectiveness",
 					Num:        44,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -10338,9 +9724,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "left_pedal_smoothness",
 					Num:        45,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -10354,9 +9739,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "right_pedal_smoothness",
 					Num:        46,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -10370,9 +9754,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "combined_pedal_smoothness",
 					Num:        47,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -10386,9 +9769,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time128",
 					Num:        48,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -10402,9 +9784,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stroke_type",
 					Num:        49,
-					Type:       profile.StrokeType, /* basetype.Enum */
+					Type:       profile.StrokeType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10418,9 +9799,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "zone",
 					Num:        50,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10434,9 +9814,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ball_speed",
 					Num:        51,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -10450,9 +9829,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cadence256",
 					Num:        52,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      256,
 					Offset:     0,
@@ -10466,9 +9844,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "fractional_cadence",
 					Num:        53,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -10482,9 +9859,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_hemoglobin_conc",
 					Num:        54,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -10498,9 +9874,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_hemoglobin_conc_min",
 					Num:        55,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -10514,9 +9889,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_hemoglobin_conc_max",
 					Num:        56,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -10530,9 +9904,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "saturated_hemoglobin_percent",
 					Num:        57,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -10546,9 +9919,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "saturated_hemoglobin_percent_min",
 					Num:        58,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -10562,9 +9934,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "saturated_hemoglobin_percent_max",
 					Num:        59,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -10578,9 +9949,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "device_index",
 					Num:        62,
-					Type:       profile.DeviceIndex, /* basetype.Uint8 */
+					Type:       profile.DeviceIndex, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10594,9 +9964,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "left_pco",
 					Num:        67,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10610,9 +9979,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "right_pco",
 					Num:        68,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10626,9 +9994,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "left_power_phase",
 					Num:        69,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -10642,9 +10009,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "left_power_phase_peak",
 					Num:        70,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -10658,9 +10024,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "right_power_phase",
 					Num:        71,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -10674,9 +10039,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "right_power_phase_peak",
 					Num:        72,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -10690,9 +10054,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_speed",
 					Num:        73,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -10706,9 +10069,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_altitude",
 					Num:        78,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -10722,9 +10084,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "battery_soc",
 					Num:        81,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -10738,9 +10099,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "motor_power",
 					Num:        82,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10754,9 +10114,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "vertical_ratio",
 					Num:        83,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -10770,9 +10129,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stance_time_balance",
 					Num:        84,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -10786,9 +10144,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "step_length",
 					Num:        85,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -10802,9 +10159,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cycle_length16",
 					Num:        87,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -10818,9 +10174,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "absolute_pressure",
 					Num:        91,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10834,9 +10189,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "depth",
 					Num:        92,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -10850,9 +10204,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "next_stop_depth",
 					Num:        93,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -10866,9 +10219,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "next_stop_time",
 					Num:        94,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10882,9 +10234,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_to_surface",
 					Num:        95,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10898,9 +10249,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ndl_time",
 					Num:        96,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10914,9 +10264,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cns_load",
 					Num:        97,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10930,9 +10279,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "n2_load",
 					Num:        98,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10946,9 +10294,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "respiration_rate",
 					Num:   99,
-					Type:  profile.Uint8, /* basetype.Uint8 */
+					Type:  profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 108 /* enhanced_respiration_rate */, Scale: 1, Offset: 0, Accumulate: false, Bits: 8},
 					},
@@ -10964,9 +10311,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_respiration_rate",
 					Num:        108,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -10980,9 +10326,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "grit",
 					Num:        114,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -10996,9 +10341,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "flow",
 					Num:        115,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11012,9 +10356,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "current_stress",
 					Num:        116,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -11028,9 +10371,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ebike_travel_range",
 					Num:        117,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11044,9 +10386,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ebike_battery_level",
 					Num:        118,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11060,9 +10401,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ebike_assist_mode",
 					Num:        119,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11076,9 +10416,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ebike_assist_level_percent",
 					Num:        120,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11092,9 +10431,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "air_time_remaining",
 					Num:        123,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11108,9 +10446,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pressure_sac",
 					Num:        124,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -11124,9 +10461,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "volume_sac",
 					Num:        125,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -11140,9 +10476,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "rmv",
 					Num:        126,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -11156,9 +10491,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ascent_rate",
 					Num:        127,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -11172,9 +10506,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "po2",
 					Num:        129,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -11188,9 +10521,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "core_temperature",
 					Num:        139,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -11209,9 +10541,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11225,9 +10556,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event",
 					Num:        0,
-					Type:       profile.Event, /* basetype.Enum */
+					Type:       profile.Event, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11241,9 +10571,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_type",
 					Num:        1,
-					Type:       profile.EventType, /* basetype.Enum */
+					Type:       profile.EventType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11257,9 +10586,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "data16",
 					Num:   2,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 3 /* data */, Scale: 1, Offset: 0, Accumulate: false, Bits: 16},
 					},
@@ -11275,9 +10603,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "data",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11444,9 +10771,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_group",
 					Num:        4,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11460,9 +10786,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "score",
 					Num:        7,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11476,9 +10801,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "opponent_score",
 					Num:        8,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11492,9 +10816,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "front_gear_num",
 					Num:        9,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11508,9 +10831,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "front_gear",
 					Num:        10,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11524,9 +10846,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "rear_gear_num",
 					Num:        11,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11540,9 +10861,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "rear_gear",
 					Num:        12,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11556,9 +10876,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "device_index",
 					Num:        13,
-					Type:       profile.DeviceIndex, /* basetype.Uint8 */
+					Type:       profile.DeviceIndex, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11572,9 +10891,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "activity_type",
 					Num:        14,
-					Type:       profile.ActivityType, /* basetype.Enum */
+					Type:       profile.ActivityType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11588,9 +10906,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_timestamp",
 					Num:        15,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11611,9 +10928,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "radar_threat_level_max",
 					Num:        21,
-					Type:       profile.RadarThreatLevelType, /* basetype.Enum */
+					Type:       profile.RadarThreatLevelType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11627,9 +10943,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "radar_threat_count",
 					Num:        22,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11643,9 +10958,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "radar_threat_avg_approach_speed",
 					Num:        23,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -11659,9 +10973,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "radar_threat_max_approach_speed",
 					Num:        24,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -11680,9 +10993,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11696,9 +11008,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "device_index",
 					Num:        0,
-					Type:       profile.DeviceIndex, /* basetype.Uint8 */
+					Type:       profile.DeviceIndex, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11712,9 +11023,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "device_type",
 					Num:        1,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11753,9 +11063,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "manufacturer",
 					Num:        2,
-					Type:       profile.Manufacturer, /* basetype.Uint16 */
+					Type:       profile.Manufacturer, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11769,9 +11078,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "serial_number",
 					Num:        3,
-					Type:       profile.Uint32z, /* basetype.Uint32z */
+					Type:       profile.Uint32z, /* basetype.Uint32z (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11785,9 +11093,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "product",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11817,9 +11124,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "software_version",
 					Num:        5,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -11833,9 +11139,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "hardware_version",
 					Num:        6,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11849,9 +11154,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cum_operating_time",
 					Num:        7,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11865,9 +11169,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "battery_voltage",
 					Num:        10,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      256,
 					Offset:     0,
@@ -11881,9 +11184,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "battery_status",
 					Num:        11,
-					Type:       profile.BatteryStatus, /* basetype.Uint8 */
+					Type:       profile.BatteryStatus, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11897,9 +11199,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sensor_position",
 					Num:        18,
-					Type:       profile.BodyLocation, /* basetype.Enum */
+					Type:       profile.BodyLocation, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11913,9 +11214,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "descriptor",
 					Num:        19,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11929,9 +11229,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ant_transmission_type",
 					Num:        20,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11945,9 +11244,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ant_device_number",
 					Num:        21,
-					Type:       profile.Uint16z, /* basetype.Uint16z */
+					Type:       profile.Uint16z, /* basetype.Uint16z (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11961,9 +11259,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ant_network",
 					Num:        22,
-					Type:       profile.AntNetwork, /* basetype.Enum */
+					Type:       profile.AntNetwork, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11977,9 +11274,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "source_type",
 					Num:        25,
-					Type:       profile.SourceType, /* basetype.Enum */
+					Type:       profile.SourceType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -11993,9 +11289,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "product_name",
 					Num:        27,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12009,9 +11304,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "battery_level",
 					Num:        32,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12030,9 +11324,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12046,9 +11339,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "device_index",
 					Num:        0,
-					Type:       profile.DeviceIndex, /* basetype.Uint8 */
+					Type:       profile.DeviceIndex, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12062,9 +11354,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "battery_voltage",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      256,
 					Offset:     0,
@@ -12078,9 +11369,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "battery_status",
 					Num:        2,
-					Type:       profile.BatteryStatus, /* basetype.Uint8 */
+					Type:       profile.BatteryStatus, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12094,9 +11384,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "battery_identifier",
 					Num:        3,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12115,9 +11404,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12131,9 +11419,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "type",
 					Num:        0,
-					Type:       profile.File, /* basetype.Enum */
+					Type:       profile.File, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12147,9 +11434,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "manufacturer",
 					Num:        1,
-					Type:       profile.Manufacturer, /* basetype.Uint16 */
+					Type:       profile.Manufacturer, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12163,9 +11449,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "product",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12195,9 +11480,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "serial_number",
 					Num:        3,
-					Type:       profile.Uint32z, /* basetype.Uint32z */
+					Type:       profile.Uint32z, /* basetype.Uint32z (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12211,9 +11495,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_created",
 					Num:        4,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12232,9 +11515,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12248,9 +11530,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "weather_report",
 					Num:        0,
-					Type:       profile.WeatherReport, /* basetype.Enum */
+					Type:       profile.WeatherReport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12264,9 +11545,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "temperature",
 					Num:        1,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12280,9 +11560,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "condition",
 					Num:        2,
-					Type:       profile.WeatherStatus, /* basetype.Enum */
+					Type:       profile.WeatherStatus, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12296,9 +11575,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "wind_direction",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12312,9 +11590,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "wind_speed",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -12328,9 +11605,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "precipitation_probability",
 					Num:        5,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12344,9 +11620,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "temperature_feels_like",
 					Num:        6,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12360,9 +11635,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "relative_humidity",
 					Num:        7,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12376,9 +11650,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "location",
 					Num:        8,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12392,9 +11665,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "observed_at_time",
 					Num:        9,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12408,9 +11680,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "observed_location_lat",
 					Num:        10,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12424,9 +11695,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "observed_location_long",
 					Num:        11,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12440,9 +11710,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "day_of_week",
 					Num:        12,
-					Type:       profile.DayOfWeek, /* basetype.Enum */
+					Type:       profile.DayOfWeek, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12456,9 +11725,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "high_temperature",
 					Num:        13,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12472,9 +11740,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "low_temperature",
 					Num:        14,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12493,9 +11760,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12509,9 +11775,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "report_id",
 					Num:        0,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12525,9 +11790,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "issue_time",
 					Num:        1,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12541,9 +11805,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "expire_time",
 					Num:        2,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12557,9 +11820,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "severity",
 					Num:        3,
-					Type:       profile.WeatherSeverity, /* basetype.Enum */
+					Type:       profile.WeatherSeverity, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12573,9 +11835,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "type",
 					Num:        4,
-					Type:       profile.WeatherSevereType, /* basetype.Enum */
+					Type:       profile.WeatherSevereType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12594,9 +11855,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12610,9 +11870,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_ms",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12626,9 +11885,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_lat",
 					Num:        1,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12642,9 +11900,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_long",
 					Num:        2,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12658,9 +11915,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_altitude",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -12674,9 +11930,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_speed",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -12690,9 +11945,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "heading",
 					Num:        5,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -12706,9 +11960,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "utc_timestamp",
 					Num:        6,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12722,9 +11975,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "velocity",
 					Num:        7,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      true,           /* Array Size [3] */
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -12743,9 +11995,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12759,9 +12010,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_ms",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12775,9 +12025,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "camera_event_type",
 					Num:        1,
-					Type:       profile.CameraEventType, /* basetype.Enum */
+					Type:       profile.CameraEventType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12791,9 +12040,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "camera_file_uuid",
 					Num:        2,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12807,9 +12055,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "camera_orientation",
 					Num:        3,
-					Type:       profile.CameraOrientationType, /* basetype.Enum */
+					Type:       profile.CameraOrientationType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12828,9 +12075,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12844,9 +12090,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_ms",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12860,9 +12105,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sample_time_offset",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12876,9 +12120,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gyro_x",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12892,9 +12135,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gyro_y",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12908,9 +12150,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gyro_z",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12924,9 +12165,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibrated_gyro_x",
 					Num:        5,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      true,            /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12940,9 +12180,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibrated_gyro_y",
 					Num:        6,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      true,            /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12956,9 +12195,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibrated_gyro_z",
 					Num:        7,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      true,            /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12977,9 +12215,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -12993,9 +12230,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_ms",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13009,9 +12245,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sample_time_offset",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13025,9 +12260,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "accel_x",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13041,9 +12275,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "accel_y",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13057,9 +12290,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "accel_z",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13073,9 +12305,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibrated_accel_x",
 					Num:        5,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      true,            /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13089,9 +12320,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibrated_accel_y",
 					Num:        6,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      true,            /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13105,9 +12335,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibrated_accel_z",
 					Num:        7,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      true,            /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13121,9 +12350,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "compressed_calibrated_accel_x",
 					Num:        8,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13137,9 +12365,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "compressed_calibrated_accel_y",
 					Num:        9,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13153,9 +12380,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "compressed_calibrated_accel_z",
 					Num:        10,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13174,9 +12400,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13190,9 +12415,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_ms",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13206,9 +12430,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sample_time_offset",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13222,9 +12445,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mag_x",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13238,9 +12460,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mag_y",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13254,9 +12475,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mag_z",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13270,9 +12490,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibrated_mag_x",
 					Num:        5,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      true,            /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13286,9 +12505,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibrated_mag_y",
 					Num:        6,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      true,            /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13302,9 +12520,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibrated_mag_z",
 					Num:        7,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      true,            /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13323,9 +12540,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13339,9 +12555,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_ms",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13355,9 +12570,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sample_time_offset",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13371,9 +12585,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "baro_pres",
 					Num:        2,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13392,9 +12605,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13408,9 +12620,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sensor_type",
 					Num:        0,
-					Type:       profile.SensorType, /* basetype.Enum */
+					Type:       profile.SensorType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13424,9 +12635,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibration_factor",
 					Num:        1,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13453,9 +12663,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibration_divisor",
 					Num:        2,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13469,9 +12678,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "level_shift",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13485,9 +12693,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "offset_cal",
 					Num:        4,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      true,           /* Array Size [3] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13501,9 +12708,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "orientation_matrix",
 					Num:        5,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      true,           /* Array Size [9] */
-					Size:       4,
 					Components: nil,
 					Scale:      65535,
 					Offset:     0,
@@ -13522,9 +12728,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13538,9 +12743,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sensor_type",
 					Num:        0,
-					Type:       profile.SensorType, /* basetype.Enum */
+					Type:       profile.SensorType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13554,9 +12758,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibration_factor",
 					Num:        1,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13577,9 +12780,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibration_divisor",
 					Num:        2,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13593,9 +12795,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "level_shift",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13609,9 +12810,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "offset_cal",
 					Num:        4,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13630,9 +12830,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13646,9 +12845,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_ms",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13662,9 +12860,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "frame_number",
 					Num:        1,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13683,9 +12880,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13699,9 +12895,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_ms",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13715,9 +12910,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_offset",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13731,9 +12925,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pid",
 					Num:        2,
-					Type:       profile.Byte, /* basetype.Byte */
+					Type:       profile.Byte, /* basetype.Byte (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13747,9 +12940,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "raw_data",
 					Num:        3,
-					Type:       profile.Byte, /* basetype.Byte */
+					Type:       profile.Byte, /* basetype.Byte (size: 1) */
 					Array:      true,         /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13763,9 +12955,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pid_data_size",
 					Num:        4,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13779,9 +12970,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "system_time",
 					Num:        5,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13795,9 +12985,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_timestamp",
 					Num:        6,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13811,9 +13000,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_timestamp_ms",
 					Num:        7,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13832,9 +13020,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13848,9 +13035,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_ms",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13864,9 +13050,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sentence",
 					Num:        1,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13885,9 +13070,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13901,9 +13085,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_ms",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13917,9 +13100,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "system_time",
 					Num:        1,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -13933,9 +13115,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pitch",
 					Num:        2,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      10430.38,
 					Offset:     0,
@@ -13949,9 +13130,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "roll",
 					Num:        3,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      10430.38,
 					Offset:     0,
@@ -13965,9 +13145,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "accel_lateral",
 					Num:        4,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -13981,9 +13160,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "accel_normal",
 					Num:        5,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -13997,9 +13175,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "turn_rate",
 					Num:        6,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1024,
 					Offset:     0,
@@ -14013,9 +13190,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stage",
 					Num:        7,
-					Type:       profile.AttitudeStage, /* basetype.Enum */
+					Type:       profile.AttitudeStage, /* basetype.Enum (size: 1) */
 					Array:      true,                  /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14029,9 +13205,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "attitude_stage_complete",
 					Num:        8,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14045,9 +13220,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "track",
 					Num:        9,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      10430.38,
 					Offset:     0,
@@ -14061,9 +13235,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "validity",
 					Num:        10,
-					Type:       profile.AttitudeValidity, /* basetype.Uint16 */
+					Type:       profile.AttitudeValidity, /* basetype.Uint16 (size: 2) */
 					Array:      true,                     /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14082,9 +13255,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "url",
 					Num:        0,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14098,9 +13270,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "hosting_provider",
 					Num:        1,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14114,9 +13285,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "duration",
 					Num:        2,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14135,9 +13305,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14151,9 +13320,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_count",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14167,9 +13335,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "text",
 					Num:        1,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14188,9 +13355,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14204,9 +13370,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_count",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14220,9 +13385,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "text",
 					Num:        1,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14241,9 +13405,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "clip_number",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14257,9 +13420,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_timestamp",
 					Num:        1,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14273,9 +13435,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_timestamp_ms",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14289,9 +13450,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_timestamp",
 					Num:        3,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14305,9 +13465,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_timestamp_ms",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14321,9 +13480,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "clip_start",
 					Num:        6,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14337,9 +13495,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "clip_end",
 					Num:        7,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14358,9 +13515,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        254,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14374,9 +13530,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "duration",
 					Num:        0,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -14390,9 +13545,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "repetitions",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14406,9 +13560,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "weight",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      16,
 					Offset:     0,
@@ -14422,9 +13575,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "set_type",
 					Num:        5,
-					Type:       profile.SetType, /* basetype.Uint8 */
+					Type:       profile.SetType, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14438,9 +13590,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_time",
 					Num:        6,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14454,9 +13605,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "category",
 					Num:        7,
-					Type:       profile.ExerciseCategory, /* basetype.Uint16 */
+					Type:       profile.ExerciseCategory, /* basetype.Uint16 (size: 2) */
 					Array:      true,                     /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14470,9 +13620,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "category_subtype",
 					Num:        8,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14486,9 +13635,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "weight_display_unit",
 					Num:        9,
-					Type:       profile.FitBaseUnit, /* basetype.Uint16 */
+					Type:       profile.FitBaseUnit, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14502,9 +13650,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        10,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14518,9 +13665,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "wkt_step_index",
 					Num:        11,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14539,9 +13685,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14555,9 +13700,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "distance",
 					Num:        0,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14571,9 +13715,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "height",
 					Num:        1,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14587,9 +13730,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "rotations",
 					Num:        2,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14603,9 +13745,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "hang_time",
 					Num:        3,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14619,9 +13760,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "score",
 					Num:        4,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14635,9 +13775,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_lat",
 					Num:        5,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14651,9 +13790,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_long",
 					Num:        6,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14667,9 +13805,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "speed",
 					Num:   7,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 8 /* enhanced_speed */, Scale: 1000, Offset: 0, Accumulate: false, Bits: 16},
 					},
@@ -14685,9 +13822,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_speed",
 					Num:        8,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -14706,9 +13842,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14722,9 +13857,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "split_type",
 					Num:        0,
-					Type:       profile.SplitType, /* basetype.Enum */
+					Type:       profile.SplitType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14738,9 +13872,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_elapsed_time",
 					Num:        1,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -14754,9 +13887,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_timer_time",
 					Num:        2,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -14770,9 +13902,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_distance",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -14786,9 +13917,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_speed",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -14802,9 +13932,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_time",
 					Num:        9,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14818,9 +13947,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_ascent",
 					Num:        13,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14834,9 +13962,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_descent",
 					Num:        14,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14850,9 +13977,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_position_lat",
 					Num:        21,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14866,9 +13992,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_position_long",
 					Num:        22,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14882,9 +14007,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_position_lat",
 					Num:        23,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14898,9 +14022,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_position_long",
 					Num:        24,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14914,9 +14037,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_speed",
 					Num:        25,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -14930,9 +14052,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_vert_speed",
 					Num:        26,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -14946,9 +14067,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_time",
 					Num:        27,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14962,9 +14082,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_calories",
 					Num:        28,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -14978,9 +14097,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_elevation",
 					Num:        74,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -14994,9 +14112,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_moving_time",
 					Num:        110,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -15015,9 +14132,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15031,9 +14147,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "split_type",
 					Num:        0,
-					Type:       profile.SplitType, /* basetype.Enum */
+					Type:       profile.SplitType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15047,9 +14162,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "num_splits",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15063,9 +14177,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_timer_time",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -15079,9 +14192,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_distance",
 					Num:        5,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -15095,9 +14207,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_speed",
 					Num:        6,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -15111,9 +14222,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_speed",
 					Num:        7,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -15127,9 +14237,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_ascent",
 					Num:        8,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15143,9 +14252,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_descent",
 					Num:        9,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15159,9 +14267,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_heart_rate",
 					Num:        10,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15175,9 +14282,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_heart_rate",
 					Num:        11,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15191,9 +14297,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_vert_speed",
 					Num:        12,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -15207,9 +14312,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_calories",
 					Num:        13,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15223,9 +14327,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_moving_time",
 					Num:        77,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -15244,9 +14347,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15260,9 +14362,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_lat",
 					Num:        0,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15276,9 +14377,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_long",
 					Num:        1,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15292,9 +14392,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "climb_pro_event",
 					Num:        2,
-					Type:       profile.ClimbProEvent, /* basetype.Enum */
+					Type:       profile.ClimbProEvent, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15308,9 +14407,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "climb_number",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15324,9 +14422,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "climb_category",
 					Num:        4,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15340,9 +14437,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "current_dist",
 					Num:        5,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15361,9 +14457,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "developer_data_index",
 					Num:        0,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15377,9 +14472,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "field_definition_number",
 					Num:        1,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15393,9 +14487,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "fit_base_type_id",
 					Num:        2,
-					Type:       profile.FitBaseType, /* basetype.Uint8 */
+					Type:       profile.FitBaseType, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15409,9 +14502,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "field_name",
 					Num:        3,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      true,           /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15425,9 +14517,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "array",
 					Num:        4,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15441,9 +14532,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "components",
 					Num:        5,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15457,9 +14547,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "scale",
 					Num:        6,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15473,9 +14562,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "offset",
 					Num:        7,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15489,9 +14577,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "units",
 					Num:        8,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      true,           /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15505,9 +14592,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bits",
 					Num:        9,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15521,9 +14607,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "accumulate",
 					Num:        10,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15537,9 +14622,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "fit_base_unit_id",
 					Num:        13,
-					Type:       profile.FitBaseUnit, /* basetype.Uint16 */
+					Type:       profile.FitBaseUnit, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15553,9 +14637,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "native_mesg_num",
 					Num:        14,
-					Type:       profile.MesgNum, /* basetype.Uint16 */
+					Type:       profile.MesgNum, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15569,9 +14652,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "native_field_num",
 					Num:        15,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15590,9 +14672,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "developer_id",
 					Num:        0,
-					Type:       profile.Byte, /* basetype.Byte */
+					Type:       profile.Byte, /* basetype.Byte (size: 1) */
 					Array:      true,         /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15606,9 +14687,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "application_id",
 					Num:        1,
-					Type:       profile.Byte, /* basetype.Byte */
+					Type:       profile.Byte, /* basetype.Byte (size: 1) */
 					Array:      true,         /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15622,9 +14702,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "manufacturer_id",
 					Num:        2,
-					Type:       profile.Manufacturer, /* basetype.Uint16 */
+					Type:       profile.Manufacturer, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15638,9 +14717,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "developer_data_index",
 					Num:        3,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15654,9 +14732,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "application_version",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15675,9 +14752,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport",
 					Num:        4,
-					Type:       profile.Sport, /* basetype.Enum */
+					Type:       profile.Sport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15691,9 +14767,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        5,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15707,9 +14782,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "capabilities",
 					Num:        6,
-					Type:       profile.CourseCapabilities, /* basetype.Uint32z */
+					Type:       profile.CourseCapabilities, /* basetype.Uint32z (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15723,9 +14797,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sub_sport",
 					Num:        7,
-					Type:       profile.SubSport, /* basetype.Enum */
+					Type:       profile.SubSport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15744,9 +14817,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15760,9 +14832,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        1,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15776,9 +14847,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_lat",
 					Num:        2,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15792,9 +14862,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_long",
 					Num:        3,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15808,9 +14877,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "distance",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -15824,9 +14892,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "type",
 					Num:        5,
-					Type:       profile.CoursePoint, /* basetype.Enum */
+					Type:       profile.CoursePoint, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15840,9 +14907,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        6,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15856,9 +14922,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "favorite",
 					Num:        8,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15877,9 +14942,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        0,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15893,9 +14957,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "uuid",
 					Num:        1,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15909,9 +14972,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport",
 					Num:        2,
-					Type:       profile.Sport, /* basetype.Enum */
+					Type:       profile.Sport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15925,9 +14987,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        3,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15941,9 +15002,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "user_profile_primary_key",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15957,9 +15017,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "device_id",
 					Num:        5,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15973,9 +15032,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "default_race_leader",
 					Num:        6,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -15989,9 +15047,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "delete_status",
 					Num:        7,
-					Type:       profile.SegmentDeleteStatus, /* basetype.Enum */
+					Type:       profile.SegmentDeleteStatus, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16005,9 +15062,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "selection_type",
 					Num:        8,
-					Type:       profile.SegmentSelectionType, /* basetype.Enum */
+					Type:       profile.SegmentSelectionType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16026,9 +15082,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16042,9 +15097,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        0,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16058,9 +15112,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "type",
 					Num:        1,
-					Type:       profile.SegmentLeaderboardType, /* basetype.Enum */
+					Type:       profile.SegmentLeaderboardType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16074,9 +15127,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "group_primary_key",
 					Num:        2,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16090,9 +15142,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "activity_id",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16106,9 +15157,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "segment_time",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -16122,9 +15172,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "activity_id_string",
 					Num:        5,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16143,9 +15192,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16159,9 +15207,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_lat",
 					Num:        1,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16175,9 +15222,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "position_long",
 					Num:        2,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16191,9 +15237,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "distance",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -16207,9 +15252,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "altitude",
 					Num:   4,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 6 /* enhanced_altitude */, Scale: 5, Offset: 500, Accumulate: false, Bits: 16},
 					},
@@ -16225,9 +15269,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "leader_time",
 					Num:        5,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -16241,9 +15284,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_altitude",
 					Num:        6,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -16262,9 +15304,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16278,9 +15319,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16294,9 +15334,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event",
 					Num:        0,
-					Type:       profile.Event, /* basetype.Enum */
+					Type:       profile.Event, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16310,9 +15349,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_type",
 					Num:        1,
-					Type:       profile.EventType, /* basetype.Enum */
+					Type:       profile.EventType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16326,9 +15364,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_time",
 					Num:        2,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16342,9 +15379,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_position_lat",
 					Num:        3,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16358,9 +15394,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_position_long",
 					Num:        4,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16374,9 +15409,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_position_lat",
 					Num:        5,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16390,9 +15424,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_position_long",
 					Num:        6,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16406,9 +15439,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_elapsed_time",
 					Num:        7,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -16422,9 +15454,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_timer_time",
 					Num:        8,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -16438,9 +15469,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_distance",
 					Num:        9,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -16454,9 +15484,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_cycles",
 					Num:        10,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16477,9 +15506,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_calories",
 					Num:        11,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16493,9 +15521,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_fat_calories",
 					Num:        12,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16509,9 +15536,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_speed",
 					Num:        13,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -16525,9 +15551,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_speed",
 					Num:        14,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -16541,9 +15566,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_heart_rate",
 					Num:        15,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16557,9 +15581,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_heart_rate",
 					Num:        16,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16573,9 +15596,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_cadence",
 					Num:        17,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16589,9 +15611,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_cadence",
 					Num:        18,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16605,9 +15626,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_power",
 					Num:        19,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16621,9 +15641,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_power",
 					Num:        20,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16637,9 +15656,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_ascent",
 					Num:        21,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16653,9 +15671,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_descent",
 					Num:        22,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16669,9 +15686,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport",
 					Num:        23,
-					Type:       profile.Sport, /* basetype.Enum */
+					Type:       profile.Sport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16685,9 +15701,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_group",
 					Num:        24,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16701,9 +15716,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "nec_lat",
 					Num:        25,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16717,9 +15731,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "nec_long",
 					Num:        26,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16733,9 +15746,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "swc_lat",
 					Num:        27,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16749,9 +15761,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "swc_long",
 					Num:        28,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16765,9 +15776,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "name",
 					Num:        29,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16781,9 +15791,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "normalized_power",
 					Num:        30,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16797,9 +15806,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "left_right_balance",
 					Num:        31,
-					Type:       profile.LeftRightBalance100, /* basetype.Uint16 */
+					Type:       profile.LeftRightBalance100, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16813,9 +15821,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sub_sport",
 					Num:        32,
-					Type:       profile.SubSport, /* basetype.Enum */
+					Type:       profile.SubSport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16829,9 +15836,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_work",
 					Num:        33,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16845,9 +15851,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "avg_altitude",
 					Num:   34,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 91 /* enhanced_avg_altitude */, Scale: 5, Offset: 500, Accumulate: false, Bits: 16},
 					},
@@ -16863,9 +15868,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "max_altitude",
 					Num:   35,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 92 /* enhanced_max_altitude */, Scale: 5, Offset: 500, Accumulate: false, Bits: 16},
 					},
@@ -16881,9 +15885,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gps_accuracy",
 					Num:        36,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16897,9 +15900,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_grade",
 					Num:        37,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -16913,9 +15915,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_pos_grade",
 					Num:        38,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -16929,9 +15930,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_neg_grade",
 					Num:        39,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -16945,9 +15945,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_pos_grade",
 					Num:        40,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -16961,9 +15960,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_neg_grade",
 					Num:        41,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -16977,9 +15975,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_temperature",
 					Num:        42,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -16993,9 +15990,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_temperature",
 					Num:        43,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17009,9 +16005,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_moving_time",
 					Num:        44,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -17025,9 +16020,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_pos_vertical_speed",
 					Num:        45,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -17041,9 +16035,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_neg_vertical_speed",
 					Num:        46,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -17057,9 +16050,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_pos_vertical_speed",
 					Num:        47,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -17073,9 +16065,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_neg_vertical_speed",
 					Num:        48,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -17089,9 +16080,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_hr_zone",
 					Num:        49,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -17105,9 +16095,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_speed_zone",
 					Num:        50,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -17121,9 +16110,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_cadence_zone",
 					Num:        51,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -17137,9 +16125,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_in_power_zone",
 					Num:        52,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -17153,9 +16140,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "repetition_num",
 					Num:        53,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17169,9 +16155,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "min_altitude",
 					Num:   54,
-					Type:  profile.Uint16, /* basetype.Uint16 */
+					Type:  profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array: false,
-					Size:  2,
 					Components: []proto.Component{
 						{FieldNum: 93 /* enhanced_min_altitude */, Scale: 5, Offset: 500, Accumulate: false, Bits: 16},
 					},
@@ -17187,9 +16172,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "min_heart_rate",
 					Num:        55,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17203,9 +16187,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "active_time",
 					Num:        56,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -17219,9 +16202,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "wkt_step_index",
 					Num:        57,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17235,9 +16217,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport_event",
 					Num:        58,
-					Type:       profile.SportEvent, /* basetype.Enum */
+					Type:       profile.SportEvent, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17251,9 +16232,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_torque_effectiveness",
 					Num:        59,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -17267,9 +16247,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_torque_effectiveness",
 					Num:        60,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -17283,9 +16262,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_pedal_smoothness",
 					Num:        61,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -17299,9 +16277,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_pedal_smoothness",
 					Num:        62,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -17315,9 +16292,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_combined_pedal_smoothness",
 					Num:        63,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -17331,9 +16307,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "status",
 					Num:        64,
-					Type:       profile.SegmentLapStatus, /* basetype.Enum */
+					Type:       profile.SegmentLapStatus, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17347,9 +16322,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "uuid",
 					Num:        65,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17363,9 +16337,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_fractional_cadence",
 					Num:        66,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -17379,9 +16352,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_fractional_cadence",
 					Num:        67,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -17395,9 +16367,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_fractional_cycles",
 					Num:        68,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -17411,9 +16382,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "front_gear_shift_count",
 					Num:        69,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17427,9 +16397,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "rear_gear_shift_count",
 					Num:        70,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17443,9 +16412,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_standing",
 					Num:        71,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -17459,9 +16427,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stand_count",
 					Num:        72,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17475,9 +16442,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_pco",
 					Num:        73,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17491,9 +16457,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_pco",
 					Num:        74,
-					Type:       profile.Sint8, /* basetype.Sint8 */
+					Type:       profile.Sint8, /* basetype.Sint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17507,9 +16472,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_power_phase",
 					Num:        75,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -17523,9 +16487,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_left_power_phase_peak",
 					Num:        76,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -17539,9 +16502,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_power_phase",
 					Num:        77,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -17555,9 +16517,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_right_power_phase_peak",
 					Num:        78,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      0.7111111,
 					Offset:     0,
@@ -17571,9 +16532,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_power_position",
 					Num:        79,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17587,9 +16547,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_power_position",
 					Num:        80,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17603,9 +16562,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_cadence_position",
 					Num:        81,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17619,9 +16577,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_cadence_position",
 					Num:        82,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17635,9 +16592,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "manufacturer",
 					Num:        83,
-					Type:       profile.Manufacturer, /* basetype.Uint16 */
+					Type:       profile.Manufacturer, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17651,9 +16607,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_grit",
 					Num:        84,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17667,9 +16622,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_flow",
 					Num:        85,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17683,9 +16637,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_grit",
 					Num:        86,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17699,9 +16652,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_flow",
 					Num:        87,
-					Type:       profile.Float32, /* basetype.Float32 */
+					Type:       profile.Float32, /* basetype.Float32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17715,9 +16667,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_fractional_ascent",
 					Num:        89,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -17731,9 +16682,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "total_fractional_descent",
 					Num:        90,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -17747,9 +16697,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_avg_altitude",
 					Num:        91,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -17763,9 +16712,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_max_altitude",
 					Num:        92,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -17779,9 +16727,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enhanced_min_altitude",
 					Num:        93,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      5,
 					Offset:     500,
@@ -17800,9 +16747,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17816,9 +16762,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "file_uuid",
 					Num:        1,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17832,9 +16777,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        3,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17848,9 +16792,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "user_profile_primary_key",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17864,9 +16807,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "leader_type",
 					Num:        7,
-					Type:       profile.SegmentLeaderboardType, /* basetype.Enum */
+					Type:       profile.SegmentLeaderboardType, /* basetype.Enum (size: 1) */
 					Array:      true,                           /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17880,9 +16822,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "leader_group_primary_key",
 					Num:        8,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17896,9 +16837,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "leader_activity_id",
 					Num:        9,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17912,9 +16852,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "leader_activity_id_string",
 					Num:        10,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      true,           /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17928,9 +16867,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "default_race_leader",
 					Num:        11,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17949,9 +16887,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17965,9 +16902,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport",
 					Num:        4,
-					Type:       profile.Sport, /* basetype.Enum */
+					Type:       profile.Sport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17981,9 +16917,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "capabilities",
 					Num:        5,
-					Type:       profile.WorkoutCapabilities, /* basetype.Uint32z */
+					Type:       profile.WorkoutCapabilities, /* basetype.Uint32z (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -17997,9 +16932,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "num_valid_steps",
 					Num:        6,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18013,9 +16947,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "wkt_name",
 					Num:        8,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18029,9 +16962,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sub_sport",
 					Num:        11,
-					Type:       profile.SubSport, /* basetype.Enum */
+					Type:       profile.SubSport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18045,9 +16977,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pool_length",
 					Num:        14,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -18061,9 +16992,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pool_length_unit",
 					Num:        15,
-					Type:       profile.DisplayMeasure, /* basetype.Enum */
+					Type:       profile.DisplayMeasure, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18082,9 +17012,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18098,9 +17027,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport",
 					Num:        0,
-					Type:       profile.Sport, /* basetype.Enum */
+					Type:       profile.Sport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18114,9 +17042,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sub_sport",
 					Num:        1,
-					Type:       profile.SubSport, /* basetype.Enum */
+					Type:       profile.SubSport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18130,9 +17057,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "num_valid_steps",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18146,9 +17072,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "first_step_index",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18162,9 +17087,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pool_length",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -18178,9 +17102,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pool_length_unit",
 					Num:        5,
-					Type:       profile.DisplayMeasure, /* basetype.Enum */
+					Type:       profile.DisplayMeasure, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18199,9 +17122,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18215,9 +17137,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "wkt_step_name",
 					Num:        0,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18231,9 +17152,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "duration_type",
 					Num:        1,
-					Type:       profile.WktStepDuration, /* basetype.Enum */
+					Type:       profile.WktStepDuration, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18247,9 +17167,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "duration_value",
 					Num:        2,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18316,9 +17235,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "target_type",
 					Num:        3,
-					Type:       profile.WktStepTarget, /* basetype.Enum */
+					Type:       profile.WktStepTarget, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18332,9 +17250,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "target_value",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18417,9 +17334,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "custom_target_value_low",
 					Num:        5,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18458,9 +17374,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "custom_target_value_high",
 					Num:        6,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18499,9 +17414,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "intensity",
 					Num:        7,
-					Type:       profile.Intensity, /* basetype.Enum */
+					Type:       profile.Intensity, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18515,9 +17429,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "notes",
 					Num:        8,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18531,9 +17444,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "equipment",
 					Num:        9,
-					Type:       profile.WorkoutEquipment, /* basetype.Enum */
+					Type:       profile.WorkoutEquipment, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18547,9 +17459,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "exercise_category",
 					Num:        10,
-					Type:       profile.ExerciseCategory, /* basetype.Uint16 */
+					Type:       profile.ExerciseCategory, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18563,9 +17474,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "exercise_name",
 					Num:        11,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18579,9 +17489,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "exercise_weight",
 					Num:        12,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -18595,9 +17504,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "weight_display_unit",
 					Num:        13,
-					Type:       profile.FitBaseUnit, /* basetype.Uint16 */
+					Type:       profile.FitBaseUnit, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18611,9 +17519,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "secondary_target_type",
 					Num:        19,
-					Type:       profile.WktStepTarget, /* basetype.Enum */
+					Type:       profile.WktStepTarget, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18627,9 +17534,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "secondary_target_value",
 					Num:        20,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18674,9 +17580,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "secondary_custom_target_value_low",
 					Num:        21,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18715,9 +17620,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "secondary_custom_target_value_high",
 					Num:        22,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18761,9 +17665,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18777,9 +17680,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "exercise_category",
 					Num:        0,
-					Type:       profile.ExerciseCategory, /* basetype.Uint16 */
+					Type:       profile.ExerciseCategory, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18793,9 +17695,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "exercise_name",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18809,9 +17710,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "wkt_step_name",
 					Num:        2,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      true,           /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18830,9 +17730,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "manufacturer",
 					Num:        0,
-					Type:       profile.Manufacturer, /* basetype.Uint16 */
+					Type:       profile.Manufacturer, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18846,9 +17745,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "product",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18878,9 +17776,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "serial_number",
 					Num:        2,
-					Type:       profile.Uint32z, /* basetype.Uint32z */
+					Type:       profile.Uint32z, /* basetype.Uint32z (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18894,9 +17791,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time_created",
 					Num:        3,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18910,9 +17806,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "completed",
 					Num:        4,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18926,9 +17821,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "type",
 					Num:        5,
-					Type:       profile.Schedule, /* basetype.Enum */
+					Type:       profile.Schedule, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18942,9 +17836,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "scheduled_time",
 					Num:        6,
-					Type:       profile.LocalDateTime, /* basetype.Uint32 */
+					Type:       profile.LocalDateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18963,9 +17856,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "message_index",
 					Num:        254,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18979,9 +17871,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -18995,9 +17886,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timer_time",
 					Num:        0,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19011,9 +17901,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "distance",
 					Num:        1,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19027,9 +17916,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calories",
 					Num:        2,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19043,9 +17931,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport",
 					Num:        3,
-					Type:       profile.Sport, /* basetype.Enum */
+					Type:       profile.Sport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19059,9 +17946,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "elapsed_time",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19075,9 +17961,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sessions",
 					Num:        5,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19091,9 +17976,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "active_time",
 					Num:        6,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19107,9 +17991,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport_index",
 					Num:        9,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19128,9 +18011,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19144,9 +18026,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "weight",
 					Num:        0,
-					Type:       profile.Weight, /* basetype.Uint16 */
+					Type:       profile.Weight, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -19160,9 +18041,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "percent_fat",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -19176,9 +18056,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "percent_hydration",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -19192,9 +18071,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "visceral_fat_mass",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -19208,9 +18086,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bone_mass",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -19224,9 +18101,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "muscle_mass",
 					Num:        5,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -19240,9 +18116,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "basal_met",
 					Num:        7,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      4,
 					Offset:     0,
@@ -19256,9 +18131,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "physique_rating",
 					Num:        8,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19272,9 +18146,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "active_met",
 					Num:        9,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      4,
 					Offset:     0,
@@ -19288,9 +18161,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "metabolic_age",
 					Num:        10,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19304,9 +18176,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "visceral_fat_rating",
 					Num:        11,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19320,9 +18191,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "user_profile_index",
 					Num:        12,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19336,9 +18206,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bmi",
 					Num:        13,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -19357,9 +18226,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19373,9 +18241,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "systolic_pressure",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19389,9 +18256,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "diastolic_pressure",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19405,9 +18271,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mean_arterial_pressure",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19421,9 +18286,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "map_3_sample_mean",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19437,9 +18301,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "map_morning_values",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19453,9 +18316,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "map_evening_values",
 					Num:        5,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19469,9 +18331,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "heart_rate",
 					Num:        6,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19485,9 +18346,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "heart_rate_type",
 					Num:        7,
-					Type:       profile.HrType, /* basetype.Enum */
+					Type:       profile.HrType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19501,9 +18361,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "status",
 					Num:        8,
-					Type:       profile.BpStatus, /* basetype.Enum */
+					Type:       profile.BpStatus, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19517,9 +18376,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "user_profile_index",
 					Num:        9,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19538,9 +18396,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19554,9 +18411,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "local_timestamp",
 					Num:        0,
-					Type:       profile.LocalDateTime, /* basetype.Uint32 */
+					Type:       profile.LocalDateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19570,9 +18426,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "activity_type",
 					Num:        1,
-					Type:       profile.ActivityType, /* basetype.Enum */
+					Type:       profile.ActivityType, /* basetype.Enum (size: 1) */
 					Array:      true,                 /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19586,9 +18441,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cycles_to_distance",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      5000,
 					Offset:     0,
@@ -19602,9 +18456,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cycles_to_calories",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      5000,
 					Offset:     0,
@@ -19618,9 +18471,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "resting_metabolic_rate",
 					Num:        5,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19639,9 +18491,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19655,9 +18506,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "device_index",
 					Num:        0,
-					Type:       profile.DeviceIndex, /* basetype.Uint8 */
+					Type:       profile.DeviceIndex, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19671,9 +18521,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calories",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19687,9 +18536,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "distance",
 					Num:        2,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -19703,9 +18551,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cycles",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      2,
 					Offset:     0,
@@ -19734,9 +18581,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "active_time",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -19750,9 +18596,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "activity_type",
 					Num:        5,
-					Type:       profile.ActivityType, /* basetype.Enum */
+					Type:       profile.ActivityType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19766,9 +18611,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "activity_subtype",
 					Num:        6,
-					Type:       profile.ActivitySubtype, /* basetype.Enum */
+					Type:       profile.ActivitySubtype, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19782,9 +18626,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "activity_level",
 					Num:        7,
-					Type:       profile.ActivityLevel, /* basetype.Enum */
+					Type:       profile.ActivityLevel, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19798,9 +18641,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "distance_16",
 					Num:        8,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19814,9 +18656,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cycles_16",
 					Num:        9,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19830,9 +18671,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "active_time_16",
 					Num:        10,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19846,9 +18686,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "local_timestamp",
 					Num:        11,
-					Type:       profile.LocalDateTime, /* basetype.Uint32 */
+					Type:       profile.LocalDateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19862,9 +18701,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "temperature",
 					Num:        12,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -19878,9 +18716,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "temperature_min",
 					Num:        14,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -19894,9 +18731,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "temperature_max",
 					Num:        15,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -19910,9 +18746,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "activity_time",
 					Num:        16,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [8] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19926,9 +18761,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "active_calories",
 					Num:        19,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19942,9 +18776,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "current_activity_type_intensity",
 					Num:   24,
-					Type:  profile.Byte, /* basetype.Byte */
+					Type:  profile.Byte, /* basetype.Byte (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 5 /* activity_type */, Scale: 1, Offset: 0, Accumulate: false, Bits: 5},
 						{FieldNum: 28 /* intensity */, Scale: 1, Offset: 0, Accumulate: false, Bits: 3},
@@ -19961,9 +18794,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_min_8",
 					Num:        25,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19977,9 +18809,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_16",
 					Num:        26,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -19993,9 +18824,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "heart_rate",
 					Num:        27,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20009,9 +18839,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "intensity",
 					Num:        28,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -20025,9 +18854,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "duration_min",
 					Num:        29,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20041,9 +18869,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "duration",
 					Num:        30,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20057,9 +18884,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ascent",
 					Num:        31,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -20073,9 +18899,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "descent",
 					Num:        32,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -20089,9 +18914,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "moderate_activity_minutes",
 					Num:        33,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20105,9 +18929,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "vigorous_activity_minutes",
 					Num:        34,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20126,9 +18949,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20142,9 +18964,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "resting_heart_rate",
 					Num:        0,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20158,9 +18979,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "current_day_resting_heart_rate",
 					Num:        1,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20179,9 +18999,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20195,9 +19014,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "reading_spo2",
 					Num:        0,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20211,9 +19029,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "reading_confidence",
 					Num:        1,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20227,9 +19044,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mode",
 					Num:        2,
-					Type:       profile.Spo2MeasurementType, /* basetype.Enum */
+					Type:       profile.Spo2MeasurementType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20248,9 +19064,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20264,9 +19079,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "fractional_timestamp",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      32768,
 					Offset:     0,
@@ -20280,9 +19094,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "time256",
 					Num:   1,
-					Type:  profile.Uint8, /* basetype.Uint8 */
+					Type:  profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 0 /* fractional_timestamp */, Scale: 256, Offset: 0, Accumulate: false, Bits: 8},
 					},
@@ -20298,9 +19111,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "filtered_bpm",
 					Num:        6,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      true,          /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20314,9 +19126,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "event_timestamp",
 					Num:        9,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      true,           /* Array Size [N] */
-					Size:       4,
 					Components: nil,
 					Scale:      1024,
 					Offset:     0,
@@ -20330,9 +19141,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "event_timestamp_12",
 					Num:   10,
-					Type:  profile.Byte, /* basetype.Byte */
+					Type:  profile.Byte, /* basetype.Byte (size: 1) */
 					Array: true,         /* Array Size [N] */
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 9 /* event_timestamp */, Scale: 1024, Offset: 0, Accumulate: true, Bits: 12},
 						{FieldNum: 9 /* event_timestamp */, Scale: 1024, Offset: 0, Accumulate: true, Bits: 12},
@@ -20362,9 +19172,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stress_level_value",
 					Num:        0,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20378,9 +19187,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "stress_level_time",
 					Num:        1,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20399,9 +19207,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "update_time",
 					Num:        0,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20415,9 +19222,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "vo2_max",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      10,
 					Offset:     0,
@@ -20431,9 +19237,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sport",
 					Num:        5,
-					Type:       profile.Sport, /* basetype.Enum */
+					Type:       profile.Sport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20447,9 +19252,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sub_sport",
 					Num:        6,
-					Type:       profile.SubSport, /* basetype.Enum */
+					Type:       profile.SubSport, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20463,9 +19267,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_met_category",
 					Num:        8,
-					Type:       profile.MaxMetCategory, /* basetype.Enum */
+					Type:       profile.MaxMetCategory, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20479,9 +19282,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibrated_data",
 					Num:        9,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20495,9 +19297,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "hr_source",
 					Num:        12,
-					Type:       profile.MaxMetHeartRateSource, /* basetype.Enum */
+					Type:       profile.MaxMetHeartRateSource, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20511,9 +19312,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "speed_source",
 					Num:        13,
-					Type:       profile.MaxMetSpeedSource, /* basetype.Enum */
+					Type:       profile.MaxMetSpeedSource, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20532,9 +19332,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "part_index",
 					Num:        250,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20548,9 +19347,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "memo",
 					Num:        0,
-					Type:       profile.Byte, /* basetype.Byte */
+					Type:       profile.Byte, /* basetype.Byte (size: 1) */
 					Array:      true,         /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20564,9 +19362,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mesg_num",
 					Num:        1,
-					Type:       profile.MesgNum, /* basetype.Uint16 */
+					Type:       profile.MesgNum, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20580,9 +19377,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "parent_index",
 					Num:        2,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20596,9 +19392,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "field_num",
 					Num:        3,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20612,9 +19407,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "data",
 					Num:        4,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      true,           /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20633,9 +19427,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20649,9 +19442,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sleep_level",
 					Num:        0,
-					Type:       profile.SleepLevel, /* basetype.Enum */
+					Type:       profile.SleepLevel, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20670,9 +19462,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "channel_number",
 					Num:        0,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20686,9 +19477,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "device_type",
 					Num:        1,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20702,9 +19492,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "device_number",
 					Num:        2,
-					Type:       profile.Uint16z, /* basetype.Uint16z */
+					Type:       profile.Uint16z, /* basetype.Uint16z (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20718,9 +19507,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "transmission_type",
 					Num:        3,
-					Type:       profile.Uint8z, /* basetype.Uint8z */
+					Type:       profile.Uint8z, /* basetype.Uint8z (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20734,9 +19522,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "device_index",
 					Num:        4,
-					Type:       profile.DeviceIndex, /* basetype.Uint8 */
+					Type:       profile.DeviceIndex, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20755,9 +19542,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20771,9 +19557,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "fractional_timestamp",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      32768,
 					Offset:     0,
@@ -20787,9 +19572,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mesg_id",
 					Num:        1,
-					Type:       profile.Byte, /* basetype.Byte */
+					Type:       profile.Byte, /* basetype.Byte (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20803,9 +19587,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "mesg_data",
 					Num:   2,
-					Type:  profile.Byte, /* basetype.Byte */
+					Type:  profile.Byte, /* basetype.Byte (size: 1) */
 					Array: true,         /* Array Size [N] */
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 3 /* channel_number */, Scale: 1, Offset: 0, Accumulate: false, Bits: 8},
 						{FieldNum: 4 /* data */, Scale: 1, Offset: 0, Accumulate: false, Bits: 8},
@@ -20829,9 +19612,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "channel_number",
 					Num:        3,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20845,9 +19627,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "data",
 					Num:        4,
-					Type:       profile.Byte, /* basetype.Byte */
+					Type:       profile.Byte, /* basetype.Byte (size: 1) */
 					Array:      true,         /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20866,9 +19647,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20882,9 +19662,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "fractional_timestamp",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      32768,
 					Offset:     0,
@@ -20898,9 +19677,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "mesg_id",
 					Num:        1,
-					Type:       profile.Byte, /* basetype.Byte */
+					Type:       profile.Byte, /* basetype.Byte (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20914,9 +19692,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "mesg_data",
 					Num:   2,
-					Type:  profile.Byte, /* basetype.Byte */
+					Type:  profile.Byte, /* basetype.Byte (size: 1) */
 					Array: true,         /* Array Size [N] */
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 3 /* channel_number */, Scale: 1, Offset: 0, Accumulate: false, Bits: 8},
 						{FieldNum: 4 /* data */, Scale: 1, Offset: 0, Accumulate: false, Bits: 8},
@@ -20940,9 +19717,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "channel_number",
 					Num:        3,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20956,9 +19732,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "data",
 					Num:        4,
-					Type:       profile.Byte, /* basetype.Byte */
+					Type:       profile.Byte, /* basetype.Byte (size: 1) */
 					Array:      true,         /* Array Size [N] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20977,9 +19752,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "screen_index",
 					Num:        0,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -20993,9 +19767,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "field_count",
 					Num:        1,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21009,9 +19782,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "layout",
 					Num:        2,
-					Type:       profile.ExdLayout, /* basetype.Enum */
+					Type:       profile.ExdLayout, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21025,9 +19797,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "screen_enabled",
 					Num:        3,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21046,9 +19817,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "screen_index",
 					Num:        0,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21062,9 +19832,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "concept_field",
 					Num:   1,
-					Type:  profile.Byte, /* basetype.Byte */
+					Type:  profile.Byte, /* basetype.Byte (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 2 /* field_id */, Scale: 1, Offset: 0, Accumulate: false, Bits: 4},
 						{FieldNum: 3 /* concept_count */, Scale: 1, Offset: 0, Accumulate: false, Bits: 4},
@@ -21081,9 +19850,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "field_id",
 					Num:        2,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21097,9 +19865,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "concept_count",
 					Num:        3,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21113,9 +19880,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "display_type",
 					Num:        4,
-					Type:       profile.ExdDisplayType, /* basetype.Enum */
+					Type:       profile.ExdDisplayType, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21129,9 +19895,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "title",
 					Num:        5,
-					Type:       profile.String, /* basetype.String */
+					Type:       profile.String, /* basetype.String (size: 1) */
 					Array:      true,           /* Array Size [32] */
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21150,9 +19915,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "screen_index",
 					Num:        0,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21166,9 +19930,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:  "concept_field",
 					Num:   1,
-					Type:  profile.Byte, /* basetype.Byte */
+					Type:  profile.Byte, /* basetype.Byte (size: 1) */
 					Array: false,
-					Size:  1,
 					Components: []proto.Component{
 						{FieldNum: 2 /* field_id */, Scale: 1, Offset: 0, Accumulate: false, Bits: 4},
 						{FieldNum: 3 /* concept_index */, Scale: 1, Offset: 0, Accumulate: false, Bits: 4},
@@ -21185,9 +19948,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "field_id",
 					Num:        2,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21201,9 +19963,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "concept_index",
 					Num:        3,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21217,9 +19978,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "data_page",
 					Num:        4,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21233,9 +19993,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "concept_key",
 					Num:        5,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21249,9 +20008,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "scaling",
 					Num:        6,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21265,9 +20023,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "data_units",
 					Num:        8,
-					Type:       profile.ExdDataUnits, /* basetype.Enum */
+					Type:       profile.ExdDataUnits, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21281,9 +20038,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "qualifier",
 					Num:        9,
-					Type:       profile.ExdQualifiers, /* basetype.Enum */
+					Type:       profile.ExdQualifiers, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21297,9 +20053,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "descriptor",
 					Num:        10,
-					Type:       profile.ExdDescriptors, /* basetype.Enum */
+					Type:       profile.ExdDescriptors, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21313,9 +20068,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "is_signed",
 					Num:        11,
-					Type:       profile.Bool, /* basetype.Bool */
+					Type:       profile.Bool, /* basetype.Bool (size: 0) */
 					Array:      false,
-					Size:       0,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21334,9 +20088,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21350,9 +20103,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "reference_mesg",
 					Num:        0,
-					Type:       profile.MesgNum, /* basetype.Uint16 */
+					Type:       profile.MesgNum, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21366,9 +20118,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "reference_index",
 					Num:        1,
-					Type:       profile.MessageIndex, /* basetype.Uint16 */
+					Type:       profile.MessageIndex, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21382,9 +20133,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_depth",
 					Num:        2,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -21398,9 +20148,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_depth",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -21414,9 +20163,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "surface_interval",
 					Num:        4,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21430,9 +20178,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_cns",
 					Num:        5,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21446,9 +20193,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_cns",
 					Num:        6,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21462,9 +20208,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_n2",
 					Num:        7,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21478,9 +20223,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_n2",
 					Num:        8,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21494,9 +20238,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "o2_toxicity",
 					Num:        9,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21510,9 +20253,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "dive_number",
 					Num:        10,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21526,9 +20268,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bottom_time",
 					Num:        11,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -21542,9 +20283,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_pressure_sac",
 					Num:        12,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -21558,9 +20298,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_volume_sac",
 					Num:        13,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -21574,9 +20313,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_rmv",
 					Num:        14,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -21590,9 +20328,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "descent_time",
 					Num:        15,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -21606,9 +20343,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ascent_time",
 					Num:        16,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -21622,9 +20358,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_ascent_rate",
 					Num:        17,
-					Type:       profile.Sint32, /* basetype.Sint32 */
+					Type:       profile.Sint32, /* basetype.Sint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -21638,9 +20373,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "avg_descent_rate",
 					Num:        22,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -21654,9 +20388,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_ascent_rate",
 					Num:        23,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -21670,9 +20403,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "max_descent_rate",
 					Num:        24,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -21686,9 +20418,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "hang_time",
 					Num:        25,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -21707,9 +20438,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1000,
 					Offset:     0,
@@ -21728,9 +20458,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21744,9 +20473,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp_ms",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21760,9 +20488,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "time",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      true,           /* Array Size [N] */
-					Size:       2,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21781,9 +20508,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21797,9 +20523,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "weekly_average",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -21813,9 +20538,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "last_night_average",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -21829,9 +20553,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "last_night_5_min_high",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -21845,9 +20568,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "baseline_low_upper",
 					Num:        3,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -21861,9 +20583,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "baseline_balanced_lower",
 					Num:        4,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -21877,9 +20598,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "baseline_balanced_upper",
 					Num:        5,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -21893,9 +20613,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "status",
 					Num:        6,
-					Type:       profile.HrvStatus, /* basetype.Enum */
+					Type:       profile.HrvStatus, /* basetype.Enum (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21914,9 +20633,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21930,9 +20648,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "value",
 					Num:        0,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      128,
 					Offset:     0,
@@ -21951,9 +20668,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -21967,9 +20683,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "respiration_rate",
 					Num:        0,
-					Type:       profile.Sint16, /* basetype.Sint16 */
+					Type:       profile.Sint16, /* basetype.Sint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -21988,9 +20703,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22004,9 +20718,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sensor",
 					Num:        0,
-					Type:       profile.AntChannelId, /* basetype.Uint32z */
+					Type:       profile.AntChannelId, /* basetype.Uint32z (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22020,9 +20733,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "pressure",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -22041,9 +20753,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "timestamp",
 					Num:        253,
-					Type:       profile.DateTime, /* basetype.Uint32 */
+					Type:       profile.DateTime, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22057,9 +20768,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sensor",
 					Num:        0,
-					Type:       profile.AntChannelId, /* basetype.Uint32z */
+					Type:       profile.AntChannelId, /* basetype.Uint32z (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22073,9 +20783,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "start_pressure",
 					Num:        1,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -22089,9 +20798,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "end_pressure",
 					Num:        2,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -22105,9 +20813,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "volume_used",
 					Num:        3,
-					Type:       profile.Uint32, /* basetype.Uint32 */
+					Type:       profile.Uint32, /* basetype.Uint32 (size: 4) */
 					Array:      false,
-					Size:       4,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,
@@ -22126,9 +20833,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "combined_awake_score",
 					Num:        0,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22142,9 +20848,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "awake_time_score",
 					Num:        1,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22158,9 +20863,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "awakenings_count_score",
 					Num:        2,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22174,9 +20878,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "deep_sleep_score",
 					Num:        3,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22190,9 +20893,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sleep_duration_score",
 					Num:        4,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22206,9 +20908,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "light_sleep_score",
 					Num:        5,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22222,9 +20923,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "overall_sleep_score",
 					Num:        6,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22238,9 +20938,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sleep_quality_score",
 					Num:        7,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22254,9 +20953,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sleep_recovery_score",
 					Num:        8,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22270,9 +20968,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "rem_sleep_score",
 					Num:        9,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22286,9 +20983,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "sleep_restlessness_score",
 					Num:        10,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22302,9 +20998,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "awakenings_count",
 					Num:        11,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22318,9 +21013,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "interruptions_score",
 					Num:        14,
-					Type:       profile.Uint8, /* basetype.Uint8 */
+					Type:       profile.Uint8, /* basetype.Uint8 (size: 1) */
 					Array:      false,
-					Size:       1,
 					Components: nil,
 					Scale:      1,
 					Offset:     0,
@@ -22334,9 +21028,8 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "average_stress_during_sleep",
 					Num:        15,
-					Type:       profile.Uint16, /* basetype.Uint16 */
+					Type:       profile.Uint16, /* basetype.Uint16 (size: 2) */
 					Array:      false,
-					Size:       2,
 					Components: nil,
 					Scale:      100,
 					Offset:     0,

--- a/internal/cmd/fitgen/factory/builder.go
+++ b/internal/cmd/fitgen/factory/builder.go
@@ -190,14 +190,12 @@ func (b *factoryBuilder) makeFields(message parser.Message) string {
 		strbuf.WriteString("FieldBase: &proto.FieldBase{\n")
 		strbuf.WriteString(fmt.Sprintf("Name: %q,\n", field.Name))
 		strbuf.WriteString(fmt.Sprintf("Num: %d,\n", field.Num))
-		strbuf.WriteString(fmt.Sprintf("Type: %s, /* %s */\n",
+		strbuf.WriteString(fmt.Sprintf("Type: %s, /* %s (size: %d) */\n",
 			b.transformProfileType(field.Type),
 			b.transformBaseType(field.Type),
-		))
-		strbuf.WriteString(fmt.Sprintf("Array: %t, %s\n", field.Array != "", makeArrayComment(field.Array)))
-		strbuf.WriteString(fmt.Sprintf("Size: %d,\n",
 			basetype.FromString(b.baseTypeMapByProfileType[field.Type]).Size(),
 		))
+		strbuf.WriteString(fmt.Sprintf("Array: %t, %s\n", field.Array != "", makeArrayComment(field.Array)))
 		strbuf.WriteString(fmt.Sprintf("Components: %s,\n", b.makeComponents(field, message.Name)))
 		strbuf.WriteString(fmt.Sprintf("Scale: %g,\n", scaleOrDefault(field.Scales, 0)))    // first index or default
 		strbuf.WriteString(fmt.Sprintf("Offset: %g,\n", offsetOrDefault(field.Offsets, 0))) // first index or default

--- a/internal/cmd/fitgen/profile/builder.go
+++ b/internal/cmd/fitgen/profile/builder.go
@@ -55,38 +55,34 @@ func (b *profilebuilder) Build() ([]builder.Data, error) {
 }
 
 func (b *profilebuilder) buildProfile() builder.Data {
-	mappingToBaseTypes := make([]MappingBaseType, 0, len(b.types))
 	constants := make([]shared.Constant, 0, len(b.types))
+	mappingToBaseTypes := make([]MappingBaseType, 0, len(b.types))
 
 	for _, t := range b.types {
-		if t.Name == FitBaseType { // special types to be included
-			ms := make([]MappingBaseType, len(mappingToBaseTypes)+len(t.Values)+1, len(t.Values)+cap(mappingToBaseTypes)+1)
-			cs := make([]shared.Constant, len(constants)+len(t.Values)+1, len(t.Values)+cap(constants)+1)
-			for i, v := range t.Values {
-				ms[i] = MappingBaseType{
-					ConstantName: strutil.ToTitle(v.Name),
-					BaseType:     transformBaseType(strutil.ToTitle(v.Name)), // mapping to itself
-				}
-				cs[i] = shared.Constant{
-					Name:   strutil.ToTitle(v.Name),
+		if t.Name == FitBaseType { // special types to be included, mapping to itself (profile.Uint8 == basetype.Uint8)
+			for _, v := range t.Values {
+				constantName := strutil.ToTitle(v.Name)
+				baseType := transformBaseType(strutil.ToTitle(v.Name))
+				constants = append(constants, shared.Constant{
+					Name:   constantName,
 					String: v.Name,
-				}
+				})
+				mappingToBaseTypes = append(mappingToBaseTypes, MappingBaseType{
+					ConstantName: constantName,
+					BaseType:     baseType,
+				})
 			}
 
-			cs[len(t.Values)] = shared.Constant{Name: "Bool", String: "bool"} // +1
-			copy(cs[len(t.Values)+1:], constants)
-			constants = cs
-
-			ms[len(t.Values)] = MappingBaseType{ConstantName: "Bool", BaseType: transformBaseType("Enum")} // +1
-			copy(ms[len(t.Values)+1:], mappingToBaseTypes)
-			mappingToBaseTypes = ms
+			constants = append(constants, shared.Constant{Name: "Bool", String: "bool"})
+			mappingToBaseTypes = append(mappingToBaseTypes, MappingBaseType{ConstantName: "Bool", BaseType: transformBaseType("Enum")})
 		}
+	}
 
+	for _, t := range b.types {
 		constants = append(constants, shared.Constant{
 			Name:   strutil.ToTitle(t.Name),
 			String: t.Name,
 		})
-
 		mappingToBaseTypes = append(mappingToBaseTypes, MappingBaseType{
 			ConstantName: strutil.ToTitle(t.Name),
 			BaseType:     transformBaseType(strutil.ToTitle(t.BaseType)),

--- a/profile/typedef/unmarshal.go
+++ b/profile/typedef/unmarshal.go
@@ -18,7 +18,9 @@ func Unmarshal(b []byte, bo binary.ByteOrder, ref basetype.BaseType, isArray boo
 	switch ref {
 	case basetype.Enum, basetype.Byte:
 		if isArray {
-			return b, nil
+			vals := make([]byte, len(b))
+			copy(vals, b)
+			return vals, nil
 		}
 		return b[0], nil
 	case basetype.Sint8:
@@ -32,7 +34,9 @@ func Unmarshal(b []byte, bo binary.ByteOrder, ref basetype.BaseType, isArray boo
 		return int8(b[0]), nil
 	case basetype.Uint8, basetype.Uint8z:
 		if isArray {
-			return b, nil
+			vals := make([]byte, len(b))
+			copy(vals, b)
+			return vals, nil
 		}
 		return b[0], nil
 	case basetype.Sint16:

--- a/profile/typedef/unmarshal_test.go
+++ b/profile/typedef/unmarshal_test.go
@@ -100,6 +100,21 @@ func TestUnmarshal(t *testing.T) {
 			if diff := cmp.Diff(v, tc.expected); diff != "" {
 				t.Fatal(diff)
 			}
+
+			// Extra check for bytes, the value should be copied
+			if in, ok := tc.value.([]byte); ok {
+				out, ok := v.([]byte)
+				if !ok {
+					return
+				}
+
+				in[0] = 255
+				out[0] = 100
+
+				if in[0] == out[0] {
+					t.Fatalf("slice of bytes should not be referenced")
+				}
+			}
 		})
 	}
 }

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -50,12 +50,9 @@ func CreateMessageDefinition(mesg *Message) (mesgDef MessageDefinition) {
 
 	fieldDefinitions := make([]FieldDefinition, 0, len(mesg.Fields))
 	for _, field := range mesg.Fields {
-		size := field.Size
-		size *= typedef.Len(field.Value)
-
 		fieldDefinitions = append(fieldDefinitions, FieldDefinition{
 			Num:      field.Num,
-			Size:     size,
+			Size:     field.Type.BaseType().Size() * typedef.Len(field.Value),
 			BaseType: field.Type.BaseType(),
 		})
 	}


### PR DESCRIPTION
- decoder: use single backing array instead of creating slice on each r read since the max size is known.
- decoder: implement reuse existing variables/instance rather than creating new one.
- proto: remove Size in FieldBase, we can get the size from basetype.
- profile: clean up fitgen's profile builder.go
- generate: profile and factory


benchmark:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/decoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                    │    old.txt    │               new.txt                │
                    │    sec/op     │    sec/op     vs base                │
DecodeMessageData-4   11.317µ ± 13%   9.543µ ±  1%  -15.68% (p=0.000 n=10)
Decode-4               160.7m ± 44%   137.0m ± 11%  -14.76% (p=0.001 n=10)
geomean                1.349m         1.144m        -15.22%

                    │   old.txt    │               new.txt               │
                    │     B/op     │     B/op      vs base               │
DecodeMessageData-4   3.430Ki ± 0%   3.277Ki ± 0%  -4.47% (p=0.000 n=10)
Decode-4              97.52Mi ± 0%   94.85Mi ± 0%  -2.74% (p=0.000 n=10)
geomean               585.3Ki        564.2Ki       -3.61%

                    │   old.txt    │               new.txt               │
                    │  allocs/op   │  allocs/op   vs base                │
DecodeMessageData-4    136.00 ± 0%    58.00 ± 0%  -57.35% (p=0.000 n=10)
Decode-4              1900.1k ± 0%   900.1k ± 0%  -52.63% (p=0.000 n=10)
geomean                16.08k        7.225k       -55.05%

```