### PR TITLE
perf: clean up proto and improve mesgdef

### DIFF
--- a/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
+++ b/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
@@ -66,33 +66,28 @@ func New{{ .Name }}(mesg *proto.Message) *{{ .Name }} {
 
 // ToMesg converts {{ .Name }} into proto.Message.
 func (m *{{ .Name }}) ToMesg(fac Factory) proto.Message {
+    fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+    defer fieldsPool.Put(fieldsPtr)
+    
+    fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
     mesg := fac.CreateMesgOnly(typedef.MesgNum{{ .Name }})
-	mesg.Fields = make([]proto.Field, 0, m.size())
-
+	
     {{ range .Fields -}}
         if {{ .ComparableValue }} != {{ .InvalidValue }} {
             field := fac.CreateField(mesg.Num, {{ .Num }})
             field.Value = {{ .PrimitiveValue }}
-            mesg.Fields = append(mesg.Fields, field)
+            fields = append(fields, field)
         }
 	{{ end }}
+
+    mesg.Fields = make([]proto.Field, len(fields))
+    copy(mesg.Fields, fields)
 
 	{{ if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
 	mesg.DeveloperFields = m.DeveloperFields
 	{{ end }}
 
 	return mesg
-}
-
-// size returns size of {{ .Name }}'s valid fields.
-func (m *{{ .Name }}) size() byte {
-    var size byte
-    {{ range .Fields -}}
-        if {{ .ComparableValue }} != {{ .InvalidValue }} {
-            size++
-        }
-	{{ end -}}
-    return size
 }
 
 {{ range .Fields -}}

--- a/profile/mesgdef/accelerometer_data_gen.go
+++ b/profile/mesgdef/accelerometer_data_gen.go
@@ -72,115 +72,79 @@ func NewAccelerometerData(mesg *proto.Message) *AccelerometerData {
 
 // ToMesg converts AccelerometerData into proto.Message.
 func (m *AccelerometerData) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumAccelerometerData)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SampleTimeOffset != nil {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.SampleTimeOffset
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AccelX != nil {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.AccelX
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AccelY != nil {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.AccelY
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AccelZ != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.AccelZ
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibratedAccelX != nil {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.CalibratedAccelX
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibratedAccelY != nil {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.CalibratedAccelY
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibratedAccelZ != nil {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.CalibratedAccelZ
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CompressedCalibratedAccelX != nil {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.CompressedCalibratedAccelX
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CompressedCalibratedAccelY != nil {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.CompressedCalibratedAccelY
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CompressedCalibratedAccelZ != nil {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.CompressedCalibratedAccelZ
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of AccelerometerData's valid fields.
-func (m *AccelerometerData) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if m.SampleTimeOffset != nil {
-		size++
-	}
-	if m.AccelX != nil {
-		size++
-	}
-	if m.AccelY != nil {
-		size++
-	}
-	if m.AccelZ != nil {
-		size++
-	}
-	if m.CalibratedAccelX != nil {
-		size++
-	}
-	if m.CalibratedAccelY != nil {
-		size++
-	}
-	if m.CalibratedAccelZ != nil {
-		size++
-	}
-	if m.CompressedCalibratedAccelX != nil {
-		size++
-	}
-	if m.CompressedCalibratedAccelY != nil {
-		size++
-	}
-	if m.CompressedCalibratedAccelZ != nil {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets AccelerometerData value.

--- a/profile/mesgdef/activity_gen.go
+++ b/profile/mesgdef/activity_gen.go
@@ -64,83 +64,59 @@ func NewActivity(mesg *proto.Message) *Activity {
 
 // ToMesg converts Activity into proto.Message.
 func (m *Activity) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumActivity)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalTimerTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TotalTimerTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NumSessions != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.NumSessions
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToEnum[byte](m.Type)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Event) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToEnum[byte](m.Event)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.EventType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToEnum[byte](m.EventType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.LocalTimestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = datetime.ToUint32(m.LocalTimestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EventGroup != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.EventGroup
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Activity's valid fields.
-func (m *Activity) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalTimerTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.NumSessions != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Event) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.EventType) != basetype.EnumInvalid {
-		size++
-	}
-	if datetime.ToUint32(m.LocalTimestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EventGroup != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets Activity value.

--- a/profile/mesgdef/ant_channel_id_gen.go
+++ b/profile/mesgdef/ant_channel_id_gen.go
@@ -56,59 +56,44 @@ func NewAntChannelId(mesg *proto.Message) *AntChannelId {
 
 // ToMesg converts AntChannelId into proto.Message.
 func (m *AntChannelId) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumAntChannelId)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.ChannelNumber != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.ChannelNumber
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.DeviceType) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToUint8z[uint8](m.DeviceType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16z[uint16](m.DeviceNumber) != basetype.Uint16zInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToUint16z[uint16](m.DeviceNumber)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.TransmissionType) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToUint8z[uint8](m.TransmissionType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToUint8[uint8](m.DeviceIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of AntChannelId's valid fields.
-func (m *AntChannelId) size() byte {
-	var size byte
-	if m.ChannelNumber != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.DeviceType) != basetype.Uint8zInvalid {
-		size++
-	}
-	if typeconv.ToUint16z[uint16](m.DeviceNumber) != basetype.Uint16zInvalid {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.TransmissionType) != basetype.Uint8zInvalid {
-		size++
-	}
-	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetChannelNumber sets AntChannelId value.

--- a/profile/mesgdef/ant_rx_gen.go
+++ b/profile/mesgdef/ant_rx_gen.go
@@ -60,67 +60,49 @@ func NewAntRx(mesg *proto.Message) *AntRx {
 
 // ToMesg converts AntRx into proto.Message.
 func (m *AntRx) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumAntRx)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FractionalTimestamp != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.FractionalTimestamp
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MesgId != basetype.ByteInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.MesgId
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MesgData != nil {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.MesgData
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ChannelNumber != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ChannelNumber
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Data != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Data
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of AntRx's valid fields.
-func (m *AntRx) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.FractionalTimestamp != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MesgId != basetype.ByteInvalid {
-		size++
-	}
-	if m.MesgData != nil {
-		size++
-	}
-	if m.ChannelNumber != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Data != nil {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets AntRx value.

--- a/profile/mesgdef/ant_tx_gen.go
+++ b/profile/mesgdef/ant_tx_gen.go
@@ -60,67 +60,49 @@ func NewAntTx(mesg *proto.Message) *AntTx {
 
 // ToMesg converts AntTx into proto.Message.
 func (m *AntTx) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumAntTx)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FractionalTimestamp != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.FractionalTimestamp
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MesgId != basetype.ByteInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.MesgId
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MesgData != nil {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.MesgData
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ChannelNumber != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ChannelNumber
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Data != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Data
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of AntTx's valid fields.
-func (m *AntTx) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.FractionalTimestamp != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MesgId != basetype.ByteInvalid {
-		size++
-	}
-	if m.MesgData != nil {
-		size++
-	}
-	if m.ChannelNumber != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Data != nil {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets AntTx value.

--- a/profile/mesgdef/aviation_attitude_gen.go
+++ b/profile/mesgdef/aviation_attitude_gen.go
@@ -72,115 +72,79 @@ func NewAviationAttitude(mesg *proto.Message) *AviationAttitude {
 
 // ToMesg converts AviationAttitude into proto.Message.
 func (m *AviationAttitude) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumAviationAttitude)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SystemTime != nil {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.SystemTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Pitch != nil {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Pitch
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Roll != nil {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Roll
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AccelLateral != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.AccelLateral
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AccelNormal != nil {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.AccelNormal
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TurnRate != nil {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.TurnRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToSliceEnum[byte](m.Stage) != nil {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = typeconv.ToSliceEnum[byte](m.Stage)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AttitudeStageComplete != nil {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.AttitudeStageComplete
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Track != nil {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.Track
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToSliceUint16[uint16](m.Validity) != nil {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = typeconv.ToSliceUint16[uint16](m.Validity)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of AviationAttitude's valid fields.
-func (m *AviationAttitude) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if m.SystemTime != nil {
-		size++
-	}
-	if m.Pitch != nil {
-		size++
-	}
-	if m.Roll != nil {
-		size++
-	}
-	if m.AccelLateral != nil {
-		size++
-	}
-	if m.AccelNormal != nil {
-		size++
-	}
-	if m.TurnRate != nil {
-		size++
-	}
-	if typeconv.ToSliceEnum[byte](m.Stage) != nil {
-		size++
-	}
-	if m.AttitudeStageComplete != nil {
-		size++
-	}
-	if m.Track != nil {
-		size++
-	}
-	if typeconv.ToSliceUint16[uint16](m.Validity) != nil {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets AviationAttitude value.

--- a/profile/mesgdef/barometer_data_gen.go
+++ b/profile/mesgdef/barometer_data_gen.go
@@ -56,51 +56,39 @@ func NewBarometerData(mesg *proto.Message) *BarometerData {
 
 // ToMesg converts BarometerData into proto.Message.
 func (m *BarometerData) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumBarometerData)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SampleTimeOffset != nil {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.SampleTimeOffset
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BaroPres != nil {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.BaroPres
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of BarometerData's valid fields.
-func (m *BarometerData) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if m.SampleTimeOffset != nil {
-		size++
-	}
-	if m.BaroPres != nil {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets BarometerData value.

--- a/profile/mesgdef/beat_intervals_gen.go
+++ b/profile/mesgdef/beat_intervals_gen.go
@@ -54,43 +54,34 @@ func NewBeatIntervals(mesg *proto.Message) *BeatIntervals {
 
 // ToMesg converts BeatIntervals into proto.Message.
 func (m *BeatIntervals) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumBeatIntervals)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Time != nil {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Time
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of BeatIntervals's valid fields.
-func (m *BeatIntervals) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Time != nil {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets BeatIntervals value.

--- a/profile/mesgdef/bike_profile_gen.go
+++ b/profile/mesgdef/bike_profile_gen.go
@@ -110,275 +110,179 @@ func NewBikeProfile(mesg *proto.Message) *BikeProfile {
 
 // ToMesg converts BikeProfile into proto.Message.
 func (m *BikeProfile) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumBikeProfile)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.Sport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToEnum[byte](m.SubSport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Odometer != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Odometer
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16z[uint16](m.BikeSpdAntId) != basetype.Uint16zInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToUint16z[uint16](m.BikeSpdAntId)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16z[uint16](m.BikeCadAntId) != basetype.Uint16zInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToUint16z[uint16](m.BikeCadAntId)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16z[uint16](m.BikeSpdcadAntId) != basetype.Uint16zInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = typeconv.ToUint16z[uint16](m.BikeSpdcadAntId)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16z[uint16](m.BikePowerAntId) != basetype.Uint16zInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = typeconv.ToUint16z[uint16](m.BikePowerAntId)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CustomWheelsize != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.CustomWheelsize
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AutoWheelsize != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.AutoWheelsize
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BikeWeight != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.BikeWeight
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PowerCalFactor != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.PowerCalFactor
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AutoWheelCal != false {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = m.AutoWheelCal
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AutoPowerZero != false {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = m.AutoPowerZero
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Id != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = m.Id
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SpdEnabled != false {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = m.SpdEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CadEnabled != false {
 		field := fac.CreateField(mesg.Num, 16)
 		field.Value = m.CadEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SpdcadEnabled != false {
 		field := fac.CreateField(mesg.Num, 17)
 		field.Value = m.SpdcadEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PowerEnabled != false {
 		field := fac.CreateField(mesg.Num, 18)
 		field.Value = m.PowerEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CrankLength != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = m.CrankLength
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Enabled != false {
 		field := fac.CreateField(mesg.Num, 20)
 		field.Value = m.Enabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.BikeSpdAntIdTransType) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = typeconv.ToUint8z[uint8](m.BikeSpdAntIdTransType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.BikeCadAntIdTransType) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = typeconv.ToUint8z[uint8](m.BikeCadAntIdTransType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.BikeSpdcadAntIdTransType) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = typeconv.ToUint8z[uint8](m.BikeSpdcadAntIdTransType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.BikePowerAntIdTransType) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = typeconv.ToUint8z[uint8](m.BikePowerAntIdTransType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.OdometerRollover != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 37)
 		field.Value = m.OdometerRollover
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.FrontGearNum) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 38)
 		field.Value = typeconv.ToUint8z[uint8](m.FrontGearNum)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToSliceUint8z[uint8](m.FrontGear) != nil {
 		field := fac.CreateField(mesg.Num, 39)
 		field.Value = typeconv.ToSliceUint8z[uint8](m.FrontGear)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.RearGearNum) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 40)
 		field.Value = typeconv.ToUint8z[uint8](m.RearGearNum)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToSliceUint8z[uint8](m.RearGear) != nil {
 		field := fac.CreateField(mesg.Num, 41)
 		field.Value = typeconv.ToSliceUint8z[uint8](m.RearGear)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ShimanoDi2Enabled != false {
 		field := fac.CreateField(mesg.Num, 44)
 		field.Value = m.ShimanoDi2Enabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of BikeProfile's valid fields.
-func (m *BikeProfile) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Odometer != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint16z[uint16](m.BikeSpdAntId) != basetype.Uint16zInvalid {
-		size++
-	}
-	if typeconv.ToUint16z[uint16](m.BikeCadAntId) != basetype.Uint16zInvalid {
-		size++
-	}
-	if typeconv.ToUint16z[uint16](m.BikeSpdcadAntId) != basetype.Uint16zInvalid {
-		size++
-	}
-	if typeconv.ToUint16z[uint16](m.BikePowerAntId) != basetype.Uint16zInvalid {
-		size++
-	}
-	if m.CustomWheelsize != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AutoWheelsize != basetype.Uint16Invalid {
-		size++
-	}
-	if m.BikeWeight != basetype.Uint16Invalid {
-		size++
-	}
-	if m.PowerCalFactor != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AutoWheelCal != false {
-		size++
-	}
-	if m.AutoPowerZero != false {
-		size++
-	}
-	if m.Id != basetype.Uint8Invalid {
-		size++
-	}
-	if m.SpdEnabled != false {
-		size++
-	}
-	if m.CadEnabled != false {
-		size++
-	}
-	if m.SpdcadEnabled != false {
-		size++
-	}
-	if m.PowerEnabled != false {
-		size++
-	}
-	if m.CrankLength != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Enabled != false {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.BikeSpdAntIdTransType) != basetype.Uint8zInvalid {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.BikeCadAntIdTransType) != basetype.Uint8zInvalid {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.BikeSpdcadAntIdTransType) != basetype.Uint8zInvalid {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.BikePowerAntIdTransType) != basetype.Uint8zInvalid {
-		size++
-	}
-	if m.OdometerRollover != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.FrontGearNum) != basetype.Uint8zInvalid {
-		size++
-	}
-	if typeconv.ToSliceUint8z[uint8](m.FrontGear) != nil {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.RearGearNum) != basetype.Uint8zInvalid {
-		size++
-	}
-	if typeconv.ToSliceUint8z[uint8](m.RearGear) != nil {
-		size++
-	}
-	if m.ShimanoDi2Enabled != false {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets BikeProfile value.

--- a/profile/mesgdef/blood_pressure_gen.go
+++ b/profile/mesgdef/blood_pressure_gen.go
@@ -70,107 +70,74 @@ func NewBloodPressure(mesg *proto.Message) *BloodPressure {
 
 // ToMesg converts BloodPressure into proto.Message.
 func (m *BloodPressure) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumBloodPressure)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SystolicPressure != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.SystolicPressure
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DiastolicPressure != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.DiastolicPressure
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MeanArterialPressure != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.MeanArterialPressure
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Map3SampleMean != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Map3SampleMean
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MapMorningValues != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.MapMorningValues
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MapEveningValues != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.MapEveningValues
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.HeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.HeartRateType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = typeconv.ToEnum[byte](m.HeartRateType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Status) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = typeconv.ToEnum[byte](m.Status)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.UserProfileIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = typeconv.ToUint16[uint16](m.UserProfileIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of BloodPressure's valid fields.
-func (m *BloodPressure) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.SystolicPressure != basetype.Uint16Invalid {
-		size++
-	}
-	if m.DiastolicPressure != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MeanArterialPressure != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Map3SampleMean != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MapMorningValues != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MapEveningValues != basetype.Uint16Invalid {
-		size++
-	}
-	if m.HeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.HeartRateType) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Status) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.UserProfileIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets BloodPressure value.

--- a/profile/mesgdef/cadence_zone_gen.go
+++ b/profile/mesgdef/cadence_zone_gen.go
@@ -52,43 +52,34 @@ func NewCadenceZone(mesg *proto.Message) *CadenceZone {
 
 // ToMesg converts CadenceZone into proto.Message.
 func (m *CadenceZone) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumCadenceZone)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HighValue != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.HighValue
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of CadenceZone's valid fields.
-func (m *CadenceZone) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.HighValue != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets CadenceZone value.

--- a/profile/mesgdef/camera_event_gen.go
+++ b/profile/mesgdef/camera_event_gen.go
@@ -58,59 +58,44 @@ func NewCameraEvent(mesg *proto.Message) *CameraEvent {
 
 // ToMesg converts CameraEvent into proto.Message.
 func (m *CameraEvent) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumCameraEvent)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.CameraEventType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.CameraEventType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CameraFileUuid != basetype.StringInvalid && m.CameraFileUuid != "" {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.CameraFileUuid
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.CameraOrientation) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToEnum[byte](m.CameraOrientation)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of CameraEvent's valid fields.
-func (m *CameraEvent) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.CameraEventType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.CameraFileUuid != basetype.StringInvalid && m.CameraFileUuid != "" {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.CameraOrientation) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets CameraEvent value.

--- a/profile/mesgdef/capabilities_gen.go
+++ b/profile/mesgdef/capabilities_gen.go
@@ -54,51 +54,39 @@ func NewCapabilities(mesg *proto.Message) *Capabilities {
 
 // ToMesg converts Capabilities into proto.Message.
 func (m *Capabilities) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumCapabilities)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToSliceUint8z[uint8](m.Languages) != nil {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToSliceUint8z[uint8](m.Languages)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToSliceUint8z[uint8](m.Sports) != nil {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToSliceUint8z[uint8](m.Sports)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32z[uint32](m.WorkoutsSupported) != basetype.Uint32zInvalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = typeconv.ToUint32z[uint32](m.WorkoutsSupported)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32z[uint32](m.ConnectivitySupported) != basetype.Uint32zInvalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = typeconv.ToUint32z[uint32](m.ConnectivitySupported)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Capabilities's valid fields.
-func (m *Capabilities) size() byte {
-	var size byte
-	if typeconv.ToSliceUint8z[uint8](m.Languages) != nil {
-		size++
-	}
-	if typeconv.ToSliceUint8z[uint8](m.Sports) != nil {
-		size++
-	}
-	if typeconv.ToUint32z[uint32](m.WorkoutsSupported) != basetype.Uint32zInvalid {
-		size++
-	}
-	if typeconv.ToUint32z[uint32](m.ConnectivitySupported) != basetype.Uint32zInvalid {
-		size++
-	}
-	return size
 }
 
 // SetLanguages sets Capabilities value.

--- a/profile/mesgdef/climb_pro_gen.go
+++ b/profile/mesgdef/climb_pro_gen.go
@@ -62,75 +62,54 @@ func NewClimbPro(mesg *proto.Message) *ClimbPro {
 
 // ToMesg converts ClimbPro into proto.Message.
 func (m *ClimbPro) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumClimbPro)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.PositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.PositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.ClimbProEvent) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToEnum[byte](m.ClimbProEvent)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ClimbNumber != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ClimbNumber
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ClimbCategory != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.ClimbCategory
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.CurrentDist) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.CurrentDist
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of ClimbPro's valid fields.
-func (m *ClimbPro) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.PositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.PositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.ClimbProEvent) != basetype.EnumInvalid {
-		size++
-	}
-	if m.ClimbNumber != basetype.Uint16Invalid {
-		size++
-	}
-	if m.ClimbCategory != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.CurrentDist) != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets ClimbPro value.

--- a/profile/mesgdef/connectivity_gen.go
+++ b/profile/mesgdef/connectivity_gen.go
@@ -72,123 +72,84 @@ func NewConnectivity(mesg *proto.Message) *Connectivity {
 
 // ToMesg converts Connectivity into proto.Message.
 func (m *Connectivity) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumConnectivity)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.BluetoothEnabled != false {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.BluetoothEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BluetoothLeEnabled != false {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.BluetoothLeEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AntEnabled != false {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.AntEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LiveTrackingEnabled != false {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.LiveTrackingEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.WeatherConditionsEnabled != false {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.WeatherConditionsEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.WeatherAlertsEnabled != false {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.WeatherAlertsEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AutoActivityUploadEnabled != false {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.AutoActivityUploadEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CourseDownloadEnabled != false {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.CourseDownloadEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.WorkoutDownloadEnabled != false {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.WorkoutDownloadEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GpsEphemerisDownloadEnabled != false {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.GpsEphemerisDownloadEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.IncidentDetectionEnabled != false {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.IncidentDetectionEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GrouptrackEnabled != false {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = m.GrouptrackEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Connectivity's valid fields.
-func (m *Connectivity) size() byte {
-	var size byte
-	if m.BluetoothEnabled != false {
-		size++
-	}
-	if m.BluetoothLeEnabled != false {
-		size++
-	}
-	if m.AntEnabled != false {
-		size++
-	}
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	if m.LiveTrackingEnabled != false {
-		size++
-	}
-	if m.WeatherConditionsEnabled != false {
-		size++
-	}
-	if m.WeatherAlertsEnabled != false {
-		size++
-	}
-	if m.AutoActivityUploadEnabled != false {
-		size++
-	}
-	if m.CourseDownloadEnabled != false {
-		size++
-	}
-	if m.WorkoutDownloadEnabled != false {
-		size++
-	}
-	if m.GpsEphemerisDownloadEnabled != false {
-		size++
-	}
-	if m.IncidentDetectionEnabled != false {
-		size++
-	}
-	if m.GrouptrackEnabled != false {
-		size++
-	}
-	return size
 }
 
 // SetBluetoothEnabled sets Connectivity value.

--- a/profile/mesgdef/course_gen.go
+++ b/profile/mesgdef/course_gen.go
@@ -54,51 +54,39 @@ func NewCourse(mesg *proto.Message) *Course {
 
 // ToMesg converts Course into proto.Message.
 func (m *Course) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumCourse)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToEnum[byte](m.Sport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32z[uint32](m.Capabilities) != basetype.Uint32zInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = typeconv.ToUint32z[uint32](m.Capabilities)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = typeconv.ToEnum[byte](m.SubSport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Course's valid fields.
-func (m *Course) size() byte {
-	var size byte
-	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	if typeconv.ToUint32z[uint32](m.Capabilities) != basetype.Uint32zInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetSport sets Course value.

--- a/profile/mesgdef/course_point_gen.go
+++ b/profile/mesgdef/course_point_gen.go
@@ -64,83 +64,59 @@ func NewCoursePoint(mesg *proto.Message) *CoursePoint {
 
 // ToMesg converts CoursePoint into proto.Message.
 func (m *CoursePoint) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumCoursePoint)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.PositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.PositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Distance != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Distance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToEnum[byte](m.Type)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Favorite != false {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.Favorite
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of CoursePoint's valid fields.
-func (m *CoursePoint) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.PositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.PositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.Distance != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	if m.Favorite != false {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets CoursePoint value.

--- a/profile/mesgdef/developer_data_id_gen.go
+++ b/profile/mesgdef/developer_data_id_gen.go
@@ -48,57 +48,42 @@ func NewDeveloperDataId(mesg *proto.Message) *DeveloperDataId {
 
 // ToMesg converts DeveloperDataId into proto.Message.
 func (m *DeveloperDataId) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumDeveloperDataId)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.DeveloperId != nil {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.DeveloperId
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ApplicationId != nil {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.ApplicationId
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.ManufacturerId) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToUint16[uint16](m.ManufacturerId)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DeveloperDataIndex != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.DeveloperDataIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ApplicationVersion != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.ApplicationVersion
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	return mesg
-}
-
-// size returns size of DeveloperDataId's valid fields.
-func (m *DeveloperDataId) size() byte {
-	var size byte
-	if m.DeveloperId != nil {
-		size++
-	}
-	if m.ApplicationId != nil {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.ManufacturerId) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.DeveloperDataIndex != basetype.Uint8Invalid {
-		size++
-	}
-	if m.ApplicationVersion != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetDeveloperId sets DeveloperDataId value.

--- a/profile/mesgdef/device_aux_battery_info_gen.go
+++ b/profile/mesgdef/device_aux_battery_info_gen.go
@@ -58,59 +58,44 @@ func NewDeviceAuxBatteryInfo(mesg *proto.Message) *DeviceAuxBatteryInfo {
 
 // ToMesg converts DeviceAuxBatteryInfo into proto.Message.
 func (m *DeviceAuxBatteryInfo) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumDeviceAuxBatteryInfo)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToUint8[uint8](m.DeviceIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BatteryVoltage != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.BatteryVoltage
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.BatteryStatus) != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToUint8[uint8](m.BatteryStatus)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BatteryIdentifier != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.BatteryIdentifier
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of DeviceAuxBatteryInfo's valid fields.
-func (m *DeviceAuxBatteryInfo) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
-		size++
-	}
-	if m.BatteryVoltage != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint8[uint8](m.BatteryStatus) != basetype.Uint8Invalid {
-		size++
-	}
-	if m.BatteryIdentifier != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets DeviceAuxBatteryInfo value.

--- a/profile/mesgdef/device_info_gen.go
+++ b/profile/mesgdef/device_info_gen.go
@@ -86,171 +86,114 @@ func NewDeviceInfo(mesg *proto.Message) *DeviceInfo {
 
 // ToMesg converts DeviceInfo into proto.Message.
 func (m *DeviceInfo) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumDeviceInfo)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToUint8[uint8](m.DeviceIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DeviceType != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.DeviceType
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.Manufacturer) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToUint16[uint16](m.Manufacturer)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32z[uint32](m.SerialNumber) != basetype.Uint32zInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToUint32z[uint32](m.SerialNumber)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Product != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Product
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SoftwareVersion != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.SoftwareVersion
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HardwareVersion != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.HardwareVersion
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CumOperatingTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.CumOperatingTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BatteryVoltage != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.BatteryVoltage
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.BatteryStatus) != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = typeconv.ToUint8[uint8](m.BatteryStatus)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SensorPosition) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 18)
 		field.Value = typeconv.ToEnum[byte](m.SensorPosition)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Descriptor != basetype.StringInvalid && m.Descriptor != "" {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = m.Descriptor
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.AntTransmissionType) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 20)
 		field.Value = typeconv.ToUint8z[uint8](m.AntTransmissionType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16z[uint16](m.AntDeviceNumber) != basetype.Uint16zInvalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = typeconv.ToUint16z[uint16](m.AntDeviceNumber)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.AntNetwork) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = typeconv.ToEnum[byte](m.AntNetwork)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SourceType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 25)
 		field.Value = typeconv.ToEnum[byte](m.SourceType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ProductName != basetype.StringInvalid && m.ProductName != "" {
 		field := fac.CreateField(mesg.Num, 27)
 		field.Value = m.ProductName
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BatteryLevel != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 32)
 		field.Value = m.BatteryLevel
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of DeviceInfo's valid fields.
-func (m *DeviceInfo) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
-		size++
-	}
-	if m.DeviceType != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.Manufacturer) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint32z[uint32](m.SerialNumber) != basetype.Uint32zInvalid {
-		size++
-	}
-	if m.Product != basetype.Uint16Invalid {
-		size++
-	}
-	if m.SoftwareVersion != basetype.Uint16Invalid {
-		size++
-	}
-	if m.HardwareVersion != basetype.Uint8Invalid {
-		size++
-	}
-	if m.CumOperatingTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.BatteryVoltage != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint8[uint8](m.BatteryStatus) != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SensorPosition) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Descriptor != basetype.StringInvalid && m.Descriptor != "" {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.AntTransmissionType) != basetype.Uint8zInvalid {
-		size++
-	}
-	if typeconv.ToUint16z[uint16](m.AntDeviceNumber) != basetype.Uint16zInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.AntNetwork) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SourceType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.ProductName != basetype.StringInvalid && m.ProductName != "" {
-		size++
-	}
-	if m.BatteryLevel != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets DeviceInfo value.

--- a/profile/mesgdef/device_settings_gen.go
+++ b/profile/mesgdef/device_settings_gen.go
@@ -96,211 +96,139 @@ func NewDeviceSettings(mesg *proto.Message) *DeviceSettings {
 
 // ToMesg converts DeviceSettings into proto.Message.
 func (m *DeviceSettings) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumDeviceSettings)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.ActiveTimeZone != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.ActiveTimeZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.UtcOffset != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.UtcOffset
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeOffset != nil {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.TimeOffset
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToSliceEnum[byte](m.TimeMode) != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToSliceEnum[byte](m.TimeMode)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeZoneOffset != nil {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.TimeZoneOffset
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.BacklightMode) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = typeconv.ToEnum[byte](m.BacklightMode)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ActivityTrackerEnabled != false {
 		field := fac.CreateField(mesg.Num, 36)
 		field.Value = m.ActivityTrackerEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.ClockTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 39)
 		field.Value = datetime.ToUint32(m.ClockTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PagesEnabled != nil {
 		field := fac.CreateField(mesg.Num, 40)
 		field.Value = m.PagesEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MoveAlertEnabled != false {
 		field := fac.CreateField(mesg.Num, 46)
 		field.Value = m.MoveAlertEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.DateMode) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 47)
 		field.Value = typeconv.ToEnum[byte](m.DateMode)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.DisplayOrientation) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 55)
 		field.Value = typeconv.ToEnum[byte](m.DisplayOrientation)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.MountingSide) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 56)
 		field.Value = typeconv.ToEnum[byte](m.MountingSide)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DefaultPage != nil {
 		field := fac.CreateField(mesg.Num, 57)
 		field.Value = m.DefaultPage
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AutosyncMinSteps != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 58)
 		field.Value = m.AutosyncMinSteps
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AutosyncMinTime != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 59)
 		field.Value = m.AutosyncMinTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LactateThresholdAutodetectEnabled != false {
 		field := fac.CreateField(mesg.Num, 80)
 		field.Value = m.LactateThresholdAutodetectEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BleAutoUploadEnabled != false {
 		field := fac.CreateField(mesg.Num, 86)
 		field.Value = m.BleAutoUploadEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.AutoSyncFrequency) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 89)
 		field.Value = typeconv.ToEnum[byte](m.AutoSyncFrequency)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.AutoActivityDetect) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 90)
 		field.Value = typeconv.ToUint32[uint32](m.AutoActivityDetect)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NumberOfScreens != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 94)
 		field.Value = m.NumberOfScreens
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SmartNotificationDisplayOrientation) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 95)
 		field.Value = typeconv.ToEnum[byte](m.SmartNotificationDisplayOrientation)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.TapInterface) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 134)
 		field.Value = typeconv.ToEnum[byte](m.TapInterface)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.TapSensitivity) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 174)
 		field.Value = typeconv.ToEnum[byte](m.TapSensitivity)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of DeviceSettings's valid fields.
-func (m *DeviceSettings) size() byte {
-	var size byte
-	if m.ActiveTimeZone != basetype.Uint8Invalid {
-		size++
-	}
-	if m.UtcOffset != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimeOffset != nil {
-		size++
-	}
-	if typeconv.ToSliceEnum[byte](m.TimeMode) != nil {
-		size++
-	}
-	if m.TimeZoneOffset != nil {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.BacklightMode) != basetype.EnumInvalid {
-		size++
-	}
-	if m.ActivityTrackerEnabled != false {
-		size++
-	}
-	if datetime.ToUint32(m.ClockTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.PagesEnabled != nil {
-		size++
-	}
-	if m.MoveAlertEnabled != false {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.DateMode) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.DisplayOrientation) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.MountingSide) != basetype.EnumInvalid {
-		size++
-	}
-	if m.DefaultPage != nil {
-		size++
-	}
-	if m.AutosyncMinSteps != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AutosyncMinTime != basetype.Uint16Invalid {
-		size++
-	}
-	if m.LactateThresholdAutodetectEnabled != false {
-		size++
-	}
-	if m.BleAutoUploadEnabled != false {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.AutoSyncFrequency) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.AutoActivityDetect) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.NumberOfScreens != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SmartNotificationDisplayOrientation) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.TapInterface) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.TapSensitivity) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetActiveTimeZone sets DeviceSettings value.

--- a/profile/mesgdef/dive_alarm_gen.go
+++ b/profile/mesgdef/dive_alarm_gen.go
@@ -72,123 +72,84 @@ func NewDiveAlarm(mesg *proto.Message) *DiveAlarm {
 
 // ToMesg converts DiveAlarm into proto.Message.
 func (m *DiveAlarm) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumDiveAlarm)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Depth != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Depth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Time != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Time
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Enabled != false {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Enabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.AlarmType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToEnum[byte](m.AlarmType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Sound) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToEnum[byte](m.Sound)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToSliceEnum[byte](m.DiveTypes) != nil {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToSliceEnum[byte](m.DiveTypes)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Id != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.Id
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PopupEnabled != false {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.PopupEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TriggerOnDescent != false {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.TriggerOnDescent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TriggerOnAscent != false {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.TriggerOnAscent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Repeating != false {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.Repeating
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Speed != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.Speed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of DiveAlarm's valid fields.
-func (m *DiveAlarm) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Depth != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Time != basetype.Sint32Invalid {
-		size++
-	}
-	if m.Enabled != false {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.AlarmType) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Sound) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToSliceEnum[byte](m.DiveTypes) != nil {
-		size++
-	}
-	if m.Id != basetype.Uint32Invalid {
-		size++
-	}
-	if m.PopupEnabled != false {
-		size++
-	}
-	if m.TriggerOnDescent != false {
-		size++
-	}
-	if m.TriggerOnAscent != false {
-		size++
-	}
-	if m.Repeating != false {
-		size++
-	}
-	if m.Speed != basetype.Sint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets DiveAlarm value.

--- a/profile/mesgdef/dive_apnea_alarm_gen.go
+++ b/profile/mesgdef/dive_apnea_alarm_gen.go
@@ -72,123 +72,84 @@ func NewDiveApneaAlarm(mesg *proto.Message) *DiveApneaAlarm {
 
 // ToMesg converts DiveApneaAlarm into proto.Message.
 func (m *DiveApneaAlarm) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumDiveApneaAlarm)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Depth != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Depth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Time != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Time
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Enabled != false {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Enabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.AlarmType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToEnum[byte](m.AlarmType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Sound) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToEnum[byte](m.Sound)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToSliceEnum[byte](m.DiveTypes) != nil {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToSliceEnum[byte](m.DiveTypes)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Id != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.Id
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PopupEnabled != false {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.PopupEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TriggerOnDescent != false {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.TriggerOnDescent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TriggerOnAscent != false {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.TriggerOnAscent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Repeating != false {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.Repeating
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Speed != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.Speed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of DiveApneaAlarm's valid fields.
-func (m *DiveApneaAlarm) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Depth != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Time != basetype.Sint32Invalid {
-		size++
-	}
-	if m.Enabled != false {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.AlarmType) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Sound) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToSliceEnum[byte](m.DiveTypes) != nil {
-		size++
-	}
-	if m.Id != basetype.Uint32Invalid {
-		size++
-	}
-	if m.PopupEnabled != false {
-		size++
-	}
-	if m.TriggerOnDescent != false {
-		size++
-	}
-	if m.TriggerOnAscent != false {
-		size++
-	}
-	if m.Repeating != false {
-		size++
-	}
-	if m.Speed != basetype.Sint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets DiveApneaAlarm value.

--- a/profile/mesgdef/dive_gas_gen.go
+++ b/profile/mesgdef/dive_gas_gen.go
@@ -56,59 +56,44 @@ func NewDiveGas(mesg *proto.Message) *DiveGas {
 
 // ToMesg converts DiveGas into proto.Message.
 func (m *DiveGas) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumDiveGas)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HeliumContent != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.HeliumContent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.OxygenContent != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.OxygenContent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Status) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToEnum[byte](m.Status)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Mode) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToEnum[byte](m.Mode)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of DiveGas's valid fields.
-func (m *DiveGas) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.HeliumContent != basetype.Uint8Invalid {
-		size++
-	}
-	if m.OxygenContent != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Status) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Mode) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets DiveGas value.

--- a/profile/mesgdef/dive_settings_gen.go
+++ b/profile/mesgdef/dive_settings_gen.go
@@ -118,299 +118,194 @@ func NewDiveSettings(mesg *proto.Message) *DiveSettings {
 
 // ToMesg converts DiveSettings into proto.Message.
 func (m *DiveSettings) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumDiveSettings)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Model) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.Model)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GfLow != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.GfLow
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GfHigh != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.GfHigh
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.WaterType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToEnum[byte](m.WaterType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.WaterDensity) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.WaterDensity
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Po2Warn != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.Po2Warn
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Po2Critical != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.Po2Critical
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Po2Deco != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.Po2Deco
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SafetyStopEnabled != false {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.SafetyStopEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.BottomDepth) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.BottomDepth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BottomTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.BottomTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ApneaCountdownEnabled != false {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = m.ApneaCountdownEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ApneaCountdownTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = m.ApneaCountdownTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.BacklightMode) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = typeconv.ToEnum[byte](m.BacklightMode)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BacklightBrightness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = m.BacklightBrightness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.BacklightTimeout) != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 16)
 		field.Value = typeconv.ToUint8[uint8](m.BacklightTimeout)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RepeatDiveInterval != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 17)
 		field.Value = m.RepeatDiveInterval
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SafetyStopTime != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 18)
 		field.Value = m.SafetyStopTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.HeartRateSourceType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = typeconv.ToEnum[byte](m.HeartRateSourceType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HeartRateSource != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 20)
 		field.Value = m.HeartRateSource
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.TravelGas) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = typeconv.ToUint16[uint16](m.TravelGas)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.CcrLowSetpointSwitchMode) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = typeconv.ToEnum[byte](m.CcrLowSetpointSwitchMode)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CcrLowSetpoint != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = m.CcrLowSetpoint
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CcrLowSetpointDepth != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = m.CcrLowSetpointDepth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.CcrHighSetpointSwitchMode) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 25)
 		field.Value = typeconv.ToEnum[byte](m.CcrHighSetpointSwitchMode)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CcrHighSetpoint != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 26)
 		field.Value = m.CcrHighSetpoint
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CcrHighSetpointDepth != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 27)
 		field.Value = m.CcrHighSetpointDepth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.GasConsumptionDisplay) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 29)
 		field.Value = typeconv.ToEnum[byte](m.GasConsumptionDisplay)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.UpKeyEnabled != false {
 		field := fac.CreateField(mesg.Num, 30)
 		field.Value = m.UpKeyEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.DiveSounds) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 35)
 		field.Value = typeconv.ToEnum[byte](m.DiveSounds)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LastStopMultiple != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 36)
 		field.Value = m.LastStopMultiple
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.NoFlyTimeMode) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 37)
 		field.Value = typeconv.ToEnum[byte](m.NoFlyTimeMode)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of DiveSettings's valid fields.
-func (m *DiveSettings) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Model) != basetype.EnumInvalid {
-		size++
-	}
-	if m.GfLow != basetype.Uint8Invalid {
-		size++
-	}
-	if m.GfHigh != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.WaterType) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.WaterDensity) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Po2Warn != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Po2Critical != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Po2Deco != basetype.Uint8Invalid {
-		size++
-	}
-	if m.SafetyStopEnabled != false {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.BottomDepth) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.BottomTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.ApneaCountdownEnabled != false {
-		size++
-	}
-	if m.ApneaCountdownTime != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.BacklightMode) != basetype.EnumInvalid {
-		size++
-	}
-	if m.BacklightBrightness != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToUint8[uint8](m.BacklightTimeout) != basetype.Uint8Invalid {
-		size++
-	}
-	if m.RepeatDiveInterval != basetype.Uint16Invalid {
-		size++
-	}
-	if m.SafetyStopTime != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.HeartRateSourceType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.HeartRateSource != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.TravelGas) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.CcrLowSetpointSwitchMode) != basetype.EnumInvalid {
-		size++
-	}
-	if m.CcrLowSetpoint != basetype.Uint8Invalid {
-		size++
-	}
-	if m.CcrLowSetpointDepth != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.CcrHighSetpointSwitchMode) != basetype.EnumInvalid {
-		size++
-	}
-	if m.CcrHighSetpoint != basetype.Uint8Invalid {
-		size++
-	}
-	if m.CcrHighSetpointDepth != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.GasConsumptionDisplay) != basetype.EnumInvalid {
-		size++
-	}
-	if m.UpKeyEnabled != false {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.DiveSounds) != basetype.EnumInvalid {
-		size++
-	}
-	if m.LastStopMultiple != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.NoFlyTimeMode) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets DiveSettings value.

--- a/profile/mesgdef/dive_summary_gen.go
+++ b/profile/mesgdef/dive_summary_gen.go
@@ -94,203 +94,134 @@ func NewDiveSummary(mesg *proto.Message) *DiveSummary {
 
 // ToMesg converts DiveSummary into proto.Message.
 func (m *DiveSummary) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumDiveSummary)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.ReferenceMesg) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToUint16[uint16](m.ReferenceMesg)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.ReferenceIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToUint16[uint16](m.ReferenceIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgDepth != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.AvgDepth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxDepth != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.MaxDepth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SurfaceInterval != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.SurfaceInterval
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartCns != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.StartCns
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndCns != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.EndCns
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartN2 != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.StartN2
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndN2 != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.EndN2
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.O2Toxicity != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.O2Toxicity
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DiveNumber != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.DiveNumber
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BottomTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.BottomTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPressureSac != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = m.AvgPressureSac
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgVolumeSac != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = m.AvgVolumeSac
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRmv != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = m.AvgRmv
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DescentTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = m.DescentTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AscentTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 16)
 		field.Value = m.AscentTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgAscentRate != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 17)
 		field.Value = m.AvgAscentRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgDescentRate != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = m.AvgDescentRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxAscentRate != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = m.MaxAscentRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxDescentRate != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = m.MaxDescentRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HangTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 25)
 		field.Value = m.HangTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of DiveSummary's valid fields.
-func (m *DiveSummary) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.ReferenceMesg) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.ReferenceIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgDepth != basetype.Uint32Invalid {
-		size++
-	}
-	if m.MaxDepth != basetype.Uint32Invalid {
-		size++
-	}
-	if m.SurfaceInterval != basetype.Uint32Invalid {
-		size++
-	}
-	if m.StartCns != basetype.Uint8Invalid {
-		size++
-	}
-	if m.EndCns != basetype.Uint8Invalid {
-		size++
-	}
-	if m.StartN2 != basetype.Uint16Invalid {
-		size++
-	}
-	if m.EndN2 != basetype.Uint16Invalid {
-		size++
-	}
-	if m.O2Toxicity != basetype.Uint16Invalid {
-		size++
-	}
-	if m.DiveNumber != basetype.Uint32Invalid {
-		size++
-	}
-	if m.BottomTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgPressureSac != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgVolumeSac != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgRmv != basetype.Uint16Invalid {
-		size++
-	}
-	if m.DescentTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AscentTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgAscentRate != basetype.Sint32Invalid {
-		size++
-	}
-	if m.AvgDescentRate != basetype.Uint32Invalid {
-		size++
-	}
-	if m.MaxAscentRate != basetype.Uint32Invalid {
-		size++
-	}
-	if m.MaxDescentRate != basetype.Uint32Invalid {
-		size++
-	}
-	if m.HangTime != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets DiveSummary value.

--- a/profile/mesgdef/event_gen.go
+++ b/profile/mesgdef/event_gen.go
@@ -86,171 +86,114 @@ func NewEvent(mesg *proto.Message) *Event {
 
 // ToMesg converts Event into proto.Message.
 func (m *Event) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumEvent)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Event) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Event)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.EventType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.EventType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Data16 != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Data16
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Data != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Data
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EventGroup != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.EventGroup
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Score != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.Score
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.OpponentScore != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.OpponentScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.FrontGearNum) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = typeconv.ToUint8z[uint8](m.FrontGearNum)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.FrontGear) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = typeconv.ToUint8z[uint8](m.FrontGear)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.RearGearNum) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = typeconv.ToUint8z[uint8](m.RearGearNum)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.RearGear) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = typeconv.ToUint8z[uint8](m.RearGear)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = typeconv.ToUint8[uint8](m.DeviceIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.ActivityType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = typeconv.ToEnum[byte](m.ActivityType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.StartTimestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = datetime.ToUint32(m.StartTimestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.RadarThreatLevelMax) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = typeconv.ToEnum[byte](m.RadarThreatLevelMax)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RadarThreatCount != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = m.RadarThreatCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RadarThreatAvgApproachSpeed != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = m.RadarThreatAvgApproachSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RadarThreatMaxApproachSpeed != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = m.RadarThreatMaxApproachSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Event's valid fields.
-func (m *Event) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Event) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.EventType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Data16 != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Data != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EventGroup != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Score != basetype.Uint16Invalid {
-		size++
-	}
-	if m.OpponentScore != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.FrontGearNum) != basetype.Uint8zInvalid {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.FrontGear) != basetype.Uint8zInvalid {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.RearGearNum) != basetype.Uint8zInvalid {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.RearGear) != basetype.Uint8zInvalid {
-		size++
-	}
-	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.ActivityType) != basetype.EnumInvalid {
-		size++
-	}
-	if datetime.ToUint32(m.StartTimestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.RadarThreatLevelMax) != basetype.EnumInvalid {
-		size++
-	}
-	if m.RadarThreatCount != basetype.Uint8Invalid {
-		size++
-	}
-	if m.RadarThreatAvgApproachSpeed != basetype.Uint8Invalid {
-		size++
-	}
-	if m.RadarThreatMaxApproachSpeed != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets Event value.

