### PR TITLE
perf: simplify encoder's LRU

### DIFF
--- a/encoder/lru.go
+++ b/encoder/lru.go
@@ -1,0 +1,72 @@
+package encoder
+
+import "golang.org/x/exp/slices"
+
+// lru implements simple lru algorithm. Item search best case: O(1), worst case: O(n), depends how recently used is it.
+type lru struct {
+	// Holds the actual items representated in bytes.
+	items [][]byte
+
+	// Holds items's indexes as its value. The order of value will be shifted based on recent write.
+	// Example order: [0 (least recently used), 1, 2, 3, ..., 15 (most recently used)]
+	bucket []byte
+}
+
+// newLRU creates new lru with fixed size, where should be > 0.
+func newLRU(size byte) *lru {
+	return &lru{
+		items:  make([][]byte, size),
+		bucket: make([]byte, 0, size),
+	}
+}
+
+// Reset reset variables so lru can be reused again without reallocation.
+func (l *lru) Reset() {
+	for i := range l.items {
+		l.items[i] = nil
+	}
+	l.bucket = l.bucket[:0]
+}
+
+// Putwill compare the equality of item with lru' items using cmp and store the item accordingly.
+func (l *lru) Put(item []byte) (itemIndex byte, isNewItem bool) {
+	if bucketIndex := l.bucketIndex(item); bucketIndex != -1 {
+		return l.markAsRecentlyUsed(bucketIndex), false
+	}
+	if len(l.bucket) != len(l.items) {
+		return l.store(item), true
+	}
+	return l.replaceLeastRecentlyUsed(item), true
+}
+
+func (l *lru) store(item []byte) (itemIndex byte) {
+	itemIndex = byte(len(l.bucket))
+	l.items[itemIndex] = slices.Clone(item)
+	l.bucket = append(l.bucket, itemIndex)
+	return
+}
+
+func (l *lru) markAsRecentlyUsed(bucketIndex int) (itemIndex byte) {
+	itemIndex = l.bucket[bucketIndex]
+	l.bucket = append(l.bucket[:bucketIndex], l.bucket[bucketIndex+1:]...) // splice bucketIndex from the bucket
+	l.bucket = append(l.bucket, itemIndex)                                 // place at most recent index
+	return
+}
+
+func (l *lru) replaceLeastRecentlyUsed(item []byte) (itemIndex byte) {
+	itemIndex = l.bucket[0]                        // take item's index out of bucket
+	copy(l.bucket[:len(l.bucket)-1], l.bucket[1:]) // left shift bucket
+	l.bucket[len(l.bucket)-1] = itemIndex          // place at most recent index
+	l.items[itemIndex] = slices.Clone(item)
+	return
+}
+
+func (l *lru) bucketIndex(item []byte) int {
+	for i := len(l.bucket); i > 0; i-- {
+		cur := l.bucket[i-1]
+		if slices.Equal(l.items[cur], item) {
+			return i - 1
+		}
+	}
+	return -1
+}

