### PR TITLE
fix: decoder on component expansion

### DIFF
--- a/cmd/fitconv/fitcsv/converter.go
+++ b/cmd/fitconv/fitcsv/converter.go
@@ -337,7 +337,7 @@ func (c *FitToCsvConv) writeMesg(mesg proto.Message) {
 		if c.options.unknownNumber && field.Name == factory.NameUnknown {
 			name = formatUnknown(int(field.Num))
 		}
-		if subField, ok := field.SubFieldSubtitution(&mesg); ok {
+		if subField := field.SubFieldSubtitution(&mesg); subField != nil {
 			name, units = subField.Name, subField.Units
 		}
 

--- a/decoder/accumulator.go
+++ b/decoder/accumulator.go
@@ -16,7 +16,7 @@ func NewAccumulator() *Accumulator {
 	return &Accumulator{} // No need to make AccumulatedValues as it will be created on append anyway.
 }
 
-func (a *Accumulator) Collect(mesgNum typedef.MesgNum, destFieldNum byte, value int64) {
+func (a *Accumulator) Collect(mesgNum typedef.MesgNum, destFieldNum byte, value uint32) {
 	for i := range a.AccumulatedValues {
 		field := &a.AccumulatedValues[i]
 		if field.MesgNum == mesgNum && field.DestFieldNum == destFieldNum {
@@ -33,7 +33,7 @@ func (a *Accumulator) Collect(mesgNum typedef.MesgNum, destFieldNum byte, value 
 	})
 }
 
-func (a *Accumulator) Accumulate(mesgNum typedef.MesgNum, destFieldNum byte, value int64, bits byte) int64 {
+func (a *Accumulator) Accumulate(mesgNum typedef.MesgNum, destFieldNum byte, value uint32, bits byte) uint32 {
 	for i := range a.AccumulatedValues {
 		av := &a.AccumulatedValues[i]
 		if av.MesgNum == mesgNum && av.DestFieldNum == destFieldNum {
@@ -48,12 +48,12 @@ func (a *Accumulator) Reset() { a.AccumulatedValues = a.AccumulatedValues[:0] }
 type AccumulatedValue struct {
 	MesgNum      typedef.MesgNum
 	DestFieldNum byte
-	Last         int64
-	Value        int64
+	Last         uint32
+	Value        uint32
 }
 
-func (a *AccumulatedValue) Accumulate(value int64, bits byte) int64 {
-	var mask int64 = (1 << bits) - 1
+func (a *AccumulatedValue) Accumulate(value uint32, bits byte) uint32 {
+	var mask uint32 = (1 << bits) - 1
 	a.Value += (value - a.Last) & mask
 	a.Last = value
 	return a.Value

--- a/decoder/accumulator_test.go
+++ b/decoder/accumulator_test.go
@@ -16,8 +16,8 @@ func TestCollect(t *testing.T) {
 	type value struct {
 		mesgNum      typedef.MesgNum
 		destFieldNum byte
-		value        int64
-		expected     int64
+		value        uint32
+		expected     uint32
 	}
 
 	tt := []struct {

--- a/decoder/bits.go
+++ b/decoder/bits.go
@@ -1,0 +1,78 @@
+package decoder
+
+import (
+	"github.com/muktihari/fit/profile/basetype"
+)
+
+const (
+	bit    = 8
+	maxBit = 32
+	size   = maxBit / bit
+)
+
+// bitsFromValue convert value into 32-bits unsigned integer.
+//
+// Profile.xlsx (on Bits header's comment) says: Current implementation only supports Bits value of max 32.
+func bitsFromValue(value any) (bits uint32, ok bool) {
+	switch val := value.(type) {
+	case int8:
+		return uint32(val), true
+	case uint8:
+		return uint32(val), true
+	case int16:
+		return uint32(val), true
+	case uint16:
+		return uint32(val), true
+	case int32:
+		return uint32(val), true
+	case uint32:
+		return uint32(val), true
+	case int64:
+		return uint32(val), true
+	case uint64:
+		return uint32(val), true
+	case float32:
+		return uint32(val), true
+	case float64:
+		return uint32(val), true
+	case []byte:
+		if len(val) > size {
+			return 0, false
+		}
+		for i := range val {
+			if val[i] == basetype.ByteInvalid { // all values must be valid
+				return 0, false
+			}
+			bits |= uint32(val[i]) << (i * bit) // little-endian
+		}
+		return bits, true
+	}
+	return 0, false
+}
+
+// valueFromBits cast back bits into it's original value.
+func valueFromBits(bits uint32, baseType basetype.BaseType) any {
+	switch baseType {
+	case basetype.Sint8:
+		return int8(bits)
+	case basetype.Uint8, basetype.Uint8z:
+		return uint8(bits)
+	case basetype.Sint16:
+		return int16(bits)
+	case basetype.Uint16, basetype.Uint16z:
+		return uint16(bits)
+	case basetype.Sint32:
+		return int32(bits)
+	case basetype.Uint32, basetype.Uint32z:
+		return uint32(bits)
+	case basetype.Float32:
+		return float32(bits)
+	case basetype.Float64:
+		return float64(bits)
+	case basetype.Sint64:
+		return int64(bits)
+	case basetype.Uint64, basetype.Uint64z:
+		return uint64(bits)
+	}
+	return baseType.Invalid()
+}

--- a/decoder/bits_test.go
+++ b/decoder/bits_test.go
@@ -1,0 +1,73 @@
+package decoder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/muktihari/fit/profile/basetype"
+)
+
+func TestBitsFromValue(t *testing.T) {
+	tt := []struct {
+		value    any
+		expected uint32
+		ok       bool
+	}{
+		{value: int8(10), expected: 10, ok: true},
+		{value: uint8(10), expected: 10, ok: true},
+		{value: int16(10), expected: 10, ok: true},
+		{value: uint16(10), expected: 10, ok: true},
+		{value: int32(10), expected: 10, ok: true},
+		{value: uint32(10), expected: 10, ok: true},
+		{value: int64(10), expected: 10, ok: true},
+		{value: uint64(10), expected: 10, ok: true},
+		{value: float32(10), expected: 10, ok: true},
+		{value: float64(10), expected: 10, ok: true},
+		{value: []byte{1, 1, 1}, expected: 1<<0 | 1<<8 | 1<<16, ok: true},
+		{value: []byte{1, 255, 1}, expected: 0, ok: false},
+		{value: make([]byte, 33), expected: 0, ok: false},
+		{value: "string value", expected: 0, ok: false},
+	}
+
+	for _, tc := range tt {
+		t.Run(fmt.Sprintf("%v (%T)", tc.value, tc.value), func(t *testing.T) {
+			res, ok := bitsFromValue(tc.value)
+			if ok != tc.ok {
+				t.Fatalf("expected ok: %t, got: %t", tc.ok, ok)
+			}
+			if res != tc.expected {
+				t.Fatalf("expected: %d, got: %d", tc.expected, res)
+			}
+		})
+	}
+}
+
+func TestValueFromBits(t *testing.T) {
+	tt := []struct {
+		sbits    uint32
+		basetype basetype.BaseType
+		value    any
+		ok       bool
+	}{
+		{sbits: 10, basetype: basetype.Sint8, value: int8(10), ok: true},
+		{sbits: 10, basetype: basetype.Uint8, value: uint8(10), ok: true},
+		{sbits: 10, basetype: basetype.Sint16, value: int16(10), ok: true},
+		{sbits: 10, basetype: basetype.Uint16, value: uint16(10), ok: true},
+		{sbits: 10, basetype: basetype.Sint32, value: int32(10), ok: true},
+		{sbits: 10, basetype: basetype.Uint32, value: uint32(10), ok: true},
+		{sbits: 10, basetype: basetype.Sint64, value: int64(10), ok: true},
+		{sbits: 10, basetype: basetype.Uint64, value: uint64(10), ok: true},
+		{sbits: 10, basetype: basetype.Float32, value: float32(10), ok: true},
+		{sbits: 10, basetype: basetype.Float64, value: float64(10), ok: true},
+		{sbits: 10, basetype: basetype.String, value: basetype.StringInvalid, ok: false},
+	}
+
+	for _, tc := range tt {
+		t.Run(fmt.Sprintf("%s %v (%T)", tc.basetype, tc.value, tc.value), func(t *testing.T) {
+			res := valueFromBits(tc.sbits, tc.basetype)
+			if res != tc.value {
+				t.Fatalf("expected: %v, got: %v", tc.value, res)
+			}
+		})
+	}
+}

--- a/kit/typeconv/typeconv.go
+++ b/kit/typeconv/typeconv.go
@@ -4,37 +4,6 @@
 
 package typeconv
 
-import (
-	"github.com/muktihari/fit/profile/basetype"
-)
-
-// NumericToInt64 convert any numeric (~int | ~float) value of val to int64, if val is non-numeric value return false.
-func NumericToInt64(val any) (int64, bool) {
-	switch v := val.(type) {
-	case int8:
-		return int64(v), true
-	case uint8:
-		return int64(v), true
-	case int16:
-		return int64(v), true
-	case uint16:
-		return int64(v), true
-	case int32:
-		return int64(v), true
-	case uint32:
-		return int64(v), true
-	case int64:
-		return v, true
-	case uint64:
-		return int64(v), true
-	case float32:
-		return int64(v), true
-	case float64:
-		return int64(v), true
-	}
-	return 0, false
-}
-
 // IntegerToInt64 converts any integer value of val to int64, if val is non-integer value return false.
 func IntegerToInt64(val any) (int64, bool) {
 	switch v := val.(type) {
@@ -56,42 +25,4 @@ func IntegerToInt64(val any) (int64, bool) {
 		return int64(v), true
 	}
 	return 0, false
-}
-
-// FloatToInt64 converts any floating-point value of val to int64, if val is non-floating-point value return false.
-func FloatToInt64(val any) (int64, bool) {
-	switch v := val.(type) {
-	case float32:
-		return int64(v), true
-	case float64:
-		return int64(v), true
-	}
-	return 0, false
-}
-
-func Int64ToNumber(val int64, baseType basetype.BaseType) any {
-	switch baseType {
-	case basetype.Sint8:
-		return int8(val)
-	case basetype.Uint8, basetype.Uint8z:
-		return uint8(val)
-	case basetype.Sint16:
-		return int16(val)
-	case basetype.Uint16, basetype.Uint16z:
-		return uint16(val)
-	case basetype.Sint32:
-		return int32(val)
-	case basetype.Uint32, basetype.Uint32z:
-		return uint32(val)
-	case basetype.Float32:
-		return float32(val)
-	case basetype.Float64:
-		return float64(val)
-	case basetype.Sint64:
-		return int64(val)
-	case basetype.Uint64, basetype.Uint64z:
-		return uint64(val)
-	}
-
-	return baseType.Invalid()
 }

--- a/kit/typeconv/typeconv_test.go
+++ b/kit/typeconv/typeconv_test.go
@@ -10,41 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/kit/typeconv"
-	"github.com/muktihari/fit/profile/basetype"
 )
-
-func TestNumericToInt64(t *testing.T) {
-	tt := []struct {
-		value  any
-		result int64
-		ok     bool
-	}{
-		{value: nil, result: 0, ok: false},
-		{value: int8(10), result: 10, ok: true},
-		{value: uint8(10), result: 10, ok: true},
-		{value: int16(10), result: 10, ok: true},
-		{value: uint16(10), result: 10, ok: true},
-		{value: int32(10), result: 10, ok: true},
-		{value: uint32(10), result: 10, ok: true},
-		{value: float32(10.1), result: 10, ok: true},
-		{value: float64(10.2), result: 10, ok: true},
-		{value: int64(10), result: 10, ok: true},
-		{value: uint64(10), result: 10, ok: true},
-		{value: string("fit"), result: 0, ok: false},
-	}
-
-	for _, tc := range tt {
-		t.Run(fmt.Sprintf("%T(%#v)", tc.value, tc.value), func(t *testing.T) {
-			result, ok := typeconv.NumericToInt64(tc.value)
-			if ok != tc.ok {
-				t.Fatalf("expected: %t, got: %t", tc.ok, ok)
-			}
-			if diff := cmp.Diff(result, tc.result); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
-}
 
 func TestIntegerToInt64(t *testing.T) {
 	tt := []struct {
@@ -72,63 +38,6 @@ func TestIntegerToInt64(t *testing.T) {
 			if ok != tc.ok {
 				t.Fatalf("expected: %t, got: %t", tc.ok, ok)
 			}
-			if diff := cmp.Diff(result, tc.result); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
-}
-
-func TestFloatToInt64(t *testing.T) {
-	tt := []struct {
-		value  any
-		result int64
-		ok     bool
-	}{
-		{value: nil, result: 0, ok: false},
-		{value: uint32(10), result: 0, ok: false},
-		{value: float32(10.1), result: 10, ok: true},
-		{value: float64(11.2), result: 11, ok: true},
-		{value: string("fit"), result: 0, ok: false},
-	}
-
-	for _, tc := range tt {
-		t.Run(fmt.Sprintf("%T(%#v)", tc.value, tc.value), func(t *testing.T) {
-			result, ok := typeconv.FloatToInt64(tc.value)
-			if ok != tc.ok {
-				t.Fatalf("expected: %t, got: %t", tc.ok, ok)
-			}
-			if diff := cmp.Diff(result, tc.result); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
-}
-
-func TestInt64ToNumber(t *testing.T) {
-	tt := []struct {
-		value    int64
-		baseType basetype.BaseType
-		result   any
-	}{
-		{value: 10, baseType: basetype.Sint8, result: int8(10)},
-		{value: 10, baseType: basetype.Uint8, result: uint8(10)},
-		{value: 10, baseType: basetype.Uint8z, result: uint8(10)},
-		{value: 10, baseType: basetype.Sint16, result: int16(10)},
-		{value: 10, baseType: basetype.Uint16, result: uint16(10)},
-		{value: 10, baseType: basetype.Sint32, result: int32(10)},
-		{value: 10, baseType: basetype.Uint32, result: uint32(10)},
-		{value: 10, baseType: basetype.Float32, result: float32(10)},
-		{value: 10, baseType: basetype.Float64, result: float64(10)},
-		{value: 10, baseType: basetype.Sint64, result: int64(10)},
-		{value: 10, baseType: basetype.Uint64, result: uint64(10)},
-		{value: 10, baseType: basetype.Enum, result: basetype.Enum.Invalid()},
-		{value: 10, baseType: basetype.String, result: basetype.String.Invalid()},
-	}
-
-	for _, tc := range tt {
-		t.Run(fmt.Sprintf("%T(%#v)", tc.value, tc.value), func(t *testing.T) {
-			result := typeconv.Int64ToNumber(tc.value, tc.baseType)
 			if diff := cmp.Diff(result, tc.result); diff != "" {
 				t.Fatal(diff)
 			}

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -265,21 +265,21 @@ func (f Field) WithValue(v any) Field {
 }
 
 // SubFieldSubstitution returns any sub-field that can substitute the properties interpretation of the parent Field (Dynamic Field).
-func (f *Field) SubFieldSubtitution(mesgRef *Message) (*SubField, bool) {
+func (f *Field) SubFieldSubtitution(mesgRef *Message) *SubField {
 	for i := range f.SubFields {
 		subField := &f.SubFields[i]
 		for j := range subField.Maps {
 			smap := &subField.Maps[j]
 			fieldRef := mesgRef.FieldByNum(smap.RefFieldNum)
 			if fieldRef == nil {
-				return nil, false
+				continue
 			}
 			if fieldRef.isValueEqualTo(smap.RefFieldValue) {
-				return subField, true
+				return subField
 			}
 		}
 	}
-	return nil, false
+	return nil
 }
 
 // isValueEqualTo compare if Value == SubField's Map RefFieldValue.

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -298,11 +298,11 @@ func TestFieldSubFieldSubtitution(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			subfield, ok := tc.field.SubFieldSubtitution(&tc.mesg)
-			if ok != tc.ok {
-				t.Fatalf("expected: %t, got: %t", tc.ok, ok)
+			subfield := tc.field.SubFieldSubtitution(&tc.mesg)
+			if subfield != nil != tc.ok {
+				t.Fatalf("expected: %t, got: %t", tc.ok, subfield != nil)
 			}
-			if !ok {
+			if subfield == nil {
 				return
 			}
 			if subfield.Name != tc.subfieldName {


### PR DESCRIPTION
- Now component expansion will expand the expanded component (the destination field) that can itself requiring expansion.
- The expanded component candidate's value now will be matched with the scale offset with the destination field.
- Accumulate and bits calculation is in uint32 since Profile.xlsx (on Bits's comment) says:
   > "Current implementation only supports Bits value of max 32."
   - When the implementation changes, for example supporting 64 bits, we can change it later.

- Field's `SubFieldSubtitution` method now returning single value (*subField) instead of two (*subField, bool), since it will be nil anyway if no SubField is found.
- Fix on `SubFieldSubtitution` should have continue to lookup instead of returning when 1 single map is not match.
- Now when creating fields slice, we use `fieldsArray [256]proto.Field` as backing array for temporary slicing, this way we don't need to worry about  component expansion re-triggering `runtime.mallocgc` causing performance overhead.