--- a/profile/mesgdef/exd_data_concept_configuration_gen.go
+++ b/profile/mesgdef/exd_data_concept_configuration_gen.go
@@ -68,107 +68,74 @@ func NewExdDataConceptConfiguration(mesg *proto.Message) *ExdDataConceptConfigur
 
 // ToMesg converts ExdDataConceptConfiguration into proto.Message.
 func (m *ExdDataConceptConfiguration) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumExdDataConceptConfiguration)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.ScreenIndex != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.ScreenIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ConceptField != basetype.ByteInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.ConceptField
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FieldId != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.FieldId
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ConceptIndex != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ConceptIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DataPage != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.DataPage
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ConceptKey != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.ConceptKey
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Scaling != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.Scaling
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.DataUnits) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = typeconv.ToEnum[byte](m.DataUnits)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Qualifier) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = typeconv.ToEnum[byte](m.Qualifier)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Descriptor) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = typeconv.ToEnum[byte](m.Descriptor)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.IsSigned != false {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.IsSigned
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of ExdDataConceptConfiguration's valid fields.
-func (m *ExdDataConceptConfiguration) size() byte {
-	var size byte
-	if m.ScreenIndex != basetype.Uint8Invalid {
-		size++
-	}
-	if m.ConceptField != basetype.ByteInvalid {
-		size++
-	}
-	if m.FieldId != basetype.Uint8Invalid {
-		size++
-	}
-	if m.ConceptIndex != basetype.Uint8Invalid {
-		size++
-	}
-	if m.DataPage != basetype.Uint8Invalid {
-		size++
-	}
-	if m.ConceptKey != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Scaling != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.DataUnits) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Qualifier) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Descriptor) != basetype.EnumInvalid {
-		size++
-	}
-	if m.IsSigned != false {
-		size++
-	}
-	return size
 }
 
 // SetScreenIndex sets ExdDataConceptConfiguration value.