--- a/encoder/lru_test.go
+++ b/encoder/lru_test.go
@@ -1,0 +1,90 @@
+package encoder
+
+import (
+	"testing"
+
+	"github.com/muktihari/fit/proto"
+)
+
+func TestLRU(t *testing.T) {
+	const size uint8 = proto.LocalMesgNumMask + 1
+	l := newLRU(size)
+
+	// place (size * 10) different items, the lru will be shifted in roundroubin order.
+	for i := byte(0); i < size*10; i++ {
+		localMesgNum, isNew := l.Put([]byte{i})
+		if localMesgNum != i%size {
+			t.Fatalf("expected: %d, got: %d", i, localMesgNum)
+		}
+		isNewExpected := true
+		if isNew != isNewExpected {
+			t.Fatalf("expected: %t, got: %t", isNewExpected, isNew)
+		}
+	}
+
+	// put same items should shift the lru bucket
+	for i := byte(0); i < size; i++ {
+		item := l.items[i]
+		localMesgNUm, _ := l.Put(item)
+		if localMesgNUm != i {
+			t.Fatalf("expected: %d, got: %d", i, localMesgNUm)
+		}
+		if l.bucket[size-1] != i {
+			t.Fatalf("expected: %d, got: %d", i, l.bucket[size-1])
+		}
+	}
+
+	// check index exist
+	if lruIndex := l.bucketIndex(l.items[l.bucket[1]]); lruIndex != 1 {
+		t.Fatalf("expected lru index: %d, got: %d", 1, lruIndex)
+	}
+
+	// check index not exist
+	if lruIndex := l.bucketIndex([]byte{255, 255}); lruIndex != -1 {
+		t.Fatalf("expected lru index: %d, got: %d", -1, lruIndex)
+	}
+
+	l.Reset()
+	if len(l.bucket) != 0 {
+		t.Fatalf("expected lruBuckt is %d, got: %d", 0, len(l.bucket))
+	}
+	for i := range l.items {
+		if l.items[i] != nil {
+			t.Fatalf("[%d] expected nil, got: %v", i, l.items[i])
+		}
+	}
+}
+
+func BenchmarkLRU(b *testing.B) {
+	var size byte = proto.LocalMesgNumMask + 1
+	b.Run("100k items, zero alloc when item exist", func(b *testing.B) {
+		b.StopTimer()
+		l := newLRU(size)
+		items := make([][]byte, 100_000)
+		for i := range items {
+			items[i] = []byte{byte(i % int(size))}
+		}
+		b.StartTimer()
+
+		for i := 0; i < b.N; i++ {
+			for i := range items {
+				l.Put(items[i])
+			}
+		}
+	})
+	b.Run("100k items, alloc since we clone the item", func(b *testing.B) {
+		b.StopTimer()
+		l := newLRU(size)
+		items := make([][]byte, 100_000)
+		for i := range items {
+			items[i] = []byte{byte(i)}
+		}
+		b.StartTimer()
+
+		for i := 0; i < b.N; i++ {
+			for i := range items {
+				l.Put(items[i])
+			}
+		}
+	})
+}


### PR DESCRIPTION
LRU implementation is extracted from inside Encoder to a new **lru** struct and it is now simplified for easier maintainability.  It easier to read, test and benchmark. The sec/op is pretty much similar but the B/op and allocs/op is slightly reduced.

benchstat:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/encoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                                     │   old.txt    │              new.txt               │
                                     │    sec/op    │   sec/op     vs base               │
Encode/normal_header_zero-4            80.07m ±  7%   79.36m ± 4%       ~ (p=0.063 n=10)
Encode/normal_header_15-4              81.42m ± 73%   80.19m ± 8%       ~ (p=0.247 n=10)
Encode/compressed_timestamp_header-4   72.55m ± 30%   72.38m ± 0%       ~ (p=0.123 n=10)
geomean                                77.91m         77.23m       -0.88%

                                     │   old.txt    │               new.txt               │
                                     │     B/op     │     B/op      vs base               │
Encode/normal_header_zero-4            3.304Mi ± 0%   3.133Mi ± 0%  -5.18% (p=0.000 n=10)
Encode/normal_header_15-4              3.054Mi ± 0%   3.053Mi ± 0%       ~ (p=0.053 n=10)
Encode/compressed_timestamp_header-4   2.517Mi ± 0%   2.342Mi ± 0%  -6.96% (p=0.000 n=10)
geomean                                2.939Mi        2.819Mi       -4.10%

                                     │   old.txt   │              new.txt               │
                                     │  allocs/op  │  allocs/op   vs base               │
Encode/normal_header_zero-4            108.5k ± 0%   103.5k ± 0%  -4.59% (p=0.000 n=10)
Encode/normal_header_15-4              101.0k ± 0%   101.0k ± 0%  -0.02% (p=0.000 n=10)
Encode/compressed_timestamp_header-4   108.5k ± 0%   103.5k ± 0%  -4.59% (p=0.000 n=10)
geomean                                105.9k        102.7k       -3.09%

```