### PR TITLE
fix: encoder should validate UTF-8 string

### DIFF
--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -574,18 +574,14 @@ func TestEncodeMessage(t *testing.T) {
 			mesg: factory.CreateMesg(mesgnum.FileId).WithFieldValues(map[byte]any{
 				fieldnum.FileIdType: typedef.FileActivity,
 			}),
-			w: fnWriter(func(b []byte) (n int, err error) {
-				return 0, nil
-			}),
+			w: fnWriteOK,
 		},
 		{
 			name: "encode message with big-endian",
 			mesg: factory.CreateMesg(mesgnum.FileId).WithFieldValues(map[byte]any{
 				fieldnum.FileIdType: typedef.FileActivity,
 			}),
-			w: fnWriter(func(b []byte) (n int, err error) {
-				return 0, nil
-			}),
+			w:          fnWriteOK,
 			opts:       []Option{WithBigEndian()},
 			endianness: bigEndian,
 		},
@@ -597,9 +593,7 @@ func TestEncodeMessage(t *testing.T) {
 			mesg: factory.CreateMesg(mesgnum.FileId).WithFieldValues(map[byte]any{
 				fieldnum.FileIdType: typedef.FileActivity,
 			}),
-			w: fnWriter(func(b []byte) (n int, err error) {
-				return 0, nil
-			}),
+			w: fnWriteOK,
 		},
 		{
 			name: "encode message with compressed timestamp header happy flow",
@@ -609,9 +603,7 @@ func TestEncodeMessage(t *testing.T) {
 			mesg: factory.CreateMesg(mesgnum.FileId).WithFieldValues(map[byte]any{
 				fieldnum.FileIdType: typedef.FileActivity,
 			}),
-			w: fnWriter(func(b []byte) (n int, err error) {
-				return 0, nil
-			}),
+			w: fnWriteOK,
 		},
 		{
 			name: "message validator's validate return error",


### PR DESCRIPTION
Previously, we don't validate a string or []string to be a valid UTF-8 string representative before encoding, this may cause invalid FIT file when user accidentally encode non UTF-8 string as field's value. This should fix the potential issue that may arise.