--- a/profile/mesgdef/exd_data_field_configuration_gen.go
+++ b/profile/mesgdef/exd_data_field_configuration_gen.go
@@ -58,67 +58,49 @@ func NewExdDataFieldConfiguration(mesg *proto.Message) *ExdDataFieldConfiguratio
 
 // ToMesg converts ExdDataFieldConfiguration into proto.Message.
 func (m *ExdDataFieldConfiguration) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumExdDataFieldConfiguration)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.ScreenIndex != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.ScreenIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ConceptField != basetype.ByteInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.ConceptField
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FieldId != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.FieldId
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ConceptCount != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ConceptCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.DisplayType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToEnum[byte](m.DisplayType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Title != nil {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.Title
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of ExdDataFieldConfiguration's valid fields.
-func (m *ExdDataFieldConfiguration) size() byte {
-	var size byte
-	if m.ScreenIndex != basetype.Uint8Invalid {
-		size++
-	}
-	if m.ConceptField != basetype.ByteInvalid {
-		size++
-	}
-	if m.FieldId != basetype.Uint8Invalid {
-		size++
-	}
-	if m.ConceptCount != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.DisplayType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Title != nil {
-		size++
-	}
-	return size
 }
 
 // SetScreenIndex sets ExdDataFieldConfiguration value.

--- a/profile/mesgdef/exd_screen_configuration_gen.go
+++ b/profile/mesgdef/exd_screen_configuration_gen.go
@@ -54,51 +54,39 @@ func NewExdScreenConfiguration(mesg *proto.Message) *ExdScreenConfiguration {
 
 // ToMesg converts ExdScreenConfiguration into proto.Message.
 func (m *ExdScreenConfiguration) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumExdScreenConfiguration)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.ScreenIndex != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.ScreenIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FieldCount != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.FieldCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Layout) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToEnum[byte](m.Layout)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ScreenEnabled != false {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ScreenEnabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of ExdScreenConfiguration's valid fields.
-func (m *ExdScreenConfiguration) size() byte {
-	var size byte
-	if m.ScreenIndex != basetype.Uint8Invalid {
-		size++
-	}
-	if m.FieldCount != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Layout) != basetype.EnumInvalid {
-		size++
-	}
-	if m.ScreenEnabled != false {
-		size++
-	}
-	return size
 }
 
 // SetScreenIndex sets ExdScreenConfiguration value.

--- a/profile/mesgdef/exercise_title_gen.go
+++ b/profile/mesgdef/exercise_title_gen.go
@@ -54,51 +54,39 @@ func NewExerciseTitle(mesg *proto.Message) *ExerciseTitle {
 
 // ToMesg converts ExerciseTitle into proto.Message.
 func (m *ExerciseTitle) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumExerciseTitle)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.ExerciseCategory) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToUint16[uint16](m.ExerciseCategory)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ExerciseName != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.ExerciseName
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.WktStepName != nil {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.WktStepName
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of ExerciseTitle's valid fields.
-func (m *ExerciseTitle) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.ExerciseCategory) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.ExerciseName != basetype.Uint16Invalid {
-		size++
-	}
-	if m.WktStepName != nil {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets ExerciseTitle value.

--- a/profile/mesgdef/field_capabilities_gen.go
+++ b/profile/mesgdef/field_capabilities_gen.go
@@ -56,59 +56,44 @@ func NewFieldCapabilities(mesg *proto.Message) *FieldCapabilities {
 
 // ToMesg converts FieldCapabilities into proto.Message.
 func (m *FieldCapabilities) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumFieldCapabilities)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.File) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.File)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.MesgNum) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToUint16[uint16](m.MesgNum)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FieldNum != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.FieldNum
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Count != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Count
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of FieldCapabilities's valid fields.
-func (m *FieldCapabilities) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.File) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.MesgNum) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.FieldNum != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Count != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets FieldCapabilities value.

--- a/profile/mesgdef/field_description_gen.go
+++ b/profile/mesgdef/field_description_gen.go
@@ -66,129 +66,87 @@ func NewFieldDescription(mesg *proto.Message) *FieldDescription {
 
 // ToMesg converts FieldDescription into proto.Message.
 func (m *FieldDescription) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumFieldDescription)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.DeveloperDataIndex != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.DeveloperDataIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FieldDefinitionNumber != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.FieldDefinitionNumber
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.FitBaseTypeId) != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToUint8[uint8](m.FitBaseTypeId)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FieldName != nil {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.FieldName
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Array != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Array
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Components != basetype.StringInvalid && m.Components != "" {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.Components
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Scale != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.Scale
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Offset != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.Offset
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Units != nil {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.Units
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Bits != basetype.StringInvalid && m.Bits != "" {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.Bits
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Accumulate != basetype.StringInvalid && m.Accumulate != "" {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.Accumulate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.FitBaseUnitId) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = typeconv.ToUint16[uint16](m.FitBaseUnitId)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.NativeMesgNum) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = typeconv.ToUint16[uint16](m.NativeMesgNum)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NativeFieldNum != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = m.NativeFieldNum
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	return mesg
-}
-
-// size returns size of FieldDescription's valid fields.
-func (m *FieldDescription) size() byte {
-	var size byte
-	if m.DeveloperDataIndex != basetype.Uint8Invalid {
-		size++
-	}
-	if m.FieldDefinitionNumber != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToUint8[uint8](m.FitBaseTypeId) != basetype.Uint8Invalid {
-		size++
-	}
-	if m.FieldName != nil {
-		size++
-	}
-	if m.Array != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Components != basetype.StringInvalid && m.Components != "" {
-		size++
-	}
-	if m.Scale != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Offset != basetype.Sint8Invalid {
-		size++
-	}
-	if m.Units != nil {
-		size++
-	}
-	if m.Bits != basetype.StringInvalid && m.Bits != "" {
-		size++
-	}
-	if m.Accumulate != basetype.StringInvalid && m.Accumulate != "" {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.FitBaseUnitId) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.NativeMesgNum) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.NativeFieldNum != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetDeveloperDataIndex sets FieldDescription value.

--- a/profile/mesgdef/file_capabilities_gen.go
+++ b/profile/mesgdef/file_capabilities_gen.go
@@ -58,67 +58,49 @@ func NewFileCapabilities(mesg *proto.Message) *FileCapabilities {
 
 // ToMesg converts FileCapabilities into proto.Message.
 func (m *FileCapabilities) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumFileCapabilities)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Type)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.Flags) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToUint8z[uint8](m.Flags)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Directory != basetype.StringInvalid && m.Directory != "" {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Directory
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxCount != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.MaxCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxSize != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.MaxSize
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of FileCapabilities's valid fields.
-func (m *FileCapabilities) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.Flags) != basetype.Uint8zInvalid {
-		size++
-	}
-	if m.Directory != basetype.StringInvalid && m.Directory != "" {
-		size++
-	}
-	if m.MaxCount != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxSize != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets FileCapabilities value.

--- a/profile/mesgdef/file_creator_gen.go
+++ b/profile/mesgdef/file_creator_gen.go
@@ -50,35 +50,29 @@ func NewFileCreator(mesg *proto.Message) *FileCreator {
 
 // ToMesg converts FileCreator into proto.Message.
 func (m *FileCreator) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumFileCreator)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.SoftwareVersion != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.SoftwareVersion
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HardwareVersion != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.HardwareVersion
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of FileCreator's valid fields.
-func (m *FileCreator) size() byte {
-	var size byte
-	if m.SoftwareVersion != basetype.Uint16Invalid {
-		size++
-	}
-	if m.HardwareVersion != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetSoftwareVersion sets FileCreator value.

--- a/profile/mesgdef/file_id_gen.go
+++ b/profile/mesgdef/file_id_gen.go
@@ -54,73 +54,52 @@ func NewFileId(mesg *proto.Message) *FileId {
 
 // ToMesg converts FileId into proto.Message.
 func (m *FileId) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumFileId)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Type)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.Manufacturer) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToUint16[uint16](m.Manufacturer)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Product != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Product
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32z[uint32](m.SerialNumber) != basetype.Uint32zInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToUint32z[uint32](m.SerialNumber)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.TimeCreated) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = datetime.ToUint32(m.TimeCreated)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Number != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.Number
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ProductName != basetype.StringInvalid && m.ProductName != "" {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.ProductName
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	return mesg
-}
-
-// size returns size of FileId's valid fields.
-func (m *FileId) size() byte {
-	var size byte
-	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.Manufacturer) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Product != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint32z[uint32](m.SerialNumber) != basetype.Uint32zInvalid {
-		size++
-	}
-	if datetime.ToUint32(m.TimeCreated) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Number != basetype.Uint16Invalid {
-		size++
-	}
-	if m.ProductName != basetype.StringInvalid && m.ProductName != "" {
-		size++
-	}
-	return size
 }
 
 // SetType sets FileId value.

--- a/profile/mesgdef/goal_gen.go
+++ b/profile/mesgdef/goal_gen.go
@@ -74,123 +74,84 @@ func NewGoal(mesg *proto.Message) *Goal {
 
 // ToMesg converts Goal into proto.Message.
 func (m *Goal) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumGoal)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Sport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.SubSport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.StartDate) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = datetime.ToUint32(m.StartDate)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.EndDate) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = datetime.ToUint32(m.EndDate)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToEnum[byte](m.Type)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Value != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.Value
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Repeat != false {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.Repeat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TargetValue != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.TargetValue
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Recurrence) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = typeconv.ToEnum[byte](m.Recurrence)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RecurrenceValue != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.RecurrenceValue
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Enabled != false {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.Enabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Source) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = typeconv.ToEnum[byte](m.Source)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Goal's valid fields.
-func (m *Goal) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
-		size++
-	}
-	if datetime.ToUint32(m.StartDate) != basetype.Uint32Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.EndDate) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Value != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Repeat != false {
-		size++
-	}
-	if m.TargetValue != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Recurrence) != basetype.EnumInvalid {
-		size++
-	}
-	if m.RecurrenceValue != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Enabled != false {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Source) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets Goal value.

--- a/profile/mesgdef/gps_metadata_gen.go
+++ b/profile/mesgdef/gps_metadata_gen.go
@@ -66,91 +66,64 @@ func NewGpsMetadata(mesg *proto.Message) *GpsMetadata {
 
 // ToMesg converts GpsMetadata into proto.Message.
 func (m *GpsMetadata) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumGpsMetadata)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.PositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.PositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.EnhancedAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.EnhancedSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Heading != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.Heading
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.UtcTimestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = datetime.ToUint32(m.UtcTimestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Velocity != nil {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.Velocity
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of GpsMetadata's valid fields.
-func (m *GpsMetadata) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if m.PositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.PositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.EnhancedAltitude != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EnhancedSpeed != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Heading != basetype.Uint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.UtcTimestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Velocity != nil {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets GpsMetadata value.

--- a/profile/mesgdef/gyroscope_data_gen.go
+++ b/profile/mesgdef/gyroscope_data_gen.go
@@ -66,91 +66,64 @@ func NewGyroscopeData(mesg *proto.Message) *GyroscopeData {
 
 // ToMesg converts GyroscopeData into proto.Message.
 func (m *GyroscopeData) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumGyroscopeData)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SampleTimeOffset != nil {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.SampleTimeOffset
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GyroX != nil {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.GyroX
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GyroY != nil {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.GyroY
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GyroZ != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.GyroZ
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibratedGyroX != nil {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.CalibratedGyroX
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibratedGyroY != nil {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.CalibratedGyroY
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibratedGyroZ != nil {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.CalibratedGyroZ
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of GyroscopeData's valid fields.
-func (m *GyroscopeData) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if m.SampleTimeOffset != nil {
-		size++
-	}
-	if m.GyroX != nil {
-		size++
-	}
-	if m.GyroY != nil {
-		size++
-	}
-	if m.GyroZ != nil {
-		size++
-	}
-	if m.CalibratedGyroX != nil {
-		size++
-	}
-	if m.CalibratedGyroY != nil {
-		size++
-	}
-	if m.CalibratedGyroZ != nil {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets GyroscopeData value.

--- a/profile/mesgdef/hr_gen.go
+++ b/profile/mesgdef/hr_gen.go
@@ -60,67 +60,49 @@ func NewHr(mesg *proto.Message) *Hr {
 
 // ToMesg converts Hr into proto.Message.
 func (m *Hr) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumHr)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FractionalTimestamp != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.FractionalTimestamp
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Time256 != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Time256
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FilteredBpm != nil {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.FilteredBpm
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EventTimestamp != nil {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.EventTimestamp
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EventTimestamp12 != nil {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.EventTimestamp12
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Hr's valid fields.
-func (m *Hr) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.FractionalTimestamp != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Time256 != basetype.Uint8Invalid {
-		size++
-	}
-	if m.FilteredBpm != nil {
-		size++
-	}
-	if m.EventTimestamp != nil {
-		size++
-	}
-	if m.EventTimestamp12 != nil {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets Hr value.

--- a/profile/mesgdef/hr_zone_gen.go
+++ b/profile/mesgdef/hr_zone_gen.go
@@ -52,43 +52,34 @@ func NewHrZone(mesg *proto.Message) *HrZone {
 
 // ToMesg converts HrZone into proto.Message.
 func (m *HrZone) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumHrZone)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HighBpm != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.HighBpm
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of HrZone's valid fields.
-func (m *HrZone) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.HighBpm != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets HrZone value.

--- a/profile/mesgdef/hrm_profile_gen.go
+++ b/profile/mesgdef/hrm_profile_gen.go
@@ -56,59 +56,44 @@ func NewHrmProfile(mesg *proto.Message) *HrmProfile {
 
 // ToMesg converts HrmProfile into proto.Message.
 func (m *HrmProfile) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumHrmProfile)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Enabled != false {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Enabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16z[uint16](m.HrmAntId) != basetype.Uint16zInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToUint16z[uint16](m.HrmAntId)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LogHrv != false {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.LogHrv
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.HrmAntIdTransType) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToUint8z[uint8](m.HrmAntIdTransType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of HrmProfile's valid fields.
-func (m *HrmProfile) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Enabled != false {
-		size++
-	}
-	if typeconv.ToUint16z[uint16](m.HrmAntId) != basetype.Uint16zInvalid {
-		size++
-	}
-	if m.LogHrv != false {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.HrmAntIdTransType) != basetype.Uint8zInvalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets HrmProfile value.

--- a/profile/mesgdef/hrv_gen.go
+++ b/profile/mesgdef/hrv_gen.go
@@ -47,27 +47,24 @@ func NewHrv(mesg *proto.Message) *Hrv {
 
 // ToMesg converts Hrv into proto.Message.
 func (m *Hrv) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumHrv)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.Time != nil {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Time
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Hrv's valid fields.
-func (m *Hrv) size() byte {
-	var size byte
-	if m.Time != nil {
-		size++
-	}
-	return size
 }
 
 // SetTime sets Hrv value.

--- a/profile/mesgdef/hrv_status_summary_gen.go
+++ b/profile/mesgdef/hrv_status_summary_gen.go
@@ -64,83 +64,59 @@ func NewHrvStatusSummary(mesg *proto.Message) *HrvStatusSummary {
 
 // ToMesg converts HrvStatusSummary into proto.Message.
 func (m *HrvStatusSummary) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumHrvStatusSummary)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.WeeklyAverage != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.WeeklyAverage
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LastNightAverage != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.LastNightAverage
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LastNight5MinHigh != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.LastNight5MinHigh
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BaselineLowUpper != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.BaselineLowUpper
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BaselineBalancedLower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.BaselineBalancedLower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BaselineBalancedUpper != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.BaselineBalancedUpper
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Status) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = typeconv.ToEnum[byte](m.Status)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of HrvStatusSummary's valid fields.
-func (m *HrvStatusSummary) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.WeeklyAverage != basetype.Uint16Invalid {
-		size++
-	}
-	if m.LastNightAverage != basetype.Uint16Invalid {
-		size++
-	}
-	if m.LastNight5MinHigh != basetype.Uint16Invalid {
-		size++
-	}
-	if m.BaselineLowUpper != basetype.Uint16Invalid {
-		size++
-	}
-	if m.BaselineBalancedLower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.BaselineBalancedUpper != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Status) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets HrvStatusSummary value.

--- a/profile/mesgdef/hrv_value_gen.go
+++ b/profile/mesgdef/hrv_value_gen.go
@@ -52,35 +52,29 @@ func NewHrvValue(mesg *proto.Message) *HrvValue {
 
 // ToMesg converts HrvValue into proto.Message.
 func (m *HrvValue) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumHrvValue)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Value != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Value
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of HrvValue's valid fields.
-func (m *HrvValue) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Value != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets HrvValue value.

--- a/profile/mesgdef/jump_gen.go
+++ b/profile/mesgdef/jump_gen.go
@@ -68,99 +68,69 @@ func NewJump(mesg *proto.Message) *Jump {
 
 // ToMesg converts Jump into proto.Message.
 func (m *Jump) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumJump)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.Distance) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Distance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.Height) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Height
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Rotations != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Rotations
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.HangTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.HangTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.Score) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Score
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.PositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.PositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Speed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.Speed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.EnhancedSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Jump's valid fields.
-func (m *Jump) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.Distance) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.Height) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Rotations != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.HangTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.Score) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.PositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.PositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.Speed != basetype.Uint16Invalid {
-		size++
-	}
-	if m.EnhancedSpeed != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets Jump value.

--- a/profile/mesgdef/lap_gen.go
+++ b/profile/mesgdef/lap_gen.go
@@ -294,1003 +294,634 @@ func NewLap(mesg *proto.Message) *Lap {
 
 // ToMesg converts Lap into proto.Message.
 func (m *Lap) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumLap)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Event) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Event)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.EventType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.EventType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.StartTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = datetime.ToUint32(m.StartTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartPositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.StartPositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartPositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.StartPositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndPositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.EndPositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndPositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.EndPositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalElapsedTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.TotalElapsedTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalTimerTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.TotalTimerTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalDistance != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.TotalDistance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalCycles != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.TotalCycles
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalCalories != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.TotalCalories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalFatCalories != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = m.TotalFatCalories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgSpeed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = m.AvgSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxSpeed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = m.MaxSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = m.AvgHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 16)
 		field.Value = m.MaxHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 17)
 		field.Value = m.AvgCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 18)
 		field.Value = m.MaxCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = m.AvgPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 20)
 		field.Value = m.MaxPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalAscent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = m.TotalAscent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalDescent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = m.TotalDescent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Intensity) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = typeconv.ToEnum[byte](m.Intensity)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.LapTrigger) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = typeconv.ToEnum[byte](m.LapTrigger)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 25)
 		field.Value = typeconv.ToEnum[byte](m.Sport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EventGroup != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 26)
 		field.Value = m.EventGroup
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NumLengths != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 32)
 		field.Value = m.NumLengths
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NormalizedPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 33)
 		field.Value = m.NormalizedPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.LeftRightBalance) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 34)
 		field.Value = typeconv.ToUint16[uint16](m.LeftRightBalance)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FirstLengthIndex != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 35)
 		field.Value = m.FirstLengthIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgStrokeDistance != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 37)
 		field.Value = m.AvgStrokeDistance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SwimStroke) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 38)
 		field.Value = typeconv.ToEnum[byte](m.SwimStroke)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 39)
 		field.Value = typeconv.ToEnum[byte](m.SubSport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NumActiveLengths != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 40)
 		field.Value = m.NumActiveLengths
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalWork != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 41)
 		field.Value = m.TotalWork
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgAltitude != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 42)
 		field.Value = m.AvgAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxAltitude != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 43)
 		field.Value = m.MaxAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GpsAccuracy != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 44)
 		field.Value = m.GpsAccuracy
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 45)
 		field.Value = m.AvgGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPosGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 46)
 		field.Value = m.AvgPosGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgNegGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 47)
 		field.Value = m.AvgNegGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxPosGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 48)
 		field.Value = m.MaxPosGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxNegGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 49)
 		field.Value = m.MaxNegGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgTemperature != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 50)
 		field.Value = m.AvgTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxTemperature != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 51)
 		field.Value = m.MaxTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalMovingTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 52)
 		field.Value = m.TotalMovingTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPosVerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 53)
 		field.Value = m.AvgPosVerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgNegVerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 54)
 		field.Value = m.AvgNegVerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxPosVerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 55)
 		field.Value = m.MaxPosVerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxNegVerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 56)
 		field.Value = m.MaxNegVerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInHrZone != nil {
 		field := fac.CreateField(mesg.Num, 57)
 		field.Value = m.TimeInHrZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInSpeedZone != nil {
 		field := fac.CreateField(mesg.Num, 58)
 		field.Value = m.TimeInSpeedZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInCadenceZone != nil {
 		field := fac.CreateField(mesg.Num, 59)
 		field.Value = m.TimeInCadenceZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInPowerZone != nil {
 		field := fac.CreateField(mesg.Num, 60)
 		field.Value = m.TimeInPowerZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RepetitionNum != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 61)
 		field.Value = m.RepetitionNum
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinAltitude != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 62)
 		field.Value = m.MinAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 63)
 		field.Value = m.MinHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.WktStepIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 71)
 		field.Value = typeconv.ToUint16[uint16](m.WktStepIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.OpponentScore != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 74)
 		field.Value = m.OpponentScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StrokeCount != nil {
 		field := fac.CreateField(mesg.Num, 75)
 		field.Value = m.StrokeCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ZoneCount != nil {
 		field := fac.CreateField(mesg.Num, 76)
 		field.Value = m.ZoneCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgVerticalOscillation != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 77)
 		field.Value = m.AvgVerticalOscillation
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgStanceTimePercent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 78)
 		field.Value = m.AvgStanceTimePercent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgStanceTime != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 79)
 		field.Value = m.AvgStanceTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgFractionalCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 80)
 		field.Value = m.AvgFractionalCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxFractionalCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 81)
 		field.Value = m.MaxFractionalCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalFractionalCycles != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 82)
 		field.Value = m.TotalFractionalCycles
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PlayerScore != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 83)
 		field.Value = m.PlayerScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgTotalHemoglobinConc != nil {
 		field := fac.CreateField(mesg.Num, 84)
 		field.Value = m.AvgTotalHemoglobinConc
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinTotalHemoglobinConc != nil {
 		field := fac.CreateField(mesg.Num, 85)
 		field.Value = m.MinTotalHemoglobinConc
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxTotalHemoglobinConc != nil {
 		field := fac.CreateField(mesg.Num, 86)
 		field.Value = m.MaxTotalHemoglobinConc
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgSaturatedHemoglobinPercent != nil {
 		field := fac.CreateField(mesg.Num, 87)
 		field.Value = m.AvgSaturatedHemoglobinPercent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinSaturatedHemoglobinPercent != nil {
 		field := fac.CreateField(mesg.Num, 88)
 		field.Value = m.MinSaturatedHemoglobinPercent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxSaturatedHemoglobinPercent != nil {
 		field := fac.CreateField(mesg.Num, 89)
 		field.Value = m.MaxSaturatedHemoglobinPercent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftTorqueEffectiveness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 91)
 		field.Value = m.AvgLeftTorqueEffectiveness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightTorqueEffectiveness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 92)
 		field.Value = m.AvgRightTorqueEffectiveness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftPedalSmoothness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 93)
 		field.Value = m.AvgLeftPedalSmoothness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightPedalSmoothness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 94)
 		field.Value = m.AvgRightPedalSmoothness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgCombinedPedalSmoothness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 95)
 		field.Value = m.AvgCombinedPedalSmoothness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeStanding != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 98)
 		field.Value = m.TimeStanding
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StandCount != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 99)
 		field.Value = m.StandCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftPco != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 100)
 		field.Value = m.AvgLeftPco
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightPco != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 101)
 		field.Value = m.AvgRightPco
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftPowerPhase != nil {
 		field := fac.CreateField(mesg.Num, 102)
 		field.Value = m.AvgLeftPowerPhase
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftPowerPhasePeak != nil {
 		field := fac.CreateField(mesg.Num, 103)
 		field.Value = m.AvgLeftPowerPhasePeak
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightPowerPhase != nil {
 		field := fac.CreateField(mesg.Num, 104)
 		field.Value = m.AvgRightPowerPhase
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightPowerPhasePeak != nil {
 		field := fac.CreateField(mesg.Num, 105)
 		field.Value = m.AvgRightPowerPhasePeak
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPowerPosition != nil {
 		field := fac.CreateField(mesg.Num, 106)
 		field.Value = m.AvgPowerPosition
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxPowerPosition != nil {
 		field := fac.CreateField(mesg.Num, 107)
 		field.Value = m.MaxPowerPosition
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgCadencePosition != nil {
 		field := fac.CreateField(mesg.Num, 108)
 		field.Value = m.AvgCadencePosition
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxCadencePosition != nil {
 		field := fac.CreateField(mesg.Num, 109)
 		field.Value = m.MaxCadencePosition
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedAvgSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 110)
 		field.Value = m.EnhancedAvgSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedMaxSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 111)
 		field.Value = m.EnhancedMaxSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedAvgAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 112)
 		field.Value = m.EnhancedAvgAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedMinAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 113)
 		field.Value = m.EnhancedMinAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedMaxAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 114)
 		field.Value = m.EnhancedMaxAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLevMotorPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 115)
 		field.Value = m.AvgLevMotorPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxLevMotorPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 116)
 		field.Value = m.MaxLevMotorPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LevBatteryConsumption != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 117)
 		field.Value = m.LevBatteryConsumption
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgVerticalRatio != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 118)
 		field.Value = m.AvgVerticalRatio
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgStanceTimeBalance != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 119)
 		field.Value = m.AvgStanceTimeBalance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgStepLength != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 120)
 		field.Value = m.AvgStepLength
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgVam != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 121)
 		field.Value = m.AvgVam
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgDepth != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 122)
 		field.Value = m.AvgDepth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxDepth != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 123)
 		field.Value = m.MaxDepth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinTemperature != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 124)
 		field.Value = m.MinTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 136)
 		field.Value = m.EnhancedAvgRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 137)
 		field.Value = m.EnhancedMaxRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRespirationRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 147)
 		field.Value = m.AvgRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxRespirationRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 148)
 		field.Value = m.MaxRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.TotalGrit) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 149)
 		field.Value = m.TotalGrit
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.TotalFlow) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 150)
 		field.Value = m.TotalFlow
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.JumpCount != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 151)
 		field.Value = m.JumpCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.AvgGrit) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 153)
 		field.Value = m.AvgGrit
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.AvgFlow) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 154)
 		field.Value = m.AvgFlow
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalFractionalAscent != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 156)
 		field.Value = m.TotalFractionalAscent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalFractionalDescent != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 157)
 		field.Value = m.TotalFractionalDescent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgCoreTemperature != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 158)
 		field.Value = m.AvgCoreTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinCoreTemperature != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 159)
 		field.Value = m.MinCoreTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxCoreTemperature != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 160)
 		field.Value = m.MaxCoreTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Lap's valid fields.
