### PR TITLE
chore: clean up encoder

### DIFF
--- a/encoder/lru.go
+++ b/encoder/lru.go
@@ -28,7 +28,7 @@ func (l *lru) Reset() {
 	l.bucket = l.bucket[:0]
 }
 
-// Putwill compare the equality of item with lru' items using cmp and store the item accordingly.
+// Put will compare the equality of item with lru' items and store the item accordingly.
 func (l *lru) Put(item []byte) (itemIndex byte, isNewItem bool) {
 	if bucketIndex := l.bucketIndex(item); bucketIndex != -1 {
 		return l.markAsRecentlyUsed(bucketIndex), false


### PR DESCRIPTION
- This is not a bug but a potential bug (can cause panic index out of bound) if it's being abused when declaring unsupported header.Size, for example this crc calculation might cause panic `e.crc16.Write(b[:header.Size-2])` if the result of subtraction is negative, now we check the size early on and have fixed len `e.crc16.Write(b[:12])` since we now the exact len. Now we used explicit slice indexes for crc, was `b[header.Size-2:]` now `b[12:14]`. If user passing header.Size < 12 it will be replaced by default one (header with size = 14). We only guard against something that might cause panic, if user still passing wrong size intentionally, so be it, it will not cause panic or error, only the fit file might not be read by other decoder.
- Fix typo on lru's `Put` method's docs.