### PR TITLE
fix: encoder endianness

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -375,6 +375,7 @@ func (e *Encoder) encodeMessages(w io.Writer, messages []proto.Message) error {
 // encodeMessage marshals and encodes message definition and its message into w.
 func (e *Encoder) encodeMessage(w io.Writer, mesg *proto.Message) error {
 	mesg.Header = proto.MesgNormalHeaderMask
+	mesg.Architecture = e.options.endianess
 
 	if err := e.messageValidator.Validate(mesg); err != nil {
 		return fmt.Errorf("message validation failed: %w", err)

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -36,9 +36,9 @@ const (
 type headerOption byte
 
 const (
-	littleEndian     = 0
-	bigEndian        = 1
-	defaultEndianess = littleEndian
+	littleEndian      = 0
+	bigEndian         = 1
+	defaultEndianness = littleEndian
 
 	// headerOptionNormal is the default header option.
 	// This option has two sub-option to select from:
@@ -84,14 +84,14 @@ type Encoder struct {
 type options struct {
 	protocolVersion          proto.Version
 	messageValidator         MessageValidator
-	endianess                byte
+	endianness               byte
 	headerOption             headerOption
 	multipleLocalMessageType byte
 }
 
 func defaultOptions() *options {
 	return &options{
-		endianess:        defaultEndianess,
+		endianness:       defaultEndianness,
 		protocolVersion:  proto.V1,
 		messageValidator: NewMessageValidator(),
 		headerOption:     headerOptionNormal,
@@ -122,7 +122,7 @@ func WithMessageValidator(validator MessageValidator) Option {
 
 // WithBigEndian directs the Encoder to encode values in Big-Endian bytes order (default: Little-Endian).
 func WithBigEndian() Option {
-	return fnApply(func(o *options) { o.endianess = bigEndian })
+	return fnApply(func(o *options) { o.endianness = bigEndian })
 }
 
 // WithCompressedTimestampHeader directs the Encoder to compress timestamp in header to reduce file size.
@@ -375,7 +375,7 @@ func (e *Encoder) encodeMessages(w io.Writer, messages []proto.Message) error {
 // encodeMessage marshals and encodes message definition and its message into w.
 func (e *Encoder) encodeMessage(w io.Writer, mesg *proto.Message) error {
 	mesg.Header = proto.MesgNormalHeaderMask
-	mesg.Architecture = e.options.endianess
+	mesg.Architecture = e.options.endianness
 
 	if err := e.messageValidator.Validate(mesg); err != nil {
 		return fmt.Errorf("message validation failed: %w", err)

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -111,7 +111,7 @@ func TestOptions(t *testing.T) {
 			opts: nil,
 			expected: &options{
 				multipleLocalMessageType: 0,
-				endianess:                0,
+				endianness:               0,
 				protocolVersion:          proto.V1,
 				messageValidator:         NewMessageValidator(),
 			},
@@ -127,7 +127,7 @@ func TestOptions(t *testing.T) {
 			},
 			expected: &options{
 				multipleLocalMessageType: 15,
-				endianess:                1,
+				endianness:               1,
 				protocolVersion:          proto.V2,
 				messageValidator:         fnValidateOK,
 				headerOption:             headerOptionCompressedTimestamp,
@@ -562,12 +562,12 @@ func TestEncodeHeader(t *testing.T) {
 
 func TestEncodeMessage(t *testing.T) {
 	tt := []struct {
-		name      string
-		mesg      proto.Message
-		opts      []Option
-		w         io.Writer
-		endianess byte
-		err       error
+		name       string
+		mesg       proto.Message
+		opts       []Option
+		w          io.Writer
+		endianness byte
+		err        error
 	}{
 		{
 			name: "encode message with default header option happy flow",
@@ -586,8 +586,8 @@ func TestEncodeMessage(t *testing.T) {
 			w: fnWriter(func(b []byte) (n int, err error) {
 				return 0, nil
 			}),
-			opts:      []Option{WithBigEndian()},
-			endianess: bigEndian,
+			opts:       []Option{WithBigEndian()},
+			endianness: bigEndian,
 		},
 		{
 			name: "encode message with header normal multiple local message type happy flow",
@@ -705,8 +705,8 @@ func TestEncodeMessage(t *testing.T) {
 				t.Fatalf("message header should not contain Developer Data Flag")
 			}
 
-			if tc.mesg.Architecture != tc.endianess {
-				t.Fatalf("expected endianess: %d, got: %d", tc.endianess, tc.mesg.Architecture)
+			if tc.mesg.Architecture != tc.endianness {
+				t.Fatalf("expected endianness: %d, got: %d", tc.endianness, tc.mesg.Architecture)
 			}
 		})
 	}

--- a/profile/basetype/basetype.go
+++ b/profile/basetype/basetype.go
@@ -298,7 +298,7 @@ func (t BaseType) Kind() reflect.Kind {
 	return basetypes[t&BaseTypeNumMask].kind
 }
 
-// EndianAbility return whether t have endianess.
+// EndianAbility return whether t have endianness.
 func (t BaseType) EndianAbility() byte {
 	if !valid(t) {
 		return 0

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -137,7 +137,7 @@ type Message struct {
 	Header          byte             // Message Header serves to distinguish whether the message is a Normal Data or a Compressed Timestamp Data. Unlike MessageDefinition, Message's Header should not contain Developer Data Flag.
 	Num             typedef.MesgNum  // Global Message Number defined in Global Fit Profile, except number within range 0xFF00 - 0xFFFE are manufacturer specific number.
 	Reserved        byte             // Currently undetermined; the default value is 0.
-	Architecture    byte             // Architecture type / Endianess. Must be the same
+	Architecture    byte             // Architecture type / Endianness. Must be the same
 	Fields          []Field          // List of Field
 	DeveloperFields []DeveloperField // List of DeveloperField
 }

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -354,6 +354,28 @@ func TestCreateMessageDefinition(t *testing.T) {
 			},
 		},
 		{
+			name: "fields only with mesg architecture big-endian",
+			mesg: func() proto.Message {
+				mesg := factory.CreateMesgOnly(mesgnum.FileId).WithFields(
+					factory.CreateField(mesgnum.FileId, fieldnum.FileIdType).WithValue(typedef.FileActivity),
+				)
+				mesg.Architecture = 1 // big-endian
+				return mesg
+			}(),
+			mesgDef: proto.MessageDefinition{
+				Header:       proto.MesgDefinitionMask,
+				Architecture: 1, // big-endian
+				MesgNum:      mesgnum.FileId,
+				FieldDefinitions: []proto.FieldDefinition{
+					{
+						Num:      fieldnum.FileIdType,
+						Size:     1,
+						BaseType: basetype.Enum,
+					},
+				},
+			},
+		},
+		{
 			name: "fields only with string value",
 			mesg: factory.CreateMesgOnly(mesgnum.FileId).WithFields(
 				factory.CreateField(mesgnum.FileId, fieldnum.FileIdProductName).WithValue("Fit SDK Go"),


### PR DESCRIPTION
- Encoder was not set `endianness` before encoding message, causing all message would not be encoded in little-endian byte order even thought **WithBigEndian()** option is specified.
- Fix typo `endianess` should be `endianness`, missing `n` word