-func (m *Lap) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Event) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.EventType) != basetype.EnumInvalid {
-		size++
-	}
-	if datetime.ToUint32(m.StartTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.StartPositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.StartPositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.EndPositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.EndPositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.TotalElapsedTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalTimerTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalDistance != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalCycles != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalCalories != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalFatCalories != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgSpeed != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxSpeed != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalAscent != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalDescent != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Intensity) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.LapTrigger) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.EventGroup != basetype.Uint8Invalid {
-		size++
-	}
-	if m.NumLengths != basetype.Uint16Invalid {
-		size++
-	}
-	if m.NormalizedPower != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.LeftRightBalance) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.FirstLengthIndex != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgStrokeDistance != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SwimStroke) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.NumActiveLengths != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalWork != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgAltitude != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxAltitude != basetype.Uint16Invalid {
-		size++
-	}
-	if m.GpsAccuracy != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.AvgPosGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.AvgNegGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MaxPosGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MaxNegGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.AvgTemperature != basetype.Sint8Invalid {
-		size++
-	}
-	if m.MaxTemperature != basetype.Sint8Invalid {
-		size++
-	}
-	if m.TotalMovingTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgPosVerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.AvgNegVerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MaxPosVerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MaxNegVerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.TimeInHrZone != nil {
-		size++
-	}
-	if m.TimeInSpeedZone != nil {
-		size++
-	}
-	if m.TimeInCadenceZone != nil {
-		size++
-	}
-	if m.TimeInPowerZone != nil {
-		size++
-	}
-	if m.RepetitionNum != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MinAltitude != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MinHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.WktStepIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.OpponentScore != basetype.Uint16Invalid {
-		size++
-	}
-	if m.StrokeCount != nil {
-		size++
-	}
-	if m.ZoneCount != nil {
-		size++
-	}
-	if m.AvgVerticalOscillation != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgStanceTimePercent != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgStanceTime != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgFractionalCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxFractionalCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TotalFractionalCycles != basetype.Uint8Invalid {
-		size++
-	}
-	if m.PlayerScore != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgTotalHemoglobinConc != nil {
-		size++
-	}
-	if m.MinTotalHemoglobinConc != nil {
-		size++
-	}
-	if m.MaxTotalHemoglobinConc != nil {
-		size++
-	}
-	if m.AvgSaturatedHemoglobinPercent != nil {
-		size++
-	}
-	if m.MinSaturatedHemoglobinPercent != nil {
-		size++
-	}
-	if m.MaxSaturatedHemoglobinPercent != nil {
-		size++
-	}
-	if m.AvgLeftTorqueEffectiveness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgRightTorqueEffectiveness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgLeftPedalSmoothness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgRightPedalSmoothness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgCombinedPedalSmoothness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TimeStanding != basetype.Uint32Invalid {
-		size++
-	}
-	if m.StandCount != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgLeftPco != basetype.Sint8Invalid {
-		size++
-	}
-	if m.AvgRightPco != basetype.Sint8Invalid {
-		size++
-	}
-	if m.AvgLeftPowerPhase != nil {
-		size++
-	}
-	if m.AvgLeftPowerPhasePeak != nil {
-		size++
-	}
-	if m.AvgRightPowerPhase != nil {
-		size++
-	}
-	if m.AvgRightPowerPhasePeak != nil {
-		size++
-	}
-	if m.AvgPowerPosition != nil {
-		size++
-	}
-	if m.MaxPowerPosition != nil {
-		size++
-	}
-	if m.AvgCadencePosition != nil {
-		size++
-	}
-	if m.MaxCadencePosition != nil {
-		size++
-	}
-	if m.EnhancedAvgSpeed != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EnhancedMaxSpeed != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EnhancedAvgAltitude != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EnhancedMinAltitude != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EnhancedMaxAltitude != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgLevMotorPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxLevMotorPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.LevBatteryConsumption != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgVerticalRatio != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgStanceTimeBalance != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgStepLength != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgVam != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgDepth != basetype.Uint32Invalid {
-		size++
-	}
-	if m.MaxDepth != basetype.Uint32Invalid {
-		size++
-	}
-	if m.MinTemperature != basetype.Sint8Invalid {
-		size++
-	}
-	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid {
-		size++
-	}
-	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgRespirationRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxRespirationRate != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.TotalGrit) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.TotalFlow) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.JumpCount != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.AvgGrit) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.AvgFlow) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalFractionalAscent != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TotalFractionalDescent != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgCoreTemperature != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MinCoreTemperature != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxCoreTemperature != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets Lap value.

--- a/profile/mesgdef/length_gen.go
+++ b/profile/mesgdef/length_gen.go
@@ -92,195 +92,129 @@ func NewLength(mesg *proto.Message) *Length {
 
 // ToMesg converts Length into proto.Message.
 func (m *Length) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumLength)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Event) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Event)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.EventType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.EventType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.StartTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = datetime.ToUint32(m.StartTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalElapsedTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.TotalElapsedTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalTimerTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.TotalTimerTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalStrokes != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.TotalStrokes
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgSpeed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.AvgSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SwimStroke) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = typeconv.ToEnum[byte](m.SwimStroke)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgSwimmingCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.AvgSwimmingCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EventGroup != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.EventGroup
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalCalories != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.TotalCalories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.LengthType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = typeconv.ToEnum[byte](m.LengthType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PlayerScore != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 18)
 		field.Value = m.PlayerScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.OpponentScore != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = m.OpponentScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StrokeCount != nil {
 		field := fac.CreateField(mesg.Num, 20)
 		field.Value = m.StrokeCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ZoneCount != nil {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = m.ZoneCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = m.EnhancedAvgRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = m.EnhancedMaxRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRespirationRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = m.AvgRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxRespirationRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 25)
 		field.Value = m.MaxRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Length's valid fields.
-func (m *Length) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Event) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.EventType) != basetype.EnumInvalid {
-		size++
-	}
-	if datetime.ToUint32(m.StartTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalElapsedTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalTimerTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalStrokes != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgSpeed != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SwimStroke) != basetype.EnumInvalid {
-		size++
-	}
-	if m.AvgSwimmingCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.EventGroup != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TotalCalories != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.LengthType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.PlayerScore != basetype.Uint16Invalid {
-		size++
-	}
-	if m.OpponentScore != basetype.Uint16Invalid {
-		size++
-	}
-	if m.StrokeCount != nil {
-		size++
-	}
-	if m.ZoneCount != nil {
-		size++
-	}
-	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid {
-		size++
-	}
-	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgRespirationRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxRespirationRate != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets Length value.

--- a/profile/mesgdef/magnetometer_data_gen.go
+++ b/profile/mesgdef/magnetometer_data_gen.go
@@ -66,91 +66,64 @@ func NewMagnetometerData(mesg *proto.Message) *MagnetometerData {
 
 // ToMesg converts MagnetometerData into proto.Message.
 func (m *MagnetometerData) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumMagnetometerData)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SampleTimeOffset != nil {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.SampleTimeOffset
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MagX != nil {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.MagX
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MagY != nil {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.MagY
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MagZ != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.MagZ
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibratedMagX != nil {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.CalibratedMagX
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibratedMagY != nil {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.CalibratedMagY
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibratedMagZ != nil {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.CalibratedMagZ
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of MagnetometerData's valid fields.
-func (m *MagnetometerData) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if m.SampleTimeOffset != nil {
-		size++
-	}
-	if m.MagX != nil {
-		size++
-	}
-	if m.MagY != nil {
-		size++
-	}
-	if m.MagZ != nil {
-		size++
-	}
-	if m.CalibratedMagX != nil {
-		size++
-	}
-	if m.CalibratedMagY != nil {
-		size++
-	}
-	if m.CalibratedMagZ != nil {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets MagnetometerData value.

--- a/profile/mesgdef/max_met_data_gen.go
+++ b/profile/mesgdef/max_met_data_gen.go
@@ -64,83 +64,59 @@ func NewMaxMetData(mesg *proto.Message) *MaxMetData {
 
 // ToMesg converts MaxMetData into proto.Message.
 func (m *MaxMetData) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumMaxMetData)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.UpdateTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = datetime.ToUint32(m.UpdateTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Vo2Max != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Vo2Max
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToEnum[byte](m.Sport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = typeconv.ToEnum[byte](m.SubSport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.MaxMetCategory) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = typeconv.ToEnum[byte](m.MaxMetCategory)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibratedData != false {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.CalibratedData
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.HrSource) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = typeconv.ToEnum[byte](m.HrSource)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SpeedSource) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = typeconv.ToEnum[byte](m.SpeedSource)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of MaxMetData's valid fields.
-func (m *MaxMetData) size() byte {
-	var size byte
-	if datetime.ToUint32(m.UpdateTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Vo2Max != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.MaxMetCategory) != basetype.EnumInvalid {
-		size++
-	}
-	if m.CalibratedData != false {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.HrSource) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SpeedSource) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetUpdateTime sets MaxMetData value.

--- a/profile/mesgdef/memo_glob_gen.go
+++ b/profile/mesgdef/memo_glob_gen.go
@@ -58,67 +58,49 @@ func NewMemoGlob(mesg *proto.Message) *MemoGlob {
 
 // ToMesg converts MemoGlob into proto.Message.
 func (m *MemoGlob) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumMemoGlob)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.PartIndex != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 250)
 		field.Value = m.PartIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Memo != nil {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Memo
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.MesgNum) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToUint16[uint16](m.MesgNum)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.ParentIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToUint16[uint16](m.ParentIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FieldNum != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.FieldNum
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToSliceUint8z[uint8](m.Data) != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToSliceUint8z[uint8](m.Data)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of MemoGlob's valid fields.
-func (m *MemoGlob) size() byte {
-	var size byte
-	if m.PartIndex != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Memo != nil {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.MesgNum) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.ParentIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.FieldNum != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToSliceUint8z[uint8](m.Data) != nil {
-		size++
-	}
-	return size
 }
 
 // SetPartIndex sets MemoGlob value.

--- a/profile/mesgdef/mesg_capabilities_gen.go
+++ b/profile/mesgdef/mesg_capabilities_gen.go
@@ -56,59 +56,44 @@ func NewMesgCapabilities(mesg *proto.Message) *MesgCapabilities {
 
 // ToMesg converts MesgCapabilities into proto.Message.
 func (m *MesgCapabilities) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumMesgCapabilities)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.File) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.File)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.MesgNum) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToUint16[uint16](m.MesgNum)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.CountType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToEnum[byte](m.CountType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Count != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Count
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of MesgCapabilities's valid fields.
-func (m *MesgCapabilities) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.File) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.MesgNum) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.CountType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Count != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets MesgCapabilities value.

--- a/profile/mesgdef/mesgdef.go
+++ b/profile/mesgdef/mesgdef.go
@@ -1,6 +1,8 @@
 package mesgdef
 
 import (
+	"sync"
+
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -8,4 +10,11 @@ import (
 type Factory interface {
 	CreateMesgOnly(num typedef.MesgNum) proto.Message
 	CreateField(mesgNum typedef.MesgNum, num byte) proto.Field
+}
+
+var fieldsPool = sync.Pool{
+	New: func() any {
+		fields := [256]proto.Field{}
+		return &fields
+	},
 }

--- a/profile/mesgdef/met_zone_gen.go
+++ b/profile/mesgdef/met_zone_gen.go
@@ -54,51 +54,39 @@ func NewMetZone(mesg *proto.Message) *MetZone {
 
 // ToMesg converts MetZone into proto.Message.
 func (m *MetZone) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumMetZone)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HighBpm != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.HighBpm
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Calories != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Calories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FatCalories != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.FatCalories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of MetZone's valid fields.
-func (m *MetZone) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.HighBpm != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Calories != basetype.Uint16Invalid {
-		size++
-	}
-	if m.FatCalories != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets MetZone value.

--- a/profile/mesgdef/monitoring_gen.go
+++ b/profile/mesgdef/monitoring_gen.go
@@ -106,251 +106,164 @@ func NewMonitoring(mesg *proto.Message) *Monitoring {
 
 // ToMesg converts Monitoring into proto.Message.
 func (m *Monitoring) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumMonitoring)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToUint8[uint8](m.DeviceIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Calories != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Calories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Distance != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Distance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Cycles != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Cycles
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ActiveTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.ActiveTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.ActivityType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToEnum[byte](m.ActivityType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.ActivitySubtype) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = typeconv.ToEnum[byte](m.ActivitySubtype)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.ActivityLevel) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = typeconv.ToEnum[byte](m.ActivityLevel)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Distance16 != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.Distance16
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Cycles16 != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.Cycles16
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ActiveTime16 != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.ActiveTime16
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.LocalTimestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = datetime.ToUint32(m.LocalTimestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Temperature != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = m.Temperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TemperatureMin != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = m.TemperatureMin
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TemperatureMax != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = m.TemperatureMax
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ActivityTime != nil {
 		field := fac.CreateField(mesg.Num, 16)
 		field.Value = m.ActivityTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ActiveCalories != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = m.ActiveCalories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CurrentActivityTypeIntensity != basetype.ByteInvalid {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = m.CurrentActivityTypeIntensity
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMin8 != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 25)
 		field.Value = m.TimestampMin8
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Timestamp16 != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 26)
 		field.Value = m.Timestamp16
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 27)
 		field.Value = m.HeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Intensity != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 28)
 		field.Value = m.Intensity
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DurationMin != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 29)
 		field.Value = m.DurationMin
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Duration != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 30)
 		field.Value = m.Duration
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Ascent != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 31)
 		field.Value = m.Ascent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Descent != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 32)
 		field.Value = m.Descent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ModerateActivityMinutes != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 33)
 		field.Value = m.ModerateActivityMinutes
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.VigorousActivityMinutes != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 34)
 		field.Value = m.VigorousActivityMinutes
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Monitoring's valid fields.
-func (m *Monitoring) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Calories != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Distance != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Cycles != basetype.Uint32Invalid {
-		size++
-	}
-	if m.ActiveTime != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.ActivityType) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.ActivitySubtype) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.ActivityLevel) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Distance16 != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Cycles16 != basetype.Uint16Invalid {
-		size++
-	}
-	if m.ActiveTime16 != basetype.Uint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.LocalTimestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Temperature != basetype.Sint16Invalid {
-		size++
-	}
-	if m.TemperatureMin != basetype.Sint16Invalid {
-		size++
-	}
-	if m.TemperatureMax != basetype.Sint16Invalid {
-		size++
-	}
-	if m.ActivityTime != nil {
-		size++
-	}
-	if m.ActiveCalories != basetype.Uint16Invalid {
-		size++
-	}
-	if m.CurrentActivityTypeIntensity != basetype.ByteInvalid {
-		size++
-	}
-	if m.TimestampMin8 != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Timestamp16 != basetype.Uint16Invalid {
-		size++
-	}
-	if m.HeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Intensity != basetype.Uint8Invalid {
-		size++
-	}
-	if m.DurationMin != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Duration != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Ascent != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Descent != basetype.Uint32Invalid {
-		size++
-	}
-	if m.ModerateActivityMinutes != basetype.Uint16Invalid {
-		size++
-	}
-	if m.VigorousActivityMinutes != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets Monitoring value.

--- a/profile/mesgdef/monitoring_hr_data_gen.go
+++ b/profile/mesgdef/monitoring_hr_data_gen.go
@@ -54,43 +54,34 @@ func NewMonitoringHrData(mesg *proto.Message) *MonitoringHrData {
 
 // ToMesg converts MonitoringHrData into proto.Message.
 func (m *MonitoringHrData) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumMonitoringHrData)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RestingHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.RestingHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CurrentDayRestingHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.CurrentDayRestingHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of MonitoringHrData's valid fields.
-func (m *MonitoringHrData) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.RestingHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.CurrentDayRestingHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets MonitoringHrData value.

