### PR TITLE
feat: mesgdef now track fields from component expansion

### DIFF
--- a/internal/cmd/fitgen/profile/mesgdef/data.go
+++ b/internal/cmd/fitgen/profile/mesgdef/data.go
@@ -4,17 +4,14 @@
 
 package mesgdef
 
-import "github.com/muktihari/fit/internal/cmd/fitgen/parser"
-
 type Data struct {
-	SDKVersion           string
-	Package              string
-	Imports              []string
-	Name                 string
-	Fields               []Field
-	MaxFieldNum          byte
-	MaxFieldExpandNum    byte
-	SubFieldSubtitutions []parser.SubField
+	SDKVersion        string
+	Package           string
+	Imports           []string
+	Name              string
+	Fields            []Field
+	MaxFieldNum       byte
+	MaxFieldExpandNum byte
 }
 
 type Field struct {

--- a/internal/cmd/fitgen/profile/mesgdef/data.go
+++ b/internal/cmd/fitgen/profile/mesgdef/data.go
@@ -4,13 +4,17 @@
 
 package mesgdef
 
+import "github.com/muktihari/fit/internal/cmd/fitgen/parser"
+
 type Data struct {
-	SDKVersion  string
-	Package     string
-	Imports     []string
-	Name        string
-	Fields      []Field
-	MaxFieldNum byte
+	SDKVersion           string
+	Package              string
+	Imports              []string
+	Name                 string
+	Fields               []Field
+	MaxFieldNum          byte
+	MaxFieldExpandNum    byte
+	SubFieldSubtitutions []parser.SubField
 }
 
 type Field struct {
@@ -23,4 +27,5 @@ type Field struct {
 	ComparableValue string
 	InvalidValue    string
 	Comment         string
+	CanExpand       bool
 }

--- a/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
+++ b/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
@@ -29,13 +29,21 @@ type {{ .Name }} struct {
 	// Developer Fields are dynamic, can't be mapped as struct's fields. 
 	// [Added since protocol version 2.0]
 	DeveloperFields []proto.DeveloperField
-	{{- end -}}
+	{{ end -}}
+
+	{{ if gt .MaxFieldExpandNum 1 }}
+
+	IsExpandedFields [{{ .MaxFieldExpandNum }}]bool // Used for tracking expanded fields, field.Num as index.
+	{{ end -}}
 }
 
 // New{{ .Name }} creates new {{ .Name }} struct based on given mesg. 
 // If mesg is nil, it will return {{ .Name }} with all fields being set to its corresponding invalid value.
 func New{{ .Name }}(mesg *proto.Message) *{{ .Name }} {
     vals := [{{ .MaxFieldNum }}]any{}
+	{{ if gt .MaxFieldExpandNum 1 -}}
+	isExpandedFields := [{{ .MaxFieldExpandNum }}]bool{}
+	{{ end }}
 
     {{ if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  -}}
         var developerFields []proto.DeveloperField
@@ -45,6 +53,11 @@ func New{{ .Name }}(mesg *proto.Message) *{{ .Name }} {
             if mesg.Fields[i].Num >= byte(len(vals)) {
                 continue
             }
+			{{ if gt $.MaxFieldExpandNum 1 -}}
+			if mesg.Fields[i].Num < byte(len(isExpandedFields)) {
+				isExpandedFields[mesg.Fields[i].Num] = mesg.Fields[i].IsExpandedField
+			}
+			{{ end -}}
             vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
         }
         {{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
@@ -60,6 +73,9 @@ func New{{ .Name }}(mesg *proto.Message) *{{ .Name }} {
 
 		{{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
 		DeveloperFields: developerFields,
+		{{ end }}
+		{{ if gt .MaxFieldExpandNum 1 -}}
+		IsExpandedFields: isExpandedFields,
 		{{ end -}}
 	}
 }
@@ -74,9 +90,12 @@ func (m *{{ .Name }}) ToMesg(fac Factory) proto.Message {
 	
     {{ range .Fields -}}
         if {{ .ComparableValue }} != {{ .InvalidValue }} {
-            field := fac.CreateField(mesg.Num, {{ .Num }})
-            field.Value = {{ .PrimitiveValue }}
-            fields = append(fields, field)
+			field := fac.CreateField(mesg.Num, {{ .Num }})
+			field.Value = {{ .PrimitiveValue }}
+			{{ if eq .CanExpand true -}}
+				field.IsExpandedField = m.IsExpandedFields[{{ .Num }}]
+			{{ end -}}
+			fields = append(fields, field)
         }
 	{{ end }}
 

--- a/profile/mesgdef/ant_rx_gen.go
+++ b/profile/mesgdef/ant_rx_gen.go
@@ -28,18 +28,24 @@ type AntRx struct {
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
 	DeveloperFields []proto.DeveloperField
+
+	IsExpandedFields [5]bool // Used for tracking expanded fields, field.Num as index.
 }
 
 // NewAntRx creates new AntRx struct based on given mesg.
 // If mesg is nil, it will return AntRx with all fields being set to its corresponding invalid value.
 func NewAntRx(mesg *proto.Message) *AntRx {
 	vals := [254]any{}
+	isExpandedFields := [5]bool{}
 
 	var developerFields []proto.DeveloperField
 	if mesg != nil {
 		for i := range mesg.Fields {
 			if mesg.Fields[i].Num >= byte(len(vals)) {
 				continue
+			}
+			if mesg.Fields[i].Num < byte(len(isExpandedFields)) {
+				isExpandedFields[mesg.Fields[i].Num] = mesg.Fields[i].IsExpandedField
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
@@ -55,6 +61,8 @@ func NewAntRx(mesg *proto.Message) *AntRx {
 		Data:                typeconv.ToSliceByte[byte](vals[4]),
 
 		DeveloperFields: developerFields,
+
+		IsExpandedFields: isExpandedFields,
 	}
 }
 
@@ -89,11 +97,13 @@ func (m *AntRx) ToMesg(fac Factory) proto.Message {
 	if m.ChannelNumber != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ChannelNumber
+		field.IsExpandedField = m.IsExpandedFields[3]
 		fields = append(fields, field)
 	}
 	if m.Data != nil {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Data
+		field.IsExpandedField = m.IsExpandedFields[4]
 		fields = append(fields, field)
 	}
 

--- a/profile/mesgdef/event_gen.go
+++ b/profile/mesgdef/event_gen.go
@@ -41,18 +41,24 @@ type Event struct {
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
 	DeveloperFields []proto.DeveloperField
+
+	IsExpandedFields [25]bool // Used for tracking expanded fields, field.Num as index.
 }
 
 // NewEvent creates new Event struct based on given mesg.
 // If mesg is nil, it will return Event with all fields being set to its corresponding invalid value.
 func NewEvent(mesg *proto.Message) *Event {
 	vals := [254]any{}
+	isExpandedFields := [25]bool{}
 
 	var developerFields []proto.DeveloperField
 	if mesg != nil {
 		for i := range mesg.Fields {
 			if mesg.Fields[i].Num >= byte(len(vals)) {
 				continue
+			}
+			if mesg.Fields[i].Num < byte(len(isExpandedFields)) {
+				isExpandedFields[mesg.Fields[i].Num] = mesg.Fields[i].IsExpandedField
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
@@ -81,6 +87,8 @@ func NewEvent(mesg *proto.Message) *Event {
 		RadarThreatMaxApproachSpeed: typeconv.ToUint8[uint8](vals[24]),
 
 		DeveloperFields: developerFields,
+
+		IsExpandedFields: isExpandedFields,
 	}
 }
 
@@ -115,6 +123,7 @@ func (m *Event) ToMesg(fac Factory) proto.Message {
 	if m.Data != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Data
+		field.IsExpandedField = m.IsExpandedFields[3]
 		fields = append(fields, field)
 	}
 	if m.EventGroup != basetype.Uint8Invalid {
@@ -125,31 +134,37 @@ func (m *Event) ToMesg(fac Factory) proto.Message {
 	if m.Score != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.Score
+		field.IsExpandedField = m.IsExpandedFields[7]
 		fields = append(fields, field)
 	}
 	if m.OpponentScore != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.OpponentScore
+		field.IsExpandedField = m.IsExpandedFields[8]
 		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.FrontGearNum) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = typeconv.ToUint8z[uint8](m.FrontGearNum)
+		field.IsExpandedField = m.IsExpandedFields[9]
 		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.FrontGear) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = typeconv.ToUint8z[uint8](m.FrontGear)
+		field.IsExpandedField = m.IsExpandedFields[10]
 		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.RearGearNum) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = typeconv.ToUint8z[uint8](m.RearGearNum)
+		field.IsExpandedField = m.IsExpandedFields[11]
 		fields = append(fields, field)
 	}
 	if typeconv.ToUint8z[uint8](m.RearGear) != basetype.Uint8zInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = typeconv.ToUint8z[uint8](m.RearGear)
+		field.IsExpandedField = m.IsExpandedFields[12]
 		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.DeviceIndex) != basetype.Uint8Invalid {
@@ -170,21 +185,25 @@ func (m *Event) ToMesg(fac Factory) proto.Message {
 	if typeconv.ToEnum[byte](m.RadarThreatLevelMax) != basetype.EnumInvalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = typeconv.ToEnum[byte](m.RadarThreatLevelMax)
+		field.IsExpandedField = m.IsExpandedFields[21]
 		fields = append(fields, field)
 	}
 	if m.RadarThreatCount != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = m.RadarThreatCount
+		field.IsExpandedField = m.IsExpandedFields[22]
 		fields = append(fields, field)
 	}
 	if m.RadarThreatAvgApproachSpeed != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = m.RadarThreatAvgApproachSpeed
+		field.IsExpandedField = m.IsExpandedFields[23]
 		fields = append(fields, field)
 	}
 	if m.RadarThreatMaxApproachSpeed != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = m.RadarThreatMaxApproachSpeed
+		field.IsExpandedField = m.IsExpandedFields[24]
 		fields = append(fields, field)
 	}
 

--- a/profile/mesgdef/exd_data_field_configuration_gen.go
+++ b/profile/mesgdef/exd_data_field_configuration_gen.go
@@ -26,18 +26,24 @@ type ExdDataFieldConfiguration struct {
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
 	DeveloperFields []proto.DeveloperField
+
+	IsExpandedFields [4]bool // Used for tracking expanded fields, field.Num as index.
 }
 
 // NewExdDataFieldConfiguration creates new ExdDataFieldConfiguration struct based on given mesg.
 // If mesg is nil, it will return ExdDataFieldConfiguration with all fields being set to its corresponding invalid value.
 func NewExdDataFieldConfiguration(mesg *proto.Message) *ExdDataFieldConfiguration {
 	vals := [6]any{}
+	isExpandedFields := [4]bool{}
 
 	var developerFields []proto.DeveloperField
 	if mesg != nil {
 		for i := range mesg.Fields {
 			if mesg.Fields[i].Num >= byte(len(vals)) {
 				continue
+			}
+			if mesg.Fields[i].Num < byte(len(isExpandedFields)) {
+				isExpandedFields[mesg.Fields[i].Num] = mesg.Fields[i].IsExpandedField
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
@@ -53,6 +59,8 @@ func NewExdDataFieldConfiguration(mesg *proto.Message) *ExdDataFieldConfiguratio
 		Title:        typeconv.ToSliceString[string](vals[5]),
 
 		DeveloperFields: developerFields,
+
+		IsExpandedFields: isExpandedFields,
 	}
 }
 
@@ -77,11 +85,13 @@ func (m *ExdDataFieldConfiguration) ToMesg(fac Factory) proto.Message {
 	if m.FieldId != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.FieldId
+		field.IsExpandedField = m.IsExpandedFields[2]
 		fields = append(fields, field)
 	}
 	if m.ConceptCount != basetype.Uint8Invalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ConceptCount
+		field.IsExpandedField = m.IsExpandedFields[3]
 		fields = append(fields, field)
 	}
 	if typeconv.ToEnum[byte](m.DisplayType) != basetype.EnumInvalid {

--- a/profile/mesgdef/lap_gen.go
+++ b/profile/mesgdef/lap_gen.go
@@ -145,18 +145,24 @@ type Lap struct {
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
 	DeveloperFields []proto.DeveloperField
+
+	IsExpandedFields [138]bool // Used for tracking expanded fields, field.Num as index.
 }
 
 // NewLap creates new Lap struct based on given mesg.
 // If mesg is nil, it will return Lap with all fields being set to its corresponding invalid value.
 func NewLap(mesg *proto.Message) *Lap {
 	vals := [255]any{}
+	isExpandedFields := [138]bool{}
 
 	var developerFields []proto.DeveloperField
 	if mesg != nil {
 		for i := range mesg.Fields {
 			if mesg.Fields[i].Num >= byte(len(vals)) {
 				continue
+			}
+			if mesg.Fields[i].Num < byte(len(isExpandedFields)) {
+				isExpandedFields[mesg.Fields[i].Num] = mesg.Fields[i].IsExpandedField
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
@@ -289,6 +295,8 @@ func NewLap(mesg *proto.Message) *Lap {
 		MaxCoreTemperature:            typeconv.ToUint16[uint16](vals[160]),
 
 		DeveloperFields: developerFields,
+
+		IsExpandedFields: isExpandedFields,
 	}
 }
 
@@ -773,26 +781,31 @@ func (m *Lap) ToMesg(fac Factory) proto.Message {
 	if m.EnhancedAvgSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 110)
 		field.Value = m.EnhancedAvgSpeed
+		field.IsExpandedField = m.IsExpandedFields[110]
 		fields = append(fields, field)
 	}
 	if m.EnhancedMaxSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 111)
 		field.Value = m.EnhancedMaxSpeed
+		field.IsExpandedField = m.IsExpandedFields[111]
 		fields = append(fields, field)
 	}
 	if m.EnhancedAvgAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 112)
 		field.Value = m.EnhancedAvgAltitude
+		field.IsExpandedField = m.IsExpandedFields[112]
 		fields = append(fields, field)
 	}
 	if m.EnhancedMinAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 113)
 		field.Value = m.EnhancedMinAltitude
+		field.IsExpandedField = m.IsExpandedFields[113]
 		fields = append(fields, field)
 	}
 	if m.EnhancedMaxAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 114)
 		field.Value = m.EnhancedMaxAltitude
+		field.IsExpandedField = m.IsExpandedFields[114]
 		fields = append(fields, field)
 	}
 	if m.AvgLevMotorPower != basetype.Uint16Invalid {
@@ -848,11 +861,13 @@ func (m *Lap) ToMesg(fac Factory) proto.Message {
 	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 136)
 		field.Value = m.EnhancedAvgRespirationRate
+		field.IsExpandedField = m.IsExpandedFields[136]
 		fields = append(fields, field)
 	}
 	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 137)
 		field.Value = m.EnhancedMaxRespirationRate
+		field.IsExpandedField = m.IsExpandedFields[137]
 		fields = append(fields, field)
 	}
 	if m.AvgRespirationRate != basetype.Uint8Invalid {

--- a/profile/mesgdef/record_gen.go
+++ b/profile/mesgdef/record_gen.go
@@ -106,18 +106,24 @@ type Record struct {
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
 	DeveloperFields []proto.DeveloperField
+
+	IsExpandedFields [109]bool // Used for tracking expanded fields, field.Num as index.
 }
 
 // NewRecord creates new Record struct based on given mesg.
 // If mesg is nil, it will return Record with all fields being set to its corresponding invalid value.
 func NewRecord(mesg *proto.Message) *Record {
 	vals := [254]any{}
+	isExpandedFields := [109]bool{}
 
 	var developerFields []proto.DeveloperField
 	if mesg != nil {
 		for i := range mesg.Fields {
 			if mesg.Fields[i].Num >= byte(len(vals)) {
 				continue
+			}
+			if mesg.Fields[i].Num < byte(len(isExpandedFields)) {
+				isExpandedFields[mesg.Fields[i].Num] = mesg.Fields[i].IsExpandedField
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
@@ -211,6 +217,8 @@ func NewRecord(mesg *proto.Message) *Record {
 		CoreTemperature:               typeconv.ToUint16[uint16](vals[139]),
 
 		DeveloperFields: developerFields,
+
+		IsExpandedFields: isExpandedFields,
 	}
 }
 
@@ -255,11 +263,13 @@ func (m *Record) ToMesg(fac Factory) proto.Message {
 	if m.Distance != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.Distance
+		field.IsExpandedField = m.IsExpandedFields[5]
 		fields = append(fields, field)
 	}
 	if m.Speed != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.Speed
+		field.IsExpandedField = m.IsExpandedFields[6]
 		fields = append(fields, field)
 	}
 	if m.Power != basetype.Uint16Invalid {
@@ -310,6 +320,7 @@ func (m *Record) ToMesg(fac Factory) proto.Message {
 	if m.TotalCycles != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = m.TotalCycles
+		field.IsExpandedField = m.IsExpandedFields[19]
 		fields = append(fields, field)
 	}
 	if m.CompressedAccumulatedPower != basetype.Uint16Invalid {
@@ -320,6 +331,7 @@ func (m *Record) ToMesg(fac Factory) proto.Message {
 	if m.AccumulatedPower != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 29)
 		field.Value = m.AccumulatedPower
+		field.IsExpandedField = m.IsExpandedFields[29]
 		fields = append(fields, field)
 	}
 	if typeconv.ToUint8[uint8](m.LeftRightBalance) != basetype.Uint8Invalid {
@@ -485,11 +497,13 @@ func (m *Record) ToMesg(fac Factory) proto.Message {
 	if m.EnhancedSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 73)
 		field.Value = m.EnhancedSpeed
+		field.IsExpandedField = m.IsExpandedFields[73]
 		fields = append(fields, field)
 	}
 	if m.EnhancedAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 78)
 		field.Value = m.EnhancedAltitude
+		field.IsExpandedField = m.IsExpandedFields[78]
 		fields = append(fields, field)
 	}
 	if m.BatterySoc != basetype.Uint8Invalid {
@@ -570,6 +584,7 @@ func (m *Record) ToMesg(fac Factory) proto.Message {
 	if m.EnhancedRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 108)
 		field.Value = m.EnhancedRespirationRate
+		field.IsExpandedField = m.IsExpandedFields[108]
 		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.Grit) != basetype.Uint32Invalid {

--- a/profile/mesgdef/session_gen.go
+++ b/profile/mesgdef/session_gen.go
@@ -176,18 +176,24 @@ type Session struct {
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
 	DeveloperFields []proto.DeveloperField
+
+	IsExpandedFields [181]bool // Used for tracking expanded fields, field.Num as index.
 }
 
 // NewSession creates new Session struct based on given mesg.
 // If mesg is nil, it will return Session with all fields being set to its corresponding invalid value.
 func NewSession(mesg *proto.Message) *Session {
 	vals := [255]any{}
+	isExpandedFields := [181]bool{}
 
 	var developerFields []proto.DeveloperField
 	if mesg != nil {
 		for i := range mesg.Fields {
 			if mesg.Fields[i].Num >= byte(len(vals)) {
 				continue
+			}
+			if mesg.Fields[i].Num < byte(len(isExpandedFields)) {
+				isExpandedFields[mesg.Fields[i].Num] = mesg.Fields[i].IsExpandedField
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
@@ -351,6 +357,8 @@ func NewSession(mesg *proto.Message) *Session {
 		MaxCoreTemperature:            typeconv.ToUint16[uint16](vals[210]),
 
 		DeveloperFields: developerFields,
+
+		IsExpandedFields: isExpandedFields,
 	}
 }
 
@@ -915,26 +923,31 @@ func (m *Session) ToMesg(fac Factory) proto.Message {
 	if m.EnhancedAvgSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 124)
 		field.Value = m.EnhancedAvgSpeed
+		field.IsExpandedField = m.IsExpandedFields[124]
 		fields = append(fields, field)
 	}
 	if m.EnhancedMaxSpeed != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 125)
 		field.Value = m.EnhancedMaxSpeed
+		field.IsExpandedField = m.IsExpandedFields[125]
 		fields = append(fields, field)
 	}
 	if m.EnhancedAvgAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 126)
 		field.Value = m.EnhancedAvgAltitude
+		field.IsExpandedField = m.IsExpandedFields[126]
 		fields = append(fields, field)
 	}
 	if m.EnhancedMinAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 127)
 		field.Value = m.EnhancedMinAltitude
+		field.IsExpandedField = m.IsExpandedFields[127]
 		fields = append(fields, field)
 	}
 	if m.EnhancedMaxAltitude != basetype.Uint32Invalid {
 		field := fac.CreateField(mesg.Num, 128)
 		field.Value = m.EnhancedMaxAltitude
+		field.IsExpandedField = m.IsExpandedFields[128]
 		fields = append(fields, field)
 	}
 	if m.AvgLevMotorPower != basetype.Uint16Invalid {
@@ -1050,16 +1063,19 @@ func (m *Session) ToMesg(fac Factory) proto.Message {
 	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 169)
 		field.Value = m.EnhancedAvgRespirationRate
+		field.IsExpandedField = m.IsExpandedFields[169]
 		fields = append(fields, field)
 	}
 	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 170)
 		field.Value = m.EnhancedMaxRespirationRate
+		field.IsExpandedField = m.IsExpandedFields[170]
 		fields = append(fields, field)
 	}
 	if m.EnhancedMinRespirationRate != basetype.Uint16Invalid {
 		field := fac.CreateField(mesg.Num, 180)
 		field.Value = m.EnhancedMinRespirationRate
+		field.IsExpandedField = m.IsExpandedFields[180]
 		fields = append(fields, field)
 	}
 	if typeconv.ToUint32[uint32](m.TotalGrit) != basetype.Uint32Invalid {


### PR DESCRIPTION
- When creating any of mesgdef struct, we track which field is generated from component expansion so when we encode it again, we can omit the expanded fields.