--- a/profile/mesgdef/monitoring_info_gen.go
+++ b/profile/mesgdef/monitoring_info_gen.go
@@ -60,67 +60,49 @@ func NewMonitoringInfo(mesg *proto.Message) *MonitoringInfo {
 
 // ToMesg converts MonitoringInfo into proto.Message.
 func (m *MonitoringInfo) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumMonitoringInfo)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.LocalTimestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = datetime.ToUint32(m.LocalTimestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToSliceEnum[byte](m.ActivityType) != nil {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToSliceEnum[byte](m.ActivityType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CyclesToDistance != nil {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.CyclesToDistance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CyclesToCalories != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.CyclesToCalories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RestingMetabolicRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.RestingMetabolicRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of MonitoringInfo's valid fields.
-func (m *MonitoringInfo) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.LocalTimestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToSliceEnum[byte](m.ActivityType) != nil {
-		size++
-	}
-	if m.CyclesToDistance != nil {
-		size++
-	}
-	if m.CyclesToCalories != nil {
-		size++
-	}
-	if m.RestingMetabolicRate != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets MonitoringInfo value.

--- a/profile/mesgdef/nmea_sentence_gen.go
+++ b/profile/mesgdef/nmea_sentence_gen.go
@@ -54,43 +54,34 @@ func NewNmeaSentence(mesg *proto.Message) *NmeaSentence {
 
 // ToMesg converts NmeaSentence into proto.Message.
 func (m *NmeaSentence) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumNmeaSentence)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Sentence != basetype.StringInvalid && m.Sentence != "" {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Sentence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of NmeaSentence's valid fields.
-func (m *NmeaSentence) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Sentence != basetype.StringInvalid && m.Sentence != "" {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets NmeaSentence value.

--- a/profile/mesgdef/obdii_data_gen.go
+++ b/profile/mesgdef/obdii_data_gen.go
@@ -66,91 +66,64 @@ func NewObdiiData(mesg *proto.Message) *ObdiiData {
 
 // ToMesg converts ObdiiData into proto.Message.
 func (m *ObdiiData) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumObdiiData)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeOffset != nil {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.TimeOffset
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Pid != basetype.ByteInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Pid
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RawData != nil {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.RawData
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PidDataSize != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.PidDataSize
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SystemTime != nil {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.SystemTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.StartTimestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = datetime.ToUint32(m.StartTimestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartTimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.StartTimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of ObdiiData's valid fields.
-func (m *ObdiiData) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TimeOffset != nil {
-		size++
-	}
-	if m.Pid != basetype.ByteInvalid {
-		size++
-	}
-	if m.RawData != nil {
-		size++
-	}
-	if m.PidDataSize != nil {
-		size++
-	}
-	if m.SystemTime != nil {
-		size++
-	}
-	if datetime.ToUint32(m.StartTimestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.StartTimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets ObdiiData value.

--- a/profile/mesgdef/ohr_settings_gen.go
+++ b/profile/mesgdef/ohr_settings_gen.go
@@ -52,35 +52,29 @@ func NewOhrSettings(mesg *proto.Message) *OhrSettings {
 
 // ToMesg converts OhrSettings into proto.Message.
 func (m *OhrSettings) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumOhrSettings)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Enabled) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Enabled)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of OhrSettings's valid fields.
-func (m *OhrSettings) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Enabled) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets OhrSettings value.

--- a/profile/mesgdef/one_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/one_d_sensor_calibration_gen.go
@@ -60,67 +60,49 @@ func NewOneDSensorCalibration(mesg *proto.Message) *OneDSensorCalibration {
 
 // ToMesg converts OneDSensorCalibration into proto.Message.
 func (m *OneDSensorCalibration) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumOneDSensorCalibration)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SensorType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.SensorType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibrationFactor != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.CalibrationFactor
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibrationDivisor != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.CalibrationDivisor
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LevelShift != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.LevelShift
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.OffsetCal != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.OffsetCal
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of OneDSensorCalibration's valid fields.
-func (m *OneDSensorCalibration) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SensorType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.CalibrationFactor != basetype.Uint32Invalid {
-		size++
-	}
-	if m.CalibrationDivisor != basetype.Uint32Invalid {
-		size++
-	}
-	if m.LevelShift != basetype.Uint32Invalid {
-		size++
-	}
-	if m.OffsetCal != basetype.Sint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets OneDSensorCalibration value.

--- a/profile/mesgdef/power_zone_gen.go
+++ b/profile/mesgdef/power_zone_gen.go
@@ -52,43 +52,34 @@ func NewPowerZone(mesg *proto.Message) *PowerZone {
 
 // ToMesg converts PowerZone into proto.Message.
 func (m *PowerZone) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumPowerZone)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HighValue != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.HighValue
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of PowerZone's valid fields.
-func (m *PowerZone) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.HighValue != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets PowerZone value.

--- a/profile/mesgdef/record_gen.go
+++ b/profile/mesgdef/record_gen.go
@@ -216,691 +216,439 @@ func NewRecord(mesg *proto.Message) *Record {
 
 // ToMesg converts Record into proto.Message.
 func (m *Record) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumRecord)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.PositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.PositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Altitude != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Altitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.HeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Cadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Cadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Distance != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.Distance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Speed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.Speed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Power != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.Power
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CompressedSpeedDistance != nil {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.CompressedSpeedDistance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Grade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.Grade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Resistance != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.Resistance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeFromCourse != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.TimeFromCourse
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CycleLength != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = m.CycleLength
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Temperature != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = m.Temperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Speed1S != nil {
 		field := fac.CreateField(mesg.Num, 17)
 		field.Value = m.Speed1S
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Cycles != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 18)
 		field.Value = m.Cycles
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalCycles != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = m.TotalCycles
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CompressedAccumulatedPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 28)
 		field.Value = m.CompressedAccumulatedPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AccumulatedPower != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 29)
 		field.Value = m.AccumulatedPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.LeftRightBalance) != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 30)
 		field.Value = typeconv.ToUint8[uint8](m.LeftRightBalance)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GpsAccuracy != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 31)
 		field.Value = m.GpsAccuracy
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.VerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 32)
 		field.Value = m.VerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Calories != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 33)
 		field.Value = m.Calories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.VerticalOscillation != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 39)
 		field.Value = m.VerticalOscillation
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StanceTimePercent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 40)
 		field.Value = m.StanceTimePercent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StanceTime != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 41)
 		field.Value = m.StanceTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.ActivityType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 42)
 		field.Value = typeconv.ToEnum[byte](m.ActivityType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LeftTorqueEffectiveness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 43)
 		field.Value = m.LeftTorqueEffectiveness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RightTorqueEffectiveness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 44)
 		field.Value = m.RightTorqueEffectiveness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LeftPedalSmoothness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 45)
 		field.Value = m.LeftPedalSmoothness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RightPedalSmoothness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 46)
 		field.Value = m.RightPedalSmoothness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CombinedPedalSmoothness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 47)
 		field.Value = m.CombinedPedalSmoothness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Time128 != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 48)
 		field.Value = m.Time128
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.StrokeType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 49)
 		field.Value = typeconv.ToEnum[byte](m.StrokeType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Zone != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 50)
 		field.Value = m.Zone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BallSpeed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 51)
 		field.Value = m.BallSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Cadence256 != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 52)
 		field.Value = m.Cadence256
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FractionalCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 53)
 		field.Value = m.FractionalCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalHemoglobinConc != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 54)
 		field.Value = m.TotalHemoglobinConc
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalHemoglobinConcMin != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 55)
 		field.Value = m.TotalHemoglobinConcMin
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalHemoglobinConcMax != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 56)
 		field.Value = m.TotalHemoglobinConcMax
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SaturatedHemoglobinPercent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 57)
 		field.Value = m.SaturatedHemoglobinPercent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SaturatedHemoglobinPercentMin != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 58)
 		field.Value = m.SaturatedHemoglobinPercentMin
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SaturatedHemoglobinPercentMax != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 59)
 		field.Value = m.SaturatedHemoglobinPercentMax
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 62)
 		field.Value = typeconv.ToUint8[uint8](m.DeviceIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LeftPco != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 67)
 		field.Value = m.LeftPco
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RightPco != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 68)
 		field.Value = m.RightPco
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LeftPowerPhase != nil {
 		field := fac.CreateField(mesg.Num, 69)
 		field.Value = m.LeftPowerPhase
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LeftPowerPhasePeak != nil {
 		field := fac.CreateField(mesg.Num, 70)
 		field.Value = m.LeftPowerPhasePeak
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RightPowerPhase != nil {
 		field := fac.CreateField(mesg.Num, 71)
 		field.Value = m.RightPowerPhase
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RightPowerPhasePeak != nil {
 		field := fac.CreateField(mesg.Num, 72)
 		field.Value = m.RightPowerPhasePeak
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 73)
 		field.Value = m.EnhancedSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 78)
 		field.Value = m.EnhancedAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BatterySoc != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 81)
 		field.Value = m.BatterySoc
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MotorPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 82)
 		field.Value = m.MotorPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.VerticalRatio != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 83)
 		field.Value = m.VerticalRatio
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StanceTimeBalance != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 84)
 		field.Value = m.StanceTimeBalance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StepLength != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 85)
 		field.Value = m.StepLength
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CycleLength16 != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 87)
 		field.Value = m.CycleLength16
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AbsolutePressure != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 91)
 		field.Value = m.AbsolutePressure
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Depth != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 92)
 		field.Value = m.Depth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NextStopDepth != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 93)
 		field.Value = m.NextStopDepth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NextStopTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 94)
 		field.Value = m.NextStopTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeToSurface != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 95)
 		field.Value = m.TimeToSurface
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NdlTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 96)
 		field.Value = m.NdlTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CnsLoad != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 97)
 		field.Value = m.CnsLoad
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.N2Load != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 98)
 		field.Value = m.N2Load
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RespirationRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 99)
 		field.Value = m.RespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 108)
 		field.Value = m.EnhancedRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.Grit) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 114)
 		field.Value = m.Grit
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.Flow) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 115)
 		field.Value = m.Flow
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CurrentStress != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 116)
 		field.Value = m.CurrentStress
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EbikeTravelRange != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 117)
 		field.Value = m.EbikeTravelRange
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EbikeBatteryLevel != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 118)
 		field.Value = m.EbikeBatteryLevel
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EbikeAssistMode != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 119)
 		field.Value = m.EbikeAssistMode
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EbikeAssistLevelPercent != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 120)
 		field.Value = m.EbikeAssistLevelPercent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AirTimeRemaining != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 123)
 		field.Value = m.AirTimeRemaining
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PressureSac != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 124)
 		field.Value = m.PressureSac
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.VolumeSac != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 125)
 		field.Value = m.VolumeSac
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Rmv != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 126)
 		field.Value = m.Rmv
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AscentRate != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 127)
 		field.Value = m.AscentRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Po2 != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 129)
 		field.Value = m.Po2
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CoreTemperature != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 139)
 		field.Value = m.CoreTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Record's valid fields.
-func (m *Record) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.PositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.PositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.Altitude != basetype.Uint16Invalid {
-		size++
-	}
-	if m.HeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Cadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Distance != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Speed != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Power != basetype.Uint16Invalid {
-		size++
-	}
-	if m.CompressedSpeedDistance != nil {
-		size++
-	}
-	if m.Grade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.Resistance != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TimeFromCourse != basetype.Sint32Invalid {
-		size++
-	}
-	if m.CycleLength != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Temperature != basetype.Sint8Invalid {
-		size++
-	}
-	if m.Speed1S != nil {
-		size++
-	}
-	if m.Cycles != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TotalCycles != basetype.Uint32Invalid {
-		size++
-	}
-	if m.CompressedAccumulatedPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AccumulatedPower != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint8[uint8](m.LeftRightBalance) != basetype.Uint8Invalid {
-		size++
-	}
-	if m.GpsAccuracy != basetype.Uint8Invalid {
-		size++
-	}
-	if m.VerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.Calories != basetype.Uint16Invalid {
-		size++
-	}
-	if m.VerticalOscillation != basetype.Uint16Invalid {
-		size++
-	}
-	if m.StanceTimePercent != basetype.Uint16Invalid {
-		size++
-	}
-	if m.StanceTime != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.ActivityType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.LeftTorqueEffectiveness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.RightTorqueEffectiveness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.LeftPedalSmoothness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.RightPedalSmoothness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.CombinedPedalSmoothness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Time128 != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.StrokeType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Zone != basetype.Uint8Invalid {
-		size++
-	}
-	if m.BallSpeed != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Cadence256 != basetype.Uint16Invalid {
-		size++
-	}
-	if m.FractionalCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TotalHemoglobinConc != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalHemoglobinConcMin != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalHemoglobinConcMax != basetype.Uint16Invalid {
-		size++
-	}
-	if m.SaturatedHemoglobinPercent != basetype.Uint16Invalid {
-		size++
-	}
-	if m.SaturatedHemoglobinPercentMin != basetype.Uint16Invalid {
-		size++
-	}
-	if m.SaturatedHemoglobinPercentMax != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
-		size++
-	}
-	if m.LeftPco != basetype.Sint8Invalid {
-		size++
-	}
-	if m.RightPco != basetype.Sint8Invalid {
-		size++
-	}
-	if m.LeftPowerPhase != nil {
-		size++
-	}
-	if m.LeftPowerPhasePeak != nil {
-		size++
-	}
-	if m.RightPowerPhase != nil {
-		size++
-	}
-	if m.RightPowerPhasePeak != nil {
-		size++
-	}
-	if m.EnhancedSpeed != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EnhancedAltitude != basetype.Uint32Invalid {
-		size++
-	}
-	if m.BatterySoc != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MotorPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.VerticalRatio != basetype.Uint16Invalid {
-		size++
-	}
-	if m.StanceTimeBalance != basetype.Uint16Invalid {
-		size++
-	}
-	if m.StepLength != basetype.Uint16Invalid {
-		size++
-	}
-	if m.CycleLength16 != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AbsolutePressure != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Depth != basetype.Uint32Invalid {
-		size++
-	}
-	if m.NextStopDepth != basetype.Uint32Invalid {
-		size++
-	}
-	if m.NextStopTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimeToSurface != basetype.Uint32Invalid {
-		size++
-	}
-	if m.NdlTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.CnsLoad != basetype.Uint8Invalid {
-		size++
-	}
-	if m.N2Load != basetype.Uint16Invalid {
-		size++
-	}
-	if m.RespirationRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.EnhancedRespirationRate != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.Grit) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.Flow) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.CurrentStress != basetype.Uint16Invalid {
-		size++
-	}
-	if m.EbikeTravelRange != basetype.Uint16Invalid {
-		size++
-	}
-	if m.EbikeBatteryLevel != basetype.Uint8Invalid {
-		size++
-	}
-	if m.EbikeAssistMode != basetype.Uint8Invalid {
-		size++
-	}
-	if m.EbikeAssistLevelPercent != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AirTimeRemaining != basetype.Uint32Invalid {
-		size++
-	}
-	if m.PressureSac != basetype.Uint16Invalid {
-		size++
-	}
-	if m.VolumeSac != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Rmv != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AscentRate != basetype.Sint32Invalid {
-		size++
-	}
-	if m.Po2 != basetype.Uint8Invalid {
-		size++
-	}
-	if m.CoreTemperature != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets Record value.

--- a/profile/mesgdef/respiration_rate_gen.go
+++ b/profile/mesgdef/respiration_rate_gen.go
@@ -52,35 +52,29 @@ func NewRespirationRate(mesg *proto.Message) *RespirationRate {
 
 // ToMesg converts RespirationRate into proto.Message.
 func (m *RespirationRate) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumRespirationRate)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RespirationRate != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.RespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of RespirationRate's valid fields.
-func (m *RespirationRate) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.RespirationRate != basetype.Sint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets RespirationRate value.

--- a/profile/mesgdef/schedule_gen.go
+++ b/profile/mesgdef/schedule_gen.go
@@ -62,75 +62,54 @@ func NewSchedule(mesg *proto.Message) *Schedule {
 
 // ToMesg converts Schedule into proto.Message.
 func (m *Schedule) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSchedule)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.Manufacturer) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToUint16[uint16](m.Manufacturer)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Product != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Product
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32z[uint32](m.SerialNumber) != basetype.Uint32zInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToUint32z[uint32](m.SerialNumber)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.TimeCreated) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = datetime.ToUint32(m.TimeCreated)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Completed != false {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Completed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToEnum[byte](m.Type)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.ScheduledTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = datetime.ToUint32(m.ScheduledTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Schedule's valid fields.
-func (m *Schedule) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.Manufacturer) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Product != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint32z[uint32](m.SerialNumber) != basetype.Uint32zInvalid {
-		size++
-	}
-	if datetime.ToUint32(m.TimeCreated) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Completed != false {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
-		size++
-	}
-	if datetime.ToUint32(m.ScheduledTime) != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetManufacturer sets Schedule value.

--- a/profile/mesgdef/sdm_profile_gen.go
+++ b/profile/mesgdef/sdm_profile_gen.go
@@ -62,83 +62,59 @@ func NewSdmProfile(mesg *proto.Message) *SdmProfile {
 
 // ToMesg converts SdmProfile into proto.Message.
 func (m *SdmProfile) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSdmProfile)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Enabled != false {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Enabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16z[uint16](m.SdmAntId) != basetype.Uint16zInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToUint16z[uint16](m.SdmAntId)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SdmCalFactor != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.SdmCalFactor
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Odometer != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Odometer
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SpeedSource != false {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.SpeedSource
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.SdmAntIdTransType) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToUint8z[uint8](m.SdmAntIdTransType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.OdometerRollover != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.OdometerRollover
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of SdmProfile's valid fields.
-func (m *SdmProfile) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Enabled != false {
-		size++
-	}
-	if typeconv.ToUint16z[uint16](m.SdmAntId) != basetype.Uint16zInvalid {
-		size++
-	}
-	if m.SdmCalFactor != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Odometer != basetype.Uint32Invalid {
-		size++
-	}
-	if m.SpeedSource != false {
-		size++
-	}
-	if typeconv.ToUint8z[uint8](m.SdmAntIdTransType) != basetype.Uint8zInvalid {
-		size++
-	}
-	if m.OdometerRollover != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets SdmProfile value.

--- a/profile/mesgdef/segment_file_gen.go
+++ b/profile/mesgdef/segment_file_gen.go
@@ -64,91 +64,64 @@ func NewSegmentFile(mesg *proto.Message) *SegmentFile {
 
 // ToMesg converts SegmentFile into proto.Message.
 func (m *SegmentFile) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSegmentFile)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FileUuid != basetype.StringInvalid && m.FileUuid != "" {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.FileUuid
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Enabled != false {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Enabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.UserProfilePrimaryKey != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.UserProfilePrimaryKey
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToSliceEnum[byte](m.LeaderType) != nil {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = typeconv.ToSliceEnum[byte](m.LeaderType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LeaderGroupPrimaryKey != nil {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.LeaderGroupPrimaryKey
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LeaderActivityId != nil {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.LeaderActivityId
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LeaderActivityIdString != nil {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.LeaderActivityIdString
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DefaultRaceLeader != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.DefaultRaceLeader
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of SegmentFile's valid fields.
-func (m *SegmentFile) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.FileUuid != basetype.StringInvalid && m.FileUuid != "" {
-		size++
-	}
-	if m.Enabled != false {
-		size++
-	}
-	if m.UserProfilePrimaryKey != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToSliceEnum[byte](m.LeaderType) != nil {
-		size++
-	}
-	if m.LeaderGroupPrimaryKey != nil {
-		size++
-	}
-	if m.LeaderActivityId != nil {
-		size++
-	}
-	if m.LeaderActivityIdString != nil {
-		size++
-	}
-	if m.DefaultRaceLeader != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets SegmentFile value.

--- a/profile/mesgdef/segment_id_gen.go
+++ b/profile/mesgdef/segment_id_gen.go
@@ -64,91 +64,64 @@ func NewSegmentId(mesg *proto.Message) *SegmentId {
 
 // ToMesg converts SegmentId into proto.Message.
 func (m *SegmentId) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSegmentId)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Uuid != basetype.StringInvalid && m.Uuid != "" {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Uuid
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToEnum[byte](m.Sport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Enabled != false {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Enabled
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.UserProfilePrimaryKey != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.UserProfilePrimaryKey
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DeviceId != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.DeviceId
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DefaultRaceLeader != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.DefaultRaceLeader
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.DeleteStatus) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = typeconv.ToEnum[byte](m.DeleteStatus)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SelectionType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = typeconv.ToEnum[byte](m.SelectionType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of SegmentId's valid fields.
-func (m *SegmentId) size() byte {
-	var size byte
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	if m.Uuid != basetype.StringInvalid && m.Uuid != "" {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Enabled != false {
-		size++
-	}
-	if m.UserProfilePrimaryKey != basetype.Uint32Invalid {
-		size++
-	}
-	if m.DeviceId != basetype.Uint32Invalid {
-		size++
-	}
-	if m.DefaultRaceLeader != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.DeleteStatus) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SelectionType) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetName sets SegmentId value.

--- a/profile/mesgdef/segment_lap_gen.go
+++ b/profile/mesgdef/segment_lap_gen.go
@@ -238,779 +238,494 @@ func NewSegmentLap(mesg *proto.Message) *SegmentLap {
 
 // ToMesg converts SegmentLap into proto.Message.
 func (m *SegmentLap) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSegmentLap)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Event) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Event)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.EventType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.EventType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.StartTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = datetime.ToUint32(m.StartTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartPositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.StartPositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartPositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.StartPositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndPositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.EndPositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndPositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.EndPositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalElapsedTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.TotalElapsedTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalTimerTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.TotalTimerTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalDistance != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.TotalDistance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalCycles != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.TotalCycles
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalCalories != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.TotalCalories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalFatCalories != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = m.TotalFatCalories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgSpeed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = m.AvgSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxSpeed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = m.MaxSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = m.AvgHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 16)
 		field.Value = m.MaxHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 17)
 		field.Value = m.AvgCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 18)
 		field.Value = m.MaxCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = m.AvgPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 20)
 		field.Value = m.MaxPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalAscent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = m.TotalAscent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalDescent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = m.TotalDescent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = typeconv.ToEnum[byte](m.Sport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EventGroup != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = m.EventGroup
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NecLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 25)
 		field.Value = m.NecLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NecLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 26)
 		field.Value = m.NecLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SwcLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 27)
 		field.Value = m.SwcLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SwcLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 28)
 		field.Value = m.SwcLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 29)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NormalizedPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 30)
 		field.Value = m.NormalizedPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.LeftRightBalance) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 31)
 		field.Value = typeconv.ToUint16[uint16](m.LeftRightBalance)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 32)
 		field.Value = typeconv.ToEnum[byte](m.SubSport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalWork != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 33)
 		field.Value = m.TotalWork
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgAltitude != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 34)
 		field.Value = m.AvgAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxAltitude != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 35)
 		field.Value = m.MaxAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GpsAccuracy != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 36)
 		field.Value = m.GpsAccuracy
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 37)
 		field.Value = m.AvgGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPosGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 38)
 		field.Value = m.AvgPosGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgNegGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 39)
 		field.Value = m.AvgNegGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxPosGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 40)
 		field.Value = m.MaxPosGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxNegGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 41)
 		field.Value = m.MaxNegGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgTemperature != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 42)
 		field.Value = m.AvgTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxTemperature != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 43)
 		field.Value = m.MaxTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalMovingTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 44)
 		field.Value = m.TotalMovingTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPosVerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 45)
 		field.Value = m.AvgPosVerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgNegVerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 46)
 		field.Value = m.AvgNegVerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxPosVerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 47)
 		field.Value = m.MaxPosVerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxNegVerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 48)
 		field.Value = m.MaxNegVerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInHrZone != nil {
 		field := fac.CreateField(mesg.Num, 49)
 		field.Value = m.TimeInHrZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInSpeedZone != nil {
 		field := fac.CreateField(mesg.Num, 50)
 		field.Value = m.TimeInSpeedZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInCadenceZone != nil {
 		field := fac.CreateField(mesg.Num, 51)
 		field.Value = m.TimeInCadenceZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInPowerZone != nil {
 		field := fac.CreateField(mesg.Num, 52)
 		field.Value = m.TimeInPowerZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RepetitionNum != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 53)
 		field.Value = m.RepetitionNum
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinAltitude != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 54)
 		field.Value = m.MinAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 55)
 		field.Value = m.MinHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ActiveTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 56)
 		field.Value = m.ActiveTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.WktStepIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 57)
 		field.Value = typeconv.ToUint16[uint16](m.WktStepIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SportEvent) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 58)
 		field.Value = typeconv.ToEnum[byte](m.SportEvent)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftTorqueEffectiveness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 59)
 		field.Value = m.AvgLeftTorqueEffectiveness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightTorqueEffectiveness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 60)
 		field.Value = m.AvgRightTorqueEffectiveness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftPedalSmoothness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 61)
 		field.Value = m.AvgLeftPedalSmoothness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightPedalSmoothness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 62)
 		field.Value = m.AvgRightPedalSmoothness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgCombinedPedalSmoothness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 63)
 		field.Value = m.AvgCombinedPedalSmoothness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Status) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 64)
 		field.Value = typeconv.ToEnum[byte](m.Status)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Uuid != basetype.StringInvalid && m.Uuid != "" {
 		field := fac.CreateField(mesg.Num, 65)
 		field.Value = m.Uuid
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgFractionalCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 66)
 		field.Value = m.AvgFractionalCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxFractionalCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 67)
 		field.Value = m.MaxFractionalCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalFractionalCycles != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 68)
 		field.Value = m.TotalFractionalCycles
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FrontGearShiftCount != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 69)
 		field.Value = m.FrontGearShiftCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RearGearShiftCount != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 70)
 		field.Value = m.RearGearShiftCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeStanding != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 71)
 		field.Value = m.TimeStanding
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StandCount != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 72)
 		field.Value = m.StandCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftPco != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 73)
 		field.Value = m.AvgLeftPco
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightPco != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 74)
 		field.Value = m.AvgRightPco
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftPowerPhase != nil {
 		field := fac.CreateField(mesg.Num, 75)
 		field.Value = m.AvgLeftPowerPhase
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftPowerPhasePeak != nil {
 		field := fac.CreateField(mesg.Num, 76)
 		field.Value = m.AvgLeftPowerPhasePeak
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightPowerPhase != nil {
 		field := fac.CreateField(mesg.Num, 77)
 		field.Value = m.AvgRightPowerPhase
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightPowerPhasePeak != nil {
 		field := fac.CreateField(mesg.Num, 78)
 		field.Value = m.AvgRightPowerPhasePeak
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPowerPosition != nil {
 		field := fac.CreateField(mesg.Num, 79)
 		field.Value = m.AvgPowerPosition
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxPowerPosition != nil {
 		field := fac.CreateField(mesg.Num, 80)
 		field.Value = m.MaxPowerPosition
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgCadencePosition != nil {
 		field := fac.CreateField(mesg.Num, 81)
 		field.Value = m.AvgCadencePosition
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxCadencePosition != nil {
 		field := fac.CreateField(mesg.Num, 82)
 		field.Value = m.MaxCadencePosition
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.Manufacturer) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 83)
 		field.Value = typeconv.ToUint16[uint16](m.Manufacturer)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.TotalGrit) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 84)
 		field.Value = m.TotalGrit
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.TotalFlow) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 85)
 		field.Value = m.TotalFlow
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.AvgGrit) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 86)
 		field.Value = m.AvgGrit
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.AvgFlow) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 87)
 		field.Value = m.AvgFlow
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalFractionalAscent != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 89)
 		field.Value = m.TotalFractionalAscent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalFractionalDescent != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 90)
 		field.Value = m.TotalFractionalDescent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedAvgAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 91)
 		field.Value = m.EnhancedAvgAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedMaxAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 92)
 		field.Value = m.EnhancedMaxAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedMinAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 93)
 		field.Value = m.EnhancedMinAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of SegmentLap's valid fields.
-func (m *SegmentLap) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Event) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.EventType) != basetype.EnumInvalid {
-		size++
-	}
-	if datetime.ToUint32(m.StartTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.StartPositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.StartPositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.EndPositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.EndPositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.TotalElapsedTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalTimerTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalDistance != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalCycles != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalCalories != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalFatCalories != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgSpeed != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxSpeed != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalAscent != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalDescent != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.EventGroup != basetype.Uint8Invalid {
-		size++
-	}
-	if m.NecLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.NecLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.SwcLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.SwcLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	if m.NormalizedPower != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.LeftRightBalance) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.TotalWork != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgAltitude != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxAltitude != basetype.Uint16Invalid {
-		size++
-	}
-	if m.GpsAccuracy != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.AvgPosGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.AvgNegGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MaxPosGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MaxNegGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.AvgTemperature != basetype.Sint8Invalid {
-		size++
-	}
-	if m.MaxTemperature != basetype.Sint8Invalid {
-		size++
-	}
-	if m.TotalMovingTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgPosVerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.AvgNegVerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MaxPosVerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MaxNegVerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.TimeInHrZone != nil {
-		size++
-	}
-	if m.TimeInSpeedZone != nil {
-		size++
-	}
-	if m.TimeInCadenceZone != nil {
-		size++
-	}
-	if m.TimeInPowerZone != nil {
-		size++
-	}
-	if m.RepetitionNum != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MinAltitude != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MinHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.ActiveTime != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.WktStepIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SportEvent) != basetype.EnumInvalid {
-		size++
-	}
-	if m.AvgLeftTorqueEffectiveness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgRightTorqueEffectiveness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgLeftPedalSmoothness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgRightPedalSmoothness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgCombinedPedalSmoothness != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Status) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Uuid != basetype.StringInvalid && m.Uuid != "" {
-		size++
-	}
-	if m.AvgFractionalCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxFractionalCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TotalFractionalCycles != basetype.Uint8Invalid {
-		size++
-	}
-	if m.FrontGearShiftCount != basetype.Uint16Invalid {
-		size++
-	}
-	if m.RearGearShiftCount != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TimeStanding != basetype.Uint32Invalid {
-		size++
-	}
-	if m.StandCount != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgLeftPco != basetype.Sint8Invalid {
-		size++
-	}
-	if m.AvgRightPco != basetype.Sint8Invalid {
-		size++
-	}
-	if m.AvgLeftPowerPhase != nil {
-		size++
-	}
-	if m.AvgLeftPowerPhasePeak != nil {
-		size++
-	}
-	if m.AvgRightPowerPhase != nil {
-		size++
-	}
-	if m.AvgRightPowerPhasePeak != nil {
-		size++
-	}
-	if m.AvgPowerPosition != nil {
-		size++
-	}
-	if m.MaxPowerPosition != nil {
-		size++
-	}
-	if m.AvgCadencePosition != nil {
-		size++
-	}
-	if m.MaxCadencePosition != nil {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.Manufacturer) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.TotalGrit) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.TotalFlow) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.AvgGrit) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.AvgFlow) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalFractionalAscent != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TotalFractionalDescent != basetype.Uint8Invalid {
-		size++
-	}
-	if m.EnhancedAvgAltitude != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EnhancedMaxAltitude != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EnhancedMinAltitude != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets SegmentLap value.

--- a/profile/mesgdef/segment_leaderboard_entry_gen.go
+++ b/profile/mesgdef/segment_leaderboard_entry_gen.go
@@ -60,75 +60,54 @@ func NewSegmentLeaderboardEntry(mesg *proto.Message) *SegmentLeaderboardEntry {
 
 // ToMesg converts SegmentLeaderboardEntry into proto.Message.
 func (m *SegmentLeaderboardEntry) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSegmentLeaderboardEntry)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.Type)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GroupPrimaryKey != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.GroupPrimaryKey
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ActivityId != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ActivityId
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SegmentTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.SegmentTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ActivityIdString != basetype.StringInvalid && m.ActivityIdString != "" {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.ActivityIdString
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of SegmentLeaderboardEntry's valid fields.
-func (m *SegmentLeaderboardEntry) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
-		size++
-	}
-	if m.GroupPrimaryKey != basetype.Uint32Invalid {
-		size++
-	}
-	if m.ActivityId != basetype.Uint32Invalid {
-		size++
-	}
-	if m.SegmentTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.ActivityIdString != basetype.StringInvalid && m.ActivityIdString != "" {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets SegmentLeaderboardEntry value.

--- a/profile/mesgdef/segment_point_gen.go
+++ b/profile/mesgdef/segment_point_gen.go
@@ -60,75 +60,54 @@ func NewSegmentPoint(mesg *proto.Message) *SegmentPoint {
 
 // ToMesg converts SegmentPoint into proto.Message.
 func (m *SegmentPoint) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSegmentPoint)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.PositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.PositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Distance != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Distance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Altitude != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Altitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LeaderTime != nil {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.LeaderTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.EnhancedAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of SegmentPoint's valid fields.
-func (m *SegmentPoint) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.PositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.PositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.Distance != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Altitude != basetype.Uint16Invalid {
-		size++
-	}
-	if m.LeaderTime != nil {
-		size++
-	}
-	if m.EnhancedAltitude != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets SegmentPoint value.

--- a/profile/mesgdef/session_gen.go
+++ b/profile/mesgdef/session_gen.go
@@ -356,1251 +356,789 @@ func NewSession(mesg *proto.Message) *Session {
 
 // ToMesg converts Session into proto.Message.
 func (m *Session) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSession)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Event) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Event)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.EventType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.EventType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.StartTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = datetime.ToUint32(m.StartTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartPositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.StartPositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartPositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.StartPositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToEnum[byte](m.Sport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = typeconv.ToEnum[byte](m.SubSport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalElapsedTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.TotalElapsedTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalTimerTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.TotalTimerTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalDistance != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.TotalDistance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalCycles != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.TotalCycles
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalCalories != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.TotalCalories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalFatCalories != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = m.TotalFatCalories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgSpeed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = m.AvgSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxSpeed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = m.MaxSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 16)
 		field.Value = m.AvgHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 17)
 		field.Value = m.MaxHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 18)
 		field.Value = m.AvgCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = m.MaxCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 20)
 		field.Value = m.AvgPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = m.MaxPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalAscent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = m.TotalAscent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalDescent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = m.TotalDescent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalTrainingEffect != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = m.TotalTrainingEffect
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FirstLapIndex != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 25)
 		field.Value = m.FirstLapIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NumLaps != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 26)
 		field.Value = m.NumLaps
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EventGroup != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 27)
 		field.Value = m.EventGroup
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Trigger) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 28)
 		field.Value = typeconv.ToEnum[byte](m.Trigger)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NecLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 29)
 		field.Value = m.NecLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NecLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 30)
 		field.Value = m.NecLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SwcLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 31)
 		field.Value = m.SwcLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SwcLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 32)
 		field.Value = m.SwcLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NumLengths != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 33)
 		field.Value = m.NumLengths
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NormalizedPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 34)
 		field.Value = m.NormalizedPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TrainingStressScore != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 35)
 		field.Value = m.TrainingStressScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.IntensityFactor != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 36)
 		field.Value = m.IntensityFactor
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.LeftRightBalance) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 37)
 		field.Value = typeconv.ToUint16[uint16](m.LeftRightBalance)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndPositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 38)
 		field.Value = m.EndPositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndPositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 39)
 		field.Value = m.EndPositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgStrokeCount != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 41)
 		field.Value = m.AvgStrokeCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgStrokeDistance != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 42)
 		field.Value = m.AvgStrokeDistance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SwimStroke) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 43)
 		field.Value = typeconv.ToEnum[byte](m.SwimStroke)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PoolLength != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 44)
 		field.Value = m.PoolLength
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ThresholdPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 45)
 		field.Value = m.ThresholdPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.PoolLengthUnit) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 46)
 		field.Value = typeconv.ToEnum[byte](m.PoolLengthUnit)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NumActiveLengths != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 47)
 		field.Value = m.NumActiveLengths
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalWork != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 48)
 		field.Value = m.TotalWork
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgAltitude != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 49)
 		field.Value = m.AvgAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxAltitude != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 50)
 		field.Value = m.MaxAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GpsAccuracy != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 51)
 		field.Value = m.GpsAccuracy
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 52)
 		field.Value = m.AvgGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPosGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 53)
 		field.Value = m.AvgPosGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgNegGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 54)
 		field.Value = m.AvgNegGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxPosGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 55)
 		field.Value = m.MaxPosGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxNegGrade != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 56)
 		field.Value = m.MaxNegGrade
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgTemperature != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 57)
 		field.Value = m.AvgTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxTemperature != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 58)
 		field.Value = m.MaxTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalMovingTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 59)
 		field.Value = m.TotalMovingTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPosVerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 60)
 		field.Value = m.AvgPosVerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgNegVerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 61)
 		field.Value = m.AvgNegVerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxPosVerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 62)
 		field.Value = m.MaxPosVerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxNegVerticalSpeed != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 63)
 		field.Value = m.MaxNegVerticalSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 64)
 		field.Value = m.MinHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInHrZone != nil {
 		field := fac.CreateField(mesg.Num, 65)
 		field.Value = m.TimeInHrZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInSpeedZone != nil {
 		field := fac.CreateField(mesg.Num, 66)
 		field.Value = m.TimeInSpeedZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInCadenceZone != nil {
 		field := fac.CreateField(mesg.Num, 67)
 		field.Value = m.TimeInCadenceZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInPowerZone != nil {
 		field := fac.CreateField(mesg.Num, 68)
 		field.Value = m.TimeInPowerZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLapTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 69)
 		field.Value = m.AvgLapTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BestLapIndex != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 70)
 		field.Value = m.BestLapIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinAltitude != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 71)
 		field.Value = m.MinAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PlayerScore != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 82)
 		field.Value = m.PlayerScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.OpponentScore != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 83)
 		field.Value = m.OpponentScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.OpponentName != basetype.StringInvalid && m.OpponentName != "" {
 		field := fac.CreateField(mesg.Num, 84)
 		field.Value = m.OpponentName
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StrokeCount != nil {
 		field := fac.CreateField(mesg.Num, 85)
 		field.Value = m.StrokeCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ZoneCount != nil {
 		field := fac.CreateField(mesg.Num, 86)
 		field.Value = m.ZoneCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxBallSpeed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 87)
 		field.Value = m.MaxBallSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgBallSpeed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 88)
 		field.Value = m.AvgBallSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgVerticalOscillation != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 89)
 		field.Value = m.AvgVerticalOscillation
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgStanceTimePercent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 90)
 		field.Value = m.AvgStanceTimePercent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgStanceTime != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 91)
 		field.Value = m.AvgStanceTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgFractionalCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 92)
 		field.Value = m.AvgFractionalCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxFractionalCadence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 93)
 		field.Value = m.MaxFractionalCadence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalFractionalCycles != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 94)
 		field.Value = m.TotalFractionalCycles
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgTotalHemoglobinConc != nil {
 		field := fac.CreateField(mesg.Num, 95)
 		field.Value = m.AvgTotalHemoglobinConc
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinTotalHemoglobinConc != nil {
 		field := fac.CreateField(mesg.Num, 96)
 		field.Value = m.MinTotalHemoglobinConc
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxTotalHemoglobinConc != nil {
 		field := fac.CreateField(mesg.Num, 97)
 		field.Value = m.MaxTotalHemoglobinConc
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgSaturatedHemoglobinPercent != nil {
 		field := fac.CreateField(mesg.Num, 98)
 		field.Value = m.AvgSaturatedHemoglobinPercent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinSaturatedHemoglobinPercent != nil {
 		field := fac.CreateField(mesg.Num, 99)
 		field.Value = m.MinSaturatedHemoglobinPercent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxSaturatedHemoglobinPercent != nil {
 		field := fac.CreateField(mesg.Num, 100)
 		field.Value = m.MaxSaturatedHemoglobinPercent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftTorqueEffectiveness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 101)
 		field.Value = m.AvgLeftTorqueEffectiveness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightTorqueEffectiveness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 102)
 		field.Value = m.AvgRightTorqueEffectiveness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftPedalSmoothness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 103)
 		field.Value = m.AvgLeftPedalSmoothness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightPedalSmoothness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 104)
 		field.Value = m.AvgRightPedalSmoothness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgCombinedPedalSmoothness != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 105)
 		field.Value = m.AvgCombinedPedalSmoothness
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SportProfileName != basetype.StringInvalid && m.SportProfileName != "" {
 		field := fac.CreateField(mesg.Num, 110)
 		field.Value = m.SportProfileName
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SportIndex != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 111)
 		field.Value = m.SportIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeStanding != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 112)
 		field.Value = m.TimeStanding
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StandCount != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 113)
 		field.Value = m.StandCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftPco != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 114)
 		field.Value = m.AvgLeftPco
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightPco != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 115)
 		field.Value = m.AvgRightPco
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftPowerPhase != nil {
 		field := fac.CreateField(mesg.Num, 116)
 		field.Value = m.AvgLeftPowerPhase
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLeftPowerPhasePeak != nil {
 		field := fac.CreateField(mesg.Num, 117)
 		field.Value = m.AvgLeftPowerPhasePeak
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightPowerPhase != nil {
 		field := fac.CreateField(mesg.Num, 118)
 		field.Value = m.AvgRightPowerPhase
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRightPowerPhasePeak != nil {
 		field := fac.CreateField(mesg.Num, 119)
 		field.Value = m.AvgRightPowerPhasePeak
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgPowerPosition != nil {
 		field := fac.CreateField(mesg.Num, 120)
 		field.Value = m.AvgPowerPosition
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxPowerPosition != nil {
 		field := fac.CreateField(mesg.Num, 121)
 		field.Value = m.MaxPowerPosition
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgCadencePosition != nil {
 		field := fac.CreateField(mesg.Num, 122)
 		field.Value = m.AvgCadencePosition
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxCadencePosition != nil {
 		field := fac.CreateField(mesg.Num, 123)
 		field.Value = m.MaxCadencePosition
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedAvgSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 124)
 		field.Value = m.EnhancedAvgSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedMaxSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 125)
 		field.Value = m.EnhancedMaxSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedAvgAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 126)
 		field.Value = m.EnhancedAvgAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedMinAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 127)
 		field.Value = m.EnhancedMinAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedMaxAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 128)
 		field.Value = m.EnhancedMaxAltitude
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgLevMotorPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 129)
 		field.Value = m.AvgLevMotorPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxLevMotorPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 130)
 		field.Value = m.MaxLevMotorPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LevBatteryConsumption != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 131)
 		field.Value = m.LevBatteryConsumption
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgVerticalRatio != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 132)
 		field.Value = m.AvgVerticalRatio
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgStanceTimeBalance != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 133)
 		field.Value = m.AvgStanceTimeBalance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgStepLength != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 134)
 		field.Value = m.AvgStepLength
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalAnaerobicTrainingEffect != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 137)
 		field.Value = m.TotalAnaerobicTrainingEffect
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgVam != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 139)
 		field.Value = m.AvgVam
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgDepth != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 140)
 		field.Value = m.AvgDepth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxDepth != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 141)
 		field.Value = m.MaxDepth
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SurfaceInterval != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 142)
 		field.Value = m.SurfaceInterval
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartCns != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 143)
 		field.Value = m.StartCns
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndCns != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 144)
 		field.Value = m.EndCns
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartN2 != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 145)
 		field.Value = m.StartN2
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndN2 != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 146)
 		field.Value = m.EndN2
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgRespirationRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 147)
 		field.Value = m.AvgRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxRespirationRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 148)
 		field.Value = m.MaxRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinRespirationRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 149)
 		field.Value = m.MinRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinTemperature != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 150)
 		field.Value = m.MinTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.O2Toxicity != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 155)
 		field.Value = m.O2Toxicity
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DiveNumber != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 156)
 		field.Value = m.DiveNumber
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TrainingLoadPeak != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 168)
 		field.Value = m.TrainingLoadPeak
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 169)
 		field.Value = m.EnhancedAvgRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 170)
 		field.Value = m.EnhancedMaxRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EnhancedMinRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 180)
 		field.Value = m.EnhancedMinRespirationRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.TotalGrit) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 181)
 		field.Value = m.TotalGrit
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.TotalFlow) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 182)
 		field.Value = m.TotalFlow
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.JumpCount != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 183)
 		field.Value = m.JumpCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.AvgGrit) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 186)
 		field.Value = m.AvgGrit
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.AvgFlow) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 187)
 		field.Value = m.AvgFlow
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgSpo2 != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 194)
 		field.Value = m.AvgSpo2
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgStress != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 195)
 		field.Value = m.AvgStress
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SdrrHrv != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 197)
 		field.Value = m.SdrrHrv
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RmssdHrv != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 198)
 		field.Value = m.RmssdHrv
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalFractionalAscent != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 199)
 		field.Value = m.TotalFractionalAscent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalFractionalDescent != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 200)
 		field.Value = m.TotalFractionalDescent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgCoreTemperature != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 208)
 		field.Value = m.AvgCoreTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MinCoreTemperature != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 209)
 		field.Value = m.MinCoreTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxCoreTemperature != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 210)
 		field.Value = m.MaxCoreTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Session's valid fields.
-func (m *Session) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Event) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.EventType) != basetype.EnumInvalid {
-		size++
-	}
-	if datetime.ToUint32(m.StartTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.StartPositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.StartPositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.TotalElapsedTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalTimerTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalDistance != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalCycles != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalCalories != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalFatCalories != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgSpeed != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxSpeed != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalAscent != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalDescent != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalTrainingEffect != basetype.Uint8Invalid {
-		size++
-	}
-	if m.FirstLapIndex != basetype.Uint16Invalid {
-		size++
-	}
-	if m.NumLaps != basetype.Uint16Invalid {
-		size++
-	}
-	if m.EventGroup != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Trigger) != basetype.EnumInvalid {
-		size++
-	}
-	if m.NecLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.NecLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.SwcLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.SwcLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.NumLengths != basetype.Uint16Invalid {
-		size++
-	}
-	if m.NormalizedPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TrainingStressScore != basetype.Uint16Invalid {
-		size++
-	}
-	if m.IntensityFactor != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.LeftRightBalance) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.EndPositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.EndPositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.AvgStrokeCount != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgStrokeDistance != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SwimStroke) != basetype.EnumInvalid {
-		size++
-	}
-	if m.PoolLength != basetype.Uint16Invalid {
-		size++
-	}
-	if m.ThresholdPower != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.PoolLengthUnit) != basetype.EnumInvalid {
-		size++
-	}
-	if m.NumActiveLengths != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalWork != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgAltitude != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxAltitude != basetype.Uint16Invalid {
-		size++
-	}
-	if m.GpsAccuracy != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.AvgPosGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.AvgNegGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MaxPosGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MaxNegGrade != basetype.Sint16Invalid {
-		size++
-	}
-	if m.AvgTemperature != basetype.Sint8Invalid {
-		size++
-	}
-	if m.MaxTemperature != basetype.Sint8Invalid {
-		size++
-	}
-	if m.TotalMovingTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgPosVerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.AvgNegVerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MaxPosVerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MaxNegVerticalSpeed != basetype.Sint16Invalid {
-		size++
-	}
-	if m.MinHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TimeInHrZone != nil {
-		size++
-	}
-	if m.TimeInSpeedZone != nil {
-		size++
-	}
-	if m.TimeInCadenceZone != nil {
-		size++
-	}
-	if m.TimeInPowerZone != nil {
-		size++
-	}
-	if m.AvgLapTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.BestLapIndex != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MinAltitude != basetype.Uint16Invalid {
-		size++
-	}
-	if m.PlayerScore != basetype.Uint16Invalid {
-		size++
-	}
-	if m.OpponentScore != basetype.Uint16Invalid {
-		size++
-	}
-	if m.OpponentName != basetype.StringInvalid && m.OpponentName != "" {
-		size++
-	}
-	if m.StrokeCount != nil {
-		size++
-	}
-	if m.ZoneCount != nil {
-		size++
-	}
-	if m.MaxBallSpeed != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgBallSpeed != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgVerticalOscillation != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgStanceTimePercent != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgStanceTime != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgFractionalCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxFractionalCadence != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TotalFractionalCycles != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgTotalHemoglobinConc != nil {
-		size++
-	}
-	if m.MinTotalHemoglobinConc != nil {
-		size++
-	}
-	if m.MaxTotalHemoglobinConc != nil {
-		size++
-	}
-	if m.AvgSaturatedHemoglobinPercent != nil {
-		size++
-	}
-	if m.MinSaturatedHemoglobinPercent != nil {
-		size++
-	}
-	if m.MaxSaturatedHemoglobinPercent != nil {
-		size++
-	}
-	if m.AvgLeftTorqueEffectiveness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgRightTorqueEffectiveness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgLeftPedalSmoothness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgRightPedalSmoothness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgCombinedPedalSmoothness != basetype.Uint8Invalid {
-		size++
-	}
-	if m.SportProfileName != basetype.StringInvalid && m.SportProfileName != "" {
-		size++
-	}
-	if m.SportIndex != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TimeStanding != basetype.Uint32Invalid {
-		size++
-	}
-	if m.StandCount != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgLeftPco != basetype.Sint8Invalid {
-		size++
-	}
-	if m.AvgRightPco != basetype.Sint8Invalid {
-		size++
-	}
-	if m.AvgLeftPowerPhase != nil {
-		size++
-	}
-	if m.AvgLeftPowerPhasePeak != nil {
-		size++
-	}
-	if m.AvgRightPowerPhase != nil {
-		size++
-	}
-	if m.AvgRightPowerPhasePeak != nil {
-		size++
-	}
-	if m.AvgPowerPosition != nil {
-		size++
-	}
-	if m.MaxPowerPosition != nil {
-		size++
-	}
-	if m.AvgCadencePosition != nil {
-		size++
-	}
-	if m.MaxCadencePosition != nil {
-		size++
-	}
-	if m.EnhancedAvgSpeed != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EnhancedMaxSpeed != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EnhancedAvgAltitude != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EnhancedMinAltitude != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EnhancedMaxAltitude != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgLevMotorPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxLevMotorPower != basetype.Uint16Invalid {
-		size++
-	}
-	if m.LevBatteryConsumption != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgVerticalRatio != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgStanceTimeBalance != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgStepLength != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalAnaerobicTrainingEffect != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgVam != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgDepth != basetype.Uint32Invalid {
-		size++
-	}
-	if m.MaxDepth != basetype.Uint32Invalid {
-		size++
-	}
-	if m.SurfaceInterval != basetype.Uint32Invalid {
-		size++
-	}
-	if m.StartCns != basetype.Uint8Invalid {
-		size++
-	}
-	if m.EndCns != basetype.Uint8Invalid {
-		size++
-	}
-	if m.StartN2 != basetype.Uint16Invalid {
-		size++
-	}
-	if m.EndN2 != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgRespirationRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxRespirationRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MinRespirationRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MinTemperature != basetype.Sint8Invalid {
-		size++
-	}
-	if m.O2Toxicity != basetype.Uint16Invalid {
-		size++
-	}
-	if m.DiveNumber != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TrainingLoadPeak != basetype.Sint32Invalid {
-		size++
-	}
-	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid {
-		size++
-	}
-	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid {
-		size++
-	}
-	if m.EnhancedMinRespirationRate != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.TotalGrit) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.TotalFlow) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.JumpCount != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.AvgGrit) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.AvgFlow) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgSpo2 != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgStress != basetype.Uint8Invalid {
-		size++
-	}
-	if m.SdrrHrv != basetype.Uint8Invalid {
-		size++
-	}
-	if m.RmssdHrv != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TotalFractionalAscent != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TotalFractionalDescent != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgCoreTemperature != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MinCoreTemperature != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MaxCoreTemperature != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets Session value.

--- a/profile/mesgdef/set_gen.go
+++ b/profile/mesgdef/set_gen.go
@@ -70,107 +70,74 @@ func NewSet(mesg *proto.Message) *Set {
 
 // ToMesg converts Set into proto.Message.
 func (m *Set) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSet)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Duration != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Duration
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Repetitions != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Repetitions
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Weight != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Weight
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.SetType) != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToUint8[uint8](m.SetType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.StartTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = datetime.ToUint32(m.StartTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToSliceUint16[uint16](m.Category) != nil {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = typeconv.ToSliceUint16[uint16](m.Category)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CategorySubtype != nil {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.CategorySubtype
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.WeightDisplayUnit) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = typeconv.ToUint16[uint16](m.WeightDisplayUnit)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.WktStepIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = typeconv.ToUint16[uint16](m.WktStepIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Set's valid fields.
-func (m *Set) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Duration != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Repetitions != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Weight != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint8[uint8](m.SetType) != basetype.Uint8Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.StartTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToSliceUint16[uint16](m.Category) != nil {
-		size++
-	}
-	if m.CategorySubtype != nil {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.WeightDisplayUnit) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.WktStepIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets Set value.

--- a/profile/mesgdef/slave_device_gen.go
+++ b/profile/mesgdef/slave_device_gen.go
@@ -50,35 +50,29 @@ func NewSlaveDevice(mesg *proto.Message) *SlaveDevice {
 
 // ToMesg converts SlaveDevice into proto.Message.
 func (m *SlaveDevice) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSlaveDevice)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.Manufacturer) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToUint16[uint16](m.Manufacturer)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Product != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Product
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of SlaveDevice's valid fields.
-func (m *SlaveDevice) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.Manufacturer) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Product != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetManufacturer sets SlaveDevice value.

--- a/profile/mesgdef/sleep_assessment_gen.go
+++ b/profile/mesgdef/sleep_assessment_gen.go
@@ -74,131 +74,89 @@ func NewSleepAssessment(mesg *proto.Message) *SleepAssessment {
 
 // ToMesg converts SleepAssessment into proto.Message.
 func (m *SleepAssessment) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSleepAssessment)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.CombinedAwakeScore != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.CombinedAwakeScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AwakeTimeScore != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.AwakeTimeScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AwakeningsCountScore != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.AwakeningsCountScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DeepSleepScore != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.DeepSleepScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SleepDurationScore != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.SleepDurationScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LightSleepScore != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.LightSleepScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.OverallSleepScore != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.OverallSleepScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SleepQualityScore != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.SleepQualityScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SleepRecoveryScore != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.SleepRecoveryScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RemSleepScore != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.RemSleepScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SleepRestlessnessScore != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.SleepRestlessnessScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AwakeningsCount != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.AwakeningsCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.InterruptionsScore != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = m.InterruptionsScore
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AverageStressDuringSleep != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = m.AverageStressDuringSleep
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of SleepAssessment's valid fields.
-func (m *SleepAssessment) size() byte {
-	var size byte
-	if m.CombinedAwakeScore != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AwakeTimeScore != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AwakeningsCountScore != basetype.Uint8Invalid {
-		size++
-	}
-	if m.DeepSleepScore != basetype.Uint8Invalid {
-		size++
-	}
-	if m.SleepDurationScore != basetype.Uint8Invalid {
-		size++
-	}
-	if m.LightSleepScore != basetype.Uint8Invalid {
-		size++
-	}
-	if m.OverallSleepScore != basetype.Uint8Invalid {
-		size++
-	}
-	if m.SleepQualityScore != basetype.Uint8Invalid {
-		size++
-	}
-	if m.SleepRecoveryScore != basetype.Uint8Invalid {
-		size++
-	}
-	if m.RemSleepScore != basetype.Uint8Invalid {
-		size++
-	}
-	if m.SleepRestlessnessScore != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AwakeningsCount != basetype.Uint8Invalid {
-		size++
-	}
-	if m.InterruptionsScore != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AverageStressDuringSleep != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetCombinedAwakeScore sets SleepAssessment value.

--- a/profile/mesgdef/sleep_level_gen.go
+++ b/profile/mesgdef/sleep_level_gen.go
@@ -52,35 +52,29 @@ func NewSleepLevel(mesg *proto.Message) *SleepLevel {
 
 // ToMesg converts SleepLevel into proto.Message.
 func (m *SleepLevel) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSleepLevel)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SleepLevel) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.SleepLevel)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of SleepLevel's valid fields.
-func (m *SleepLevel) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SleepLevel) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets SleepLevel value.

--- a/profile/mesgdef/software_gen.go
+++ b/profile/mesgdef/software_gen.go
@@ -52,43 +52,34 @@ func NewSoftware(mesg *proto.Message) *Software {
 
 // ToMesg converts Software into proto.Message.
 func (m *Software) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSoftware)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Version != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Version
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PartNumber != basetype.StringInvalid && m.PartNumber != "" {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.PartNumber
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Software's valid fields.
-func (m *Software) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Version != basetype.Uint16Invalid {
-		size++
-	}
-	if m.PartNumber != basetype.StringInvalid && m.PartNumber != "" {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets Software value.

--- a/profile/mesgdef/speed_zone_gen.go
+++ b/profile/mesgdef/speed_zone_gen.go
@@ -52,43 +52,34 @@ func NewSpeedZone(mesg *proto.Message) *SpeedZone {
 
 // ToMesg converts SpeedZone into proto.Message.
 func (m *SpeedZone) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSpeedZone)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HighValue != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.HighValue
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of SpeedZone's valid fields.
-func (m *SpeedZone) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.HighValue != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets SpeedZone value.

--- a/profile/mesgdef/split_gen.go
+++ b/profile/mesgdef/split_gen.go
@@ -86,171 +86,114 @@ func NewSplit(mesg *proto.Message) *Split {
 
 // ToMesg converts Split into proto.Message.
 func (m *Split) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSplit)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SplitType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.SplitType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalElapsedTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.TotalElapsedTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalTimerTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.TotalTimerTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalDistance != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.TotalDistance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.AvgSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.StartTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = datetime.ToUint32(m.StartTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalAscent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = m.TotalAscent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalDescent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = m.TotalDescent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartPositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = m.StartPositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartPositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = m.StartPositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndPositionLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = m.EndPositionLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndPositionLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = m.EndPositionLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 25)
 		field.Value = m.MaxSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgVertSpeed != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 26)
 		field.Value = m.AvgVertSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.EndTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 27)
 		field.Value = datetime.ToUint32(m.EndTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalCalories != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 28)
 		field.Value = m.TotalCalories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartElevation != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 74)
 		field.Value = m.StartElevation
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalMovingTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 110)
 		field.Value = m.TotalMovingTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Split's valid fields.
-func (m *Split) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SplitType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.TotalElapsedTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalTimerTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalDistance != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgSpeed != basetype.Uint32Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.StartTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalAscent != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalDescent != basetype.Uint16Invalid {
-		size++
-	}
-	if m.StartPositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.StartPositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.EndPositionLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.EndPositionLong != basetype.Sint32Invalid {
-		size++
-	}
-	if m.MaxSpeed != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgVertSpeed != basetype.Sint32Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.EndTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalCalories != basetype.Uint32Invalid {
-		size++
-	}
-	if m.StartElevation != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalMovingTime != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets Split value.

--- a/profile/mesgdef/split_summary_gen.go
+++ b/profile/mesgdef/split_summary_gen.go
@@ -74,131 +74,89 @@ func NewSplitSummary(mesg *proto.Message) *SplitSummary {
 
 // ToMesg converts SplitSummary into proto.Message.
 func (m *SplitSummary) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSplitSummary)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SplitType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.SplitType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NumSplits != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.NumSplits
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalTimerTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.TotalTimerTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalDistance != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.TotalDistance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.AvgSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.MaxSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalAscent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.TotalAscent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalDescent != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.TotalDescent
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.AvgHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.MaxHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.AvgVertSpeed != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = m.AvgVertSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalCalories != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = m.TotalCalories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TotalMovingTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 77)
 		field.Value = m.TotalMovingTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of SplitSummary's valid fields.
-func (m *SplitSummary) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SplitType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.NumSplits != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalTimerTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalDistance != basetype.Uint32Invalid {
-		size++
-	}
-	if m.AvgSpeed != basetype.Uint32Invalid {
-		size++
-	}
-	if m.MaxSpeed != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalAscent != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TotalDescent != basetype.Uint16Invalid {
-		size++
-	}
-	if m.AvgHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.MaxHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.AvgVertSpeed != basetype.Sint32Invalid {
-		size++
-	}
-	if m.TotalCalories != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TotalMovingTime != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets SplitSummary value.

--- a/profile/mesgdef/spo2_data_gen.go
+++ b/profile/mesgdef/spo2_data_gen.go
@@ -56,51 +56,39 @@ func NewSpo2Data(mesg *proto.Message) *Spo2Data {
 
 // ToMesg converts Spo2Data into proto.Message.
 func (m *Spo2Data) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSpo2Data)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ReadingSpo2 != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.ReadingSpo2
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ReadingConfidence != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.ReadingConfidence
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Mode) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToEnum[byte](m.Mode)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Spo2Data's valid fields.
-func (m *Spo2Data) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.ReadingSpo2 != basetype.Uint8Invalid {
-		size++
-	}
-	if m.ReadingConfidence != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Mode) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets Spo2Data value.

--- a/profile/mesgdef/sport_gen.go
+++ b/profile/mesgdef/sport_gen.go
@@ -52,43 +52,34 @@ func NewSport(mesg *proto.Message) *Sport {
 
 // ToMesg converts Sport into proto.Message.
 func (m *Sport) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumSport)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Sport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.SubSport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Name != basetype.StringInvalid && m.Name != "" {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Name
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Sport's valid fields.
-func (m *Sport) size() byte {
-	var size byte
-	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Name != basetype.StringInvalid && m.Name != "" {
-		size++
-	}
-	return size
 }
 
 // SetSport sets Sport value.

--- a/profile/mesgdef/stress_level_gen.go
+++ b/profile/mesgdef/stress_level_gen.go
@@ -52,35 +52,29 @@ func NewStressLevel(mesg *proto.Message) *StressLevel {
 
 // ToMesg converts StressLevel into proto.Message.
 func (m *StressLevel) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumStressLevel)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.StressLevelValue != basetype.Sint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.StressLevelValue
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.StressLevelTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = datetime.ToUint32(m.StressLevelTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of StressLevel's valid fields.
-func (m *StressLevel) size() byte {
-	var size byte
-	if m.StressLevelValue != basetype.Sint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.StressLevelTime) != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetStressLevelValue sets StressLevel value.

--- a/profile/mesgdef/tank_summary_gen.go
+++ b/profile/mesgdef/tank_summary_gen.go
@@ -58,59 +58,44 @@ func NewTankSummary(mesg *proto.Message) *TankSummary {
 
 // ToMesg converts TankSummary into proto.Message.
 func (m *TankSummary) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumTankSummary)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32z[uint32](m.Sensor) != basetype.Uint32zInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToUint32z[uint32](m.Sensor)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartPressure != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.StartPressure
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndPressure != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.EndPressure
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.VolumeUsed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.VolumeUsed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of TankSummary's valid fields.
-func (m *TankSummary) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32z[uint32](m.Sensor) != basetype.Uint32zInvalid {
-		size++
-	}
-	if m.StartPressure != basetype.Uint16Invalid {
-		size++
-	}
-	if m.EndPressure != basetype.Uint16Invalid {
-		size++
-	}
-	if m.VolumeUsed != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets TankSummary value.

--- a/profile/mesgdef/tank_update_gen.go
+++ b/profile/mesgdef/tank_update_gen.go
@@ -54,43 +54,34 @@ func NewTankUpdate(mesg *proto.Message) *TankUpdate {
 
 // ToMesg converts TankUpdate into proto.Message.
 func (m *TankUpdate) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumTankUpdate)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32z[uint32](m.Sensor) != basetype.Uint32zInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToUint32z[uint32](m.Sensor)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Pressure != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Pressure
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of TankUpdate's valid fields.
-func (m *TankUpdate) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32z[uint32](m.Sensor) != basetype.Uint32zInvalid {
-		size++
-	}
-	if m.Pressure != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets TankUpdate value.

--- a/profile/mesgdef/three_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/three_d_sensor_calibration_gen.go
@@ -62,75 +62,54 @@ func NewThreeDSensorCalibration(mesg *proto.Message) *ThreeDSensorCalibration {
 
 // ToMesg converts ThreeDSensorCalibration into proto.Message.
 func (m *ThreeDSensorCalibration) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumThreeDSensorCalibration)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SensorType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.SensorType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibrationFactor != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.CalibrationFactor
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CalibrationDivisor != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.CalibrationDivisor
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LevelShift != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.LevelShift
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.OffsetCal != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.OffsetCal
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.OrientationMatrix != nil {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.OrientationMatrix
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of ThreeDSensorCalibration's valid fields.
-func (m *ThreeDSensorCalibration) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SensorType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.CalibrationFactor != basetype.Uint32Invalid {
-		size++
-	}
-	if m.CalibrationDivisor != basetype.Uint32Invalid {
-		size++
-	}
-	if m.LevelShift != basetype.Uint32Invalid {
-		size++
-	}
-	if m.OffsetCal != nil {
-		size++
-	}
-	if m.OrientationMatrix != nil {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets ThreeDSensorCalibration value.

--- a/profile/mesgdef/time_in_zone_gen.go
+++ b/profile/mesgdef/time_in_zone_gen.go
@@ -82,155 +82,104 @@ func NewTimeInZone(mesg *proto.Message) *TimeInZone {
 
 // ToMesg converts TimeInZone into proto.Message.
 func (m *TimeInZone) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumTimeInZone)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.ReferenceMesg) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToUint16[uint16](m.ReferenceMesg)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.ReferenceIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToUint16[uint16](m.ReferenceIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInHrZone != nil {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.TimeInHrZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInSpeedZone != nil {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.TimeInSpeedZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInCadenceZone != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.TimeInCadenceZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimeInPowerZone != nil {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.TimeInPowerZone
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HrZoneHighBoundary != nil {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.HrZoneHighBoundary
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SpeedZoneHighBoundary != nil {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.SpeedZoneHighBoundary
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CadenceZoneHighBondary != nil {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.CadenceZoneHighBondary
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PowerZoneHighBoundary != nil {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.PowerZoneHighBoundary
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.HrCalcType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = typeconv.ToEnum[byte](m.HrCalcType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MaxHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.MaxHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RestingHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = m.RestingHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ThresholdHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = m.ThresholdHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.PwrCalcType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = typeconv.ToEnum[byte](m.PwrCalcType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FunctionalThresholdPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = m.FunctionalThresholdPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of TimeInZone's valid fields.
-func (m *TimeInZone) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.ReferenceMesg) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.ReferenceIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.TimeInHrZone != nil {
-		size++
-	}
-	if m.TimeInSpeedZone != nil {
-		size++
-	}
-	if m.TimeInCadenceZone != nil {
-		size++
-	}
-	if m.TimeInPowerZone != nil {
-		size++
-	}
-	if m.HrZoneHighBoundary != nil {
-		size++
-	}
-	if m.SpeedZoneHighBoundary != nil {
-		size++
-	}
-	if m.CadenceZoneHighBondary != nil {
-		size++
-	}
-	if m.PowerZoneHighBoundary != nil {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.HrCalcType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.MaxHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.RestingHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.ThresholdHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.PwrCalcType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.FunctionalThresholdPower != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets TimeInZone value.

--- a/profile/mesgdef/timestamp_correlation_gen.go
+++ b/profile/mesgdef/timestamp_correlation_gen.go
@@ -62,75 +62,54 @@ func NewTimestampCorrelation(mesg *proto.Message) *TimestampCorrelation {
 
 // ToMesg converts TimestampCorrelation into proto.Message.
 func (m *TimestampCorrelation) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumTimestampCorrelation)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FractionalTimestamp != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.FractionalTimestamp
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.SystemTimestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = datetime.ToUint32(m.SystemTimestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FractionalSystemTimestamp != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.FractionalSystemTimestamp
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.LocalTimestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = datetime.ToUint32(m.LocalTimestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.TimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SystemTimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.SystemTimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of TimestampCorrelation's valid fields.
-func (m *TimestampCorrelation) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.FractionalTimestamp != basetype.Uint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.SystemTimestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.FractionalSystemTimestamp != basetype.Uint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.LocalTimestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if m.SystemTimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets TimestampCorrelation value.

--- a/profile/mesgdef/totals_gen.go
+++ b/profile/mesgdef/totals_gen.go
@@ -68,99 +68,69 @@ func NewTotals(mesg *proto.Message) *Totals {
 
 // ToMesg converts Totals into proto.Message.
 func (m *Totals) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumTotals)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimerTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TimerTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Distance != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Distance
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Calories != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Calories
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToEnum[byte](m.Sport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ElapsedTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.ElapsedTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Sessions != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.Sessions
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ActiveTime != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.ActiveTime
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SportIndex != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.SportIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Totals's valid fields.
-func (m *Totals) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimerTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Distance != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Calories != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.ElapsedTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.Sessions != basetype.Uint16Invalid {
-		size++
-	}
-	if m.ActiveTime != basetype.Uint32Invalid {
-		size++
-	}
-	if m.SportIndex != basetype.Uint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets Totals value.

--- a/profile/mesgdef/training_file_gen.go
+++ b/profile/mesgdef/training_file_gen.go
@@ -60,67 +60,49 @@ func NewTrainingFile(mesg *proto.Message) *TrainingFile {
 
 // ToMesg converts TrainingFile into proto.Message.
 func (m *TrainingFile) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumTrainingFile)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Type)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.Manufacturer) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToUint16[uint16](m.Manufacturer)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Product != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Product
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32z[uint32](m.SerialNumber) != basetype.Uint32zInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToUint32z[uint32](m.SerialNumber)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.TimeCreated) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = datetime.ToUint32(m.TimeCreated)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of TrainingFile's valid fields.
-func (m *TrainingFile) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.Manufacturer) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Product != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint32z[uint32](m.SerialNumber) != basetype.Uint32zInvalid {
-		size++
-	}
-	if datetime.ToUint32(m.TimeCreated) != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets TrainingFile value.

--- a/profile/mesgdef/user_profile_gen.go
+++ b/profile/mesgdef/user_profile_gen.go
@@ -104,251 +104,164 @@ func NewUserProfile(mesg *proto.Message) *UserProfile {
 
 // ToMesg converts UserProfile into proto.Message.
 func (m *UserProfile) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumUserProfile)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FriendlyName != basetype.StringInvalid && m.FriendlyName != "" {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.FriendlyName
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Gender) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.Gender)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Age != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Age
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Height != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Height
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Weight != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Weight
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Language) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToEnum[byte](m.Language)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.ElevSetting) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = typeconv.ToEnum[byte](m.ElevSetting)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.WeightSetting) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = typeconv.ToEnum[byte](m.WeightSetting)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RestingHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.RestingHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DefaultMaxRunningHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.DefaultMaxRunningHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DefaultMaxBikingHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.DefaultMaxBikingHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DefaultMaxHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.DefaultMaxHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.HrSetting) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = typeconv.ToEnum[byte](m.HrSetting)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SpeedSetting) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = typeconv.ToEnum[byte](m.SpeedSetting)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.DistSetting) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = typeconv.ToEnum[byte](m.DistSetting)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.PowerSetting) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 16)
 		field.Value = typeconv.ToEnum[byte](m.PowerSetting)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.ActivityClass) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 17)
 		field.Value = typeconv.ToEnum[byte](m.ActivityClass)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.PositionSetting) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 18)
 		field.Value = typeconv.ToEnum[byte](m.PositionSetting)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.TemperatureSetting) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = typeconv.ToEnum[byte](m.TemperatureSetting)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.LocalId) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = typeconv.ToUint16[uint16](m.LocalId)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.GlobalId != nil {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = m.GlobalId
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.WakeTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 28)
 		field.Value = typeconv.ToUint32[uint32](m.WakeTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.SleepTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 29)
 		field.Value = typeconv.ToUint32[uint32](m.SleepTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.HeightSetting) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 30)
 		field.Value = typeconv.ToEnum[byte](m.HeightSetting)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.UserRunningStepLength != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 31)
 		field.Value = m.UserRunningStepLength
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.UserWalkingStepLength != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 32)
 		field.Value = m.UserWalkingStepLength
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.DepthSetting) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 47)
 		field.Value = typeconv.ToEnum[byte](m.DepthSetting)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DiveCount != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 49)
 		field.Value = m.DiveCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of UserProfile's valid fields.
-func (m *UserProfile) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.FriendlyName != basetype.StringInvalid && m.FriendlyName != "" {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Gender) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Age != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Height != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Weight != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Language) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.ElevSetting) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.WeightSetting) != basetype.EnumInvalid {
-		size++
-	}
-	if m.RestingHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.DefaultMaxRunningHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.DefaultMaxBikingHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.DefaultMaxHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.HrSetting) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SpeedSetting) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.DistSetting) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.PowerSetting) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.ActivityClass) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.PositionSetting) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.TemperatureSetting) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.LocalId) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.GlobalId != nil {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.WakeTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint32[uint32](m.SleepTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.HeightSetting) != basetype.EnumInvalid {
-		size++
-	}
-	if m.UserRunningStepLength != basetype.Uint16Invalid {
-		size++
-	}
-	if m.UserWalkingStepLength != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.DepthSetting) != basetype.EnumInvalid {
-		size++
-	}
-	if m.DiveCount != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets UserProfile value.

--- a/profile/mesgdef/video_clip_gen.go
+++ b/profile/mesgdef/video_clip_gen.go
@@ -62,75 +62,54 @@ func NewVideoClip(mesg *proto.Message) *VideoClip {
 
 // ToMesg converts VideoClip into proto.Message.
 func (m *VideoClip) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumVideoClip)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.ClipNumber != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.ClipNumber
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.StartTimestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = datetime.ToUint32(m.StartTimestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.StartTimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.StartTimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.EndTimestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = datetime.ToUint32(m.EndTimestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.EndTimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.EndTimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ClipStart != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.ClipStart
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ClipEnd != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.ClipEnd
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of VideoClip's valid fields.
-func (m *VideoClip) size() byte {
-	var size byte
-	if m.ClipNumber != basetype.Uint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.StartTimestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.StartTimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.EndTimestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.EndTimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if m.ClipStart != basetype.Uint32Invalid {
-		size++
-	}
-	if m.ClipEnd != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetClipNumber sets VideoClip value.

--- a/profile/mesgdef/video_description_gen.go
+++ b/profile/mesgdef/video_description_gen.go
@@ -52,43 +52,34 @@ func NewVideoDescription(mesg *proto.Message) *VideoDescription {
 
 // ToMesg converts VideoDescription into proto.Message.
 func (m *VideoDescription) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumVideoDescription)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MessageCount != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.MessageCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Text != basetype.StringInvalid && m.Text != "" {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Text
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of VideoDescription's valid fields.
-func (m *VideoDescription) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MessageCount != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Text != basetype.StringInvalid && m.Text != "" {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets VideoDescription value.

--- a/profile/mesgdef/video_frame_gen.go
+++ b/profile/mesgdef/video_frame_gen.go
@@ -54,43 +54,34 @@ func NewVideoFrame(mesg *proto.Message) *VideoFrame {
 
 // ToMesg converts VideoFrame into proto.Message.
 func (m *VideoFrame) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumVideoFrame)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TimestampMs != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.TimestampMs
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FrameNumber != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.FrameNumber
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of VideoFrame's valid fields.
-func (m *VideoFrame) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.TimestampMs != basetype.Uint16Invalid {
-		size++
-	}
-	if m.FrameNumber != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets VideoFrame value.

--- a/profile/mesgdef/video_gen.go
+++ b/profile/mesgdef/video_gen.go
@@ -52,43 +52,34 @@ func NewVideo(mesg *proto.Message) *Video {
 
 // ToMesg converts Video into proto.Message.
 func (m *Video) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumVideo)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.Url != basetype.StringInvalid && m.Url != "" {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.Url
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HostingProvider != basetype.StringInvalid && m.HostingProvider != "" {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.HostingProvider
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Duration != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Duration
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Video's valid fields.
-func (m *Video) size() byte {
-	var size byte
-	if m.Url != basetype.StringInvalid && m.Url != "" {
-		size++
-	}
-	if m.HostingProvider != basetype.StringInvalid && m.HostingProvider != "" {
-		size++
-	}
-	if m.Duration != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetUrl sets Video value.

--- a/profile/mesgdef/video_title_gen.go
+++ b/profile/mesgdef/video_title_gen.go
@@ -52,43 +52,34 @@ func NewVideoTitle(mesg *proto.Message) *VideoTitle {
 
 // ToMesg converts VideoTitle into proto.Message.
 func (m *VideoTitle) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumVideoTitle)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MessageCount != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.MessageCount
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Text != basetype.StringInvalid && m.Text != "" {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Text
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of VideoTitle's valid fields.
-func (m *VideoTitle) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MessageCount != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Text != basetype.StringInvalid && m.Text != "" {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets VideoTitle value.

--- a/profile/mesgdef/watchface_settings_gen.go
+++ b/profile/mesgdef/watchface_settings_gen.go
@@ -52,43 +52,34 @@ func NewWatchfaceSettings(mesg *proto.Message) *WatchfaceSettings {
 
 // ToMesg converts WatchfaceSettings into proto.Message.
 func (m *WatchfaceSettings) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumWatchfaceSettings)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Mode) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Mode)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Layout != basetype.ByteInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Layout
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of WatchfaceSettings's valid fields.
-func (m *WatchfaceSettings) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Mode) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Layout != basetype.ByteInvalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets WatchfaceSettings value.

--- a/profile/mesgdef/weather_alert_gen.go
+++ b/profile/mesgdef/weather_alert_gen.go
@@ -60,67 +60,49 @@ func NewWeatherAlert(mesg *proto.Message) *WeatherAlert {
 
 // ToMesg converts WeatherAlert into proto.Message.
 func (m *WeatherAlert) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumWeatherAlert)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ReportId != basetype.StringInvalid && m.ReportId != "" {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.ReportId
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.IssueTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = datetime.ToUint32(m.IssueTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.ExpireTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = datetime.ToUint32(m.ExpireTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Severity) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToEnum[byte](m.Severity)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToEnum[byte](m.Type)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of WeatherAlert's valid fields.
-func (m *WeatherAlert) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.ReportId != basetype.StringInvalid && m.ReportId != "" {
-		size++
-	}
-	if datetime.ToUint32(m.IssueTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if datetime.ToUint32(m.ExpireTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Severity) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Type) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets WeatherAlert value.

--- a/profile/mesgdef/weather_conditions_gen.go
+++ b/profile/mesgdef/weather_conditions_gen.go
@@ -80,147 +80,99 @@ func NewWeatherConditions(mesg *proto.Message) *WeatherConditions {
 
 // ToMesg converts WeatherConditions into proto.Message.
 func (m *WeatherConditions) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumWeatherConditions)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.WeatherReport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.WeatherReport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Temperature != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.Temperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Condition) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = typeconv.ToEnum[byte](m.Condition)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.WindDirection != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.WindDirection
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.WindSpeed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.WindSpeed
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PrecipitationProbability != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.PrecipitationProbability
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TemperatureFeelsLike != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.TemperatureFeelsLike
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.RelativeHumidity != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.RelativeHumidity
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Location != basetype.StringInvalid && m.Location != "" {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.Location
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if datetime.ToUint32(m.ObservedAtTime) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = datetime.ToUint32(m.ObservedAtTime)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ObservedLocationLat != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.ObservedLocationLat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ObservedLocationLong != basetype.Sint32Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.ObservedLocationLong
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.DayOfWeek) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = typeconv.ToEnum[byte](m.DayOfWeek)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.HighTemperature != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = m.HighTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.LowTemperature != basetype.Sint8Invalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = m.LowTemperature
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of WeatherConditions's valid fields.
-func (m *WeatherConditions) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.WeatherReport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Temperature != basetype.Sint8Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Condition) != basetype.EnumInvalid {
-		size++
-	}
-	if m.WindDirection != basetype.Uint16Invalid {
-		size++
-	}
-	if m.WindSpeed != basetype.Uint16Invalid {
-		size++
-	}
-	if m.PrecipitationProbability != basetype.Uint8Invalid {
-		size++
-	}
-	if m.TemperatureFeelsLike != basetype.Sint8Invalid {
-		size++
-	}
-	if m.RelativeHumidity != basetype.Uint8Invalid {
-		size++
-	}
-	if m.Location != basetype.StringInvalid && m.Location != "" {
-		size++
-	}
-	if datetime.ToUint32(m.ObservedAtTime) != basetype.Uint32Invalid {
-		size++
-	}
-	if m.ObservedLocationLat != basetype.Sint32Invalid {
-		size++
-	}
-	if m.ObservedLocationLong != basetype.Sint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.DayOfWeek) != basetype.EnumInvalid {
-		size++
-	}
-	if m.HighTemperature != basetype.Sint8Invalid {
-		size++
-	}
-	if m.LowTemperature != basetype.Sint8Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets WeatherConditions value.

--- a/profile/mesgdef/weight_scale_gen.go
+++ b/profile/mesgdef/weight_scale_gen.go
@@ -76,131 +76,89 @@ func NewWeightScale(mesg *proto.Message) *WeightScale {
 
 // ToMesg converts WeightScale into proto.Message.
 func (m *WeightScale) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumWeightScale)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 253)
 		field.Value = datetime.ToUint32(m.Timestamp)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.Weight) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToUint16[uint16](m.Weight)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PercentFat != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.PercentFat
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PercentHydration != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.PercentHydration
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.VisceralFatMass != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.VisceralFatMass
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BoneMass != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.BoneMass
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MuscleMass != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.MuscleMass
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.BasalMet != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.BasalMet
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PhysiqueRating != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.PhysiqueRating
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ActiveMet != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.ActiveMet
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.MetabolicAge != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = m.MetabolicAge
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.VisceralFatRating != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.VisceralFatRating
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.UserProfileIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = typeconv.ToUint16[uint16](m.UserProfileIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Bmi != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = m.Bmi
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of WeightScale's valid fields.
-func (m *WeightScale) size() byte {
-	var size byte
-	if datetime.ToUint32(m.Timestamp) != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.Weight) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.PercentFat != basetype.Uint16Invalid {
-		size++
-	}
-	if m.PercentHydration != basetype.Uint16Invalid {
-		size++
-	}
-	if m.VisceralFatMass != basetype.Uint16Invalid {
-		size++
-	}
-	if m.BoneMass != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MuscleMass != basetype.Uint16Invalid {
-		size++
-	}
-	if m.BasalMet != basetype.Uint16Invalid {
-		size++
-	}
-	if m.PhysiqueRating != basetype.Uint8Invalid {
-		size++
-	}
-	if m.ActiveMet != basetype.Uint16Invalid {
-		size++
-	}
-	if m.MetabolicAge != basetype.Uint8Invalid {
-		size++
-	}
-	if m.VisceralFatRating != basetype.Uint8Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.UserProfileIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.Bmi != basetype.Uint16Invalid {
-		size++
-	}
-	return size
 }
 
 // SetTimestamp sets WeightScale value.

--- a/profile/mesgdef/workout_gen.go
+++ b/profile/mesgdef/workout_gen.go
@@ -62,83 +62,59 @@ func NewWorkout(mesg *proto.Message) *Workout {
 
 // ToMesg converts Workout into proto.Message.
 func (m *Workout) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumWorkout)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = typeconv.ToEnum[byte](m.Sport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint32z[uint32](m.Capabilities) != basetype.Uint32zInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToUint32z[uint32](m.Capabilities)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NumValidSteps != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.NumValidSteps
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.WktName != basetype.StringInvalid && m.WktName != "" {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.WktName
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = typeconv.ToEnum[byte](m.SubSport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PoolLength != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = m.PoolLength
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.PoolLengthUnit) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = typeconv.ToEnum[byte](m.PoolLengthUnit)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of Workout's valid fields.
-func (m *Workout) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToUint32z[uint32](m.Capabilities) != basetype.Uint32zInvalid {
-		size++
-	}
-	if m.NumValidSteps != basetype.Uint16Invalid {
-		size++
-	}
-	if m.WktName != basetype.StringInvalid && m.WktName != "" {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.PoolLength != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.PoolLengthUnit) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets Workout value.

--- a/profile/mesgdef/workout_session_gen.go
+++ b/profile/mesgdef/workout_session_gen.go
@@ -60,75 +60,54 @@ func NewWorkoutSession(mesg *proto.Message) *WorkoutSession {
 
 // ToMesg converts WorkoutSession into proto.Message.
 func (m *WorkoutSession) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumWorkoutSession)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = typeconv.ToEnum[byte](m.Sport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.SubSport)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.NumValidSteps != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.NumValidSteps
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FirstStepIndex != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.FirstStepIndex
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.PoolLength != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.PoolLength
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.PoolLengthUnit) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToEnum[byte](m.PoolLengthUnit)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of WorkoutSession's valid fields.
-func (m *WorkoutSession) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Sport) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SubSport) != basetype.EnumInvalid {
-		size++
-	}
-	if m.NumValidSteps != basetype.Uint16Invalid {
-		size++
-	}
-	if m.FirstStepIndex != basetype.Uint16Invalid {
-		size++
-	}
-	if m.PoolLength != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.PoolLengthUnit) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets WorkoutSession value.

--- a/profile/mesgdef/workout_step_gen.go
+++ b/profile/mesgdef/workout_step_gen.go
@@ -84,171 +84,114 @@ func NewWorkoutStep(mesg *proto.Message) *WorkoutStep {
 
 // ToMesg converts WorkoutStep into proto.Message.
 func (m *WorkoutStep) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumWorkoutStep)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = typeconv.ToUint16[uint16](m.MessageIndex)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.WktStepName != basetype.StringInvalid && m.WktStepName != "" {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.WktStepName
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.DurationType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = typeconv.ToEnum[byte](m.DurationType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.DurationValue != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.DurationValue
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.TargetType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = typeconv.ToEnum[byte](m.TargetType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.TargetValue != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.TargetValue
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CustomTargetValueLow != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.CustomTargetValueLow
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.CustomTargetValueHigh != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.CustomTargetValueHigh
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Intensity) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = typeconv.ToEnum[byte](m.Intensity)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.Notes != basetype.StringInvalid && m.Notes != "" {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.Notes
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.Equipment) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = typeconv.ToEnum[byte](m.Equipment)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.ExerciseCategory) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = typeconv.ToUint16[uint16](m.ExerciseCategory)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ExerciseName != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = m.ExerciseName
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ExerciseWeight != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = m.ExerciseWeight
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToUint16[uint16](m.WeightDisplayUnit) != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = typeconv.ToUint16[uint16](m.WeightDisplayUnit)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.SecondaryTargetType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = typeconv.ToEnum[byte](m.SecondaryTargetType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SecondaryTargetValue != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 20)
 		field.Value = m.SecondaryTargetValue
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SecondaryCustomTargetValueLow != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = m.SecondaryCustomTargetValueLow
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.SecondaryCustomTargetValueHigh != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = m.SecondaryCustomTargetValueHigh
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of WorkoutStep's valid fields.
-func (m *WorkoutStep) size() byte {
-	var size byte
-	if typeconv.ToUint16[uint16](m.MessageIndex) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.WktStepName != basetype.StringInvalid && m.WktStepName != "" {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.DurationType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.DurationValue != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.TargetType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.TargetValue != basetype.Uint32Invalid {
-		size++
-	}
-	if m.CustomTargetValueLow != basetype.Uint32Invalid {
-		size++
-	}
-	if m.CustomTargetValueHigh != basetype.Uint32Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Intensity) != basetype.EnumInvalid {
-		size++
-	}
-	if m.Notes != basetype.StringInvalid && m.Notes != "" {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.Equipment) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.ExerciseCategory) != basetype.Uint16Invalid {
-		size++
-	}
-	if m.ExerciseName != basetype.Uint16Invalid {
-		size++
-	}
-	if m.ExerciseWeight != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToUint16[uint16](m.WeightDisplayUnit) != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.SecondaryTargetType) != basetype.EnumInvalid {
-		size++
-	}
-	if m.SecondaryTargetValue != basetype.Uint32Invalid {
-		size++
-	}
-	if m.SecondaryCustomTargetValueLow != basetype.Uint32Invalid {
-		size++
-	}
-	if m.SecondaryCustomTargetValueHigh != basetype.Uint32Invalid {
-		size++
-	}
-	return size
 }
 
 // SetMessageIndex sets WorkoutStep value.

--- a/profile/mesgdef/zones_target_gen.go
+++ b/profile/mesgdef/zones_target_gen.go
@@ -56,59 +56,44 @@ func NewZonesTarget(mesg *proto.Message) *ZonesTarget {
 
 // ToMesg converts ZonesTarget into proto.Message.
 func (m *ZonesTarget) ToMesg(fac Factory) proto.Message {
+	fieldsPtr := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fieldsPtr)
+
+	fields := (*fieldsPtr)[:0] // Create slice from array with zero len.
 	mesg := fac.CreateMesgOnly(typedef.MesgNumZonesTarget)
-	mesg.Fields = make([]proto.Field, 0, m.size())
 
 	if m.MaxHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = m.MaxHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.ThresholdHeartRate != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.ThresholdHeartRate
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if m.FunctionalThresholdPower != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.FunctionalThresholdPower
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.HrCalcType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = typeconv.ToEnum[byte](m.HrCalcType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.PwrCalcType) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = typeconv.ToEnum[byte](m.PwrCalcType)
-		mesg.Fields = append(mesg.Fields, field)
+		fields = append(fields, field)
 	}
+
+	mesg.Fields = make([]proto.Field, len(fields))
+	copy(mesg.Fields, fields)
 
 	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
-}
-
-// size returns size of ZonesTarget's valid fields.
-func (m *ZonesTarget) size() byte {
-	var size byte
-	if m.MaxHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.ThresholdHeartRate != basetype.Uint8Invalid {
-		size++
-	}
-	if m.FunctionalThresholdPower != basetype.Uint16Invalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.HrCalcType) != basetype.EnumInvalid {
-		size++
-	}
-	if typeconv.ToEnum[byte](m.PwrCalcType) != basetype.EnumInvalid {
-		size++
-	}
-	return size
 }
 
 // SetMaxHeartRate sets ZonesTarget value.

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -231,7 +231,6 @@ type FieldBase struct {
 	Num        byte                // Defined in the Global FIT profile for the specified FIT message, otherwise its a manufaturer specific number (defined by manufacturer). (255 == invalid)
 	Type       profile.ProfileType // Type is defined type that serves as an abstraction layer above base types (primitive-types), e.g. DateTime is a time representation in uint32.
 	Array      bool                // Flag whether the value of this field is an array
-	Size       byte                // Size of decoded Value in bytes.
 	Scale      float64             // A scale or offset specified in the FIT profile for binary fields (sint/uint etc.) only. the binary quantity is divided by the scale factor and then the offset is subtracted. (default: 1)
 	Offset     float64             // A scale or offset specified in the FIT profile for binary fields (sint/uint etc.) only. the binary quantity is divided by the scale factor and then the offset is subtracted. (default: 0)
 	Units      string              // Units of the value, such as m (meter), m/s (meter per second), s (second), etc.


### PR DESCRIPTION
- clean up proto.Field's Size since no longer used
- improve mesgdef, now use fields pool, a backed array for slicing, instead of counting size before creating the slice.

benchstat:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/profile/mesgdef
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
         │ record_gen_old.txt │       record_gen_new.txt       │
         │       sec/op       │    sec/op     vs base          │
ToMesg-4         968.3n ± 24%   959.3n ± 20%  ~ (p=0.912 n=10)

         │ record_gen_old.txt │        record_gen_new.txt         │
         │        B/op        │    B/op     vs base               │
ToMesg-4           360.0 ± 0%   352.0 ± 0%  -2.22% (p=0.000 n=10)

         │ record_gen_old.txt │         record_gen_new.txt         │
         │     allocs/op      │ allocs/op   vs base                │
ToMesg-4          11.000 ± 0%   9.000 ± 0%  -18.18% (p=0.000 n=10)

```