### PR TITLE
feat: add raw decoder

### DIFF
--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -1857,19 +1857,3 @@ func BenchmarkCheckIntegrity(b *testing.B) {
 		}
 	}
 }
-
-func BenchmarkCheckIntegrity2(b *testing.B) {
-	b.StartTimer()
-	f, err := os.Open("../testdata/local/klaten-nganjuk.fit")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer f.Close()
-
-	dec := New(bufio.NewReader(f))
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		dec.CheckIntegrity()
-		f.Seek(0, io.SeekStart)
-	}
-}

--- a/decoder/raw.go
+++ b/decoder/raw.go
@@ -1,0 +1,230 @@
+// Copyright 2023 The Fit SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package decoder
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/muktihari/fit/proto"
+)
+
+// RawFlag is the kind of the incomming bytes, the size of the incomming bytes is vary but the the size is guaranteed
+// by the corresponding RawFlag.
+type RawFlag byte
+
+const (
+	// RawFlagFileHeader is guaranteed to have either 12 or 14 bytes (all in little-endian byte order):
+	// Size + ProtocolVersion + ProfileVersion (2 bytes) +  DataSize (4 bytes) + DataType (4 bytes) + (only if Size is 14) CRC (2 bytes)
+	RawFlagFileHeader RawFlag = iota
+
+	// RawFlagMesgDef is guaranteed to have:
+	// Header + Reserved + Architecture + MesgNum (2 bytes) + n FieldDefinitions + (n FieldDefinitions * 3) +
+	// (only if Header & 0b00100000 == 0b00100000) n DeveloperFieldDefinitions + (n DeveloperFieldDefinitions * 3)
+	RawFlagMesgDef
+
+	// RawFlagMesgData is guaranteed to have:
+	// Header + Fields' value represented by its Message Definition + (only if it has developer fields) Developer Fields' value.
+	RawFlagMesgData
+
+	// RawFlagCRC is guaranteed to have:
+	// 2 bytes (in little-endian byte order) as the checksum of the messages.
+	RawFlagCRC
+)
+
+func (f RawFlag) String() string {
+	switch f {
+	case RawFlagFileHeader:
+		return "file_header"
+	case RawFlagMesgDef:
+		return "message_definition"
+	case RawFlagMesgData:
+		return "message_data"
+	case RawFlagCRC:
+		return "crc"
+	}
+	return "unknown(" + strconv.Itoa(int(f)) + ")"
+}
+
+// RawDecoder is a sequence of FIT bytes decoder. See NewRaw() for details.
+type RawDecoder struct {
+	bytesArray [255 * 255 * 2]byte // [MesgDef: 6 + 255 * 3 = 771] < [Mesg: (255 * 255) * 2 = 130050]. Use bigger capacity.
+	lenMesgs   [proto.LocalMesgNumMask + 1]uint32
+}
+
+// NewRaw creates new RawDecoder which provides low-level building block to work with FIT bytes for the maximum performance gain.
+// RawDecoder will split bytes by its corresponding RawFlag (FileHeader, MessageDefinition, MessageData and CRC) for scoping the operation.
+//
+// However, this is still considered unsafe operation since we work with bytes directly and the responsibility for validation now placed on the user-space. The only thing that this validates is
+// the reader should be a FIT (FileHeader: has valid Size, bytes 8-12 is ".FIT", ProtocolVersion is supported and DataSize > 0).
+//
+// This is only intended to be used for performance and memory critical situation where every computation or memory usage is constrained
+// (RawDecoder itself is using constant memory < 131 KB and the Decode method has zero heap alloc (except errors) while it may use additional small stack memory).
+// The implementation of the callback function is also expected to have minimal overhead.
+//
+// For general purpose usage, use Decoder instead.
+func NewRaw() *RawDecoder {
+	return &RawDecoder{}
+}
+
+// Decode decodes r reader into sequence of FIT bytes splitted by its corresponding RawFlag (FileHeader, MessageDefinition, MessageData and CRC)
+// for every FIT sequences in the reader, until it reaches EOF. It returns the number of bytes read and any error encountered.
+// When fn returns an error, Decode will immediately return the error.
+//
+// For performance, the b is not copied and the underlying array's values will be replaced each fn call. If you need
+// to work with b in its slice form later on, it should be cloned.
+//
+// Note: We encourage wrapping r into a buffered reader such as bufio.NewReader(r),
+// decode process requires byte by byte reading and having frequent read on non-buffered reader might impact performance,
+// especially if it involves syscall such as reading a file.
+func (d *RawDecoder) Decode(r io.Reader, fn func(flag RawFlag, b []byte) error) (n int64, err error) {
+	defer d.reset() // Must reset before return, so we can invoke Decode again for the next reader.
+
+	var seq int
+	for {
+		// 1. Decode File Header
+		nr, err := io.ReadFull(r, d.bytesArray[:1])
+		n += int64(nr)
+		if seq != 0 && err == io.EOF {
+			return n, nil // Reach desirable EOF.
+		}
+		if err != nil {
+			return n, err
+		}
+
+		headerSize := d.bytesArray[0]
+		if headerSize != 12 && headerSize != 14 {
+			return n, fmt.Errorf("header size [%d]: %w", headerSize, ErrNotAFitFile)
+		}
+
+		nr, err = io.ReadFull(r, d.bytesArray[1:headerSize])
+		n += int64(nr)
+		if err != nil {
+			return n, err
+		}
+
+		if string(d.bytesArray[8:12]) != proto.DataTypeFIT {
+			return n, ErrNotAFitFile
+		}
+
+		if err := proto.Validate(d.bytesArray[1]); err != nil {
+			return n, err
+		}
+
+		dataSize := binary.LittleEndian.Uint32(d.bytesArray[4:8])
+		if dataSize == 0 {
+			return n, ErrDataSizeZero
+		}
+
+		if err := fn(RawFlagFileHeader, d.bytesArray[:headerSize]); err != nil {
+			return n, err
+		}
+
+		// 2. Decode Messages
+		var pos = int64(n)
+		for uint32(n-pos) < dataSize {
+			nr, err = io.ReadFull(r, d.bytesArray[:1])
+			n += int64(nr)
+			if err != nil {
+				return n, fmt.Errorf("mesg's header: %w", err)
+			}
+
+			// 2. a. Decode Message Definition
+			if (d.bytesArray[0] & proto.MesgDefinitionMask) == proto.MesgDefinitionMask {
+				const fixedSize = uint16(6) //  Header + Reserved + Architecture + MesgNum (2 bytes) + n Fields
+				nr, err = io.ReadFull(r, d.bytesArray[1:fixedSize])
+				n += int64(nr)
+				if err != nil {
+					return n, fmt.Errorf("mesgDef bytes 1-5: %w", err)
+				}
+				lenMesgDef := fixedSize
+
+				nFields := uint16(d.bytesArray[5])
+				nr, err = io.ReadFull(r, d.bytesArray[lenMesgDef:lenMesgDef+nFields*3])
+				n += int64(nr)
+				if err != nil {
+					return n, fmt.Errorf("fieldDefs: %w", err)
+				}
+				lenMesgDef += nFields * 3 // 3 bytes per field
+
+				// Calculate the Message Data's size as we read the Field and DeveloperField definitions.
+				lenMesg := uint32(1) // Header
+				const fieldFirstIndex = fixedSize
+				for i := uint16(0); i < nFields*3; i += 3 {
+					lenMesg += uint32(d.bytesArray[fieldFirstIndex+i+1]) // // [0, |1|, 2] -> [Num, |Size|, Type]
+				}
+
+				if (d.bytesArray[0] & proto.DevDataMask) == proto.DevDataMask {
+					nr, err = io.ReadFull(r, d.bytesArray[lenMesgDef:lenMesgDef+1])
+					n += int64(nr)
+					if err != nil {
+						return n, fmt.Errorf("nDevFieldDef: %w", err)
+					}
+
+					nDevFields := uint16(d.bytesArray[lenMesgDef])
+					lenMesgDef += 1
+					devFieldFirstIndex := lenMesgDef
+					nr, err = io.ReadFull(r, d.bytesArray[devFieldFirstIndex:devFieldFirstIndex+nDevFields*3])
+					n += int64(nr)
+					if err != nil {
+						return n, fmt.Errorf("devFieldDefs: %w", err)
+					}
+					lenMesgDef += nDevFields * 3 // 3 bytes per field
+
+					for i := uint16(0); i < nDevFields*3; i += 3 {
+						lenMesg += uint32(d.bytesArray[devFieldFirstIndex+i+1]) // [0, |1|, 2] -> [Num, |Size|, Type]
+					}
+				}
+
+				localMesgNum := d.bytesArray[0] & proto.LocalMesgNumMask
+				d.lenMesgs[localMesgNum] = lenMesg
+
+				if err := fn(RawFlagMesgDef, d.bytesArray[:lenMesgDef]); err != nil {
+					return n, err
+				}
+
+				continue
+			}
+
+			// 2. b. Decode Message Data
+			localMesgNum := proto.LocalMesgNum(d.bytesArray[0])
+			lenMesg := d.lenMesgs[localMesgNum]
+			if lenMesg == 0 {
+				return n, fmt.Errorf("localMesgNum: %d: %w", localMesgNum, ErrMesgDefMissing)
+			}
+
+			nr, err = io.ReadFull(r, d.bytesArray[1:lenMesg])
+			n += int64(nr)
+			if err != nil {
+				return n, fmt.Errorf("mesg: %w", err)
+			}
+
+			if err = fn(RawFlagMesgData, d.bytesArray[:lenMesg]); err != nil {
+				return n, err
+			}
+		}
+
+		// 3. Decode File CRC
+		nr, err = io.ReadFull(r, d.bytesArray[:2])
+		n += int64(nr)
+		if err != nil {
+			return n, err
+		}
+
+		if err = fn(RawFlagCRC, d.bytesArray[:2]); err != nil {
+			return n, err
+		}
+
+		seq++
+	}
+}
+
+func (d *RawDecoder) reset() {
+	for i := range d.lenMesgs {
+		d.lenMesgs[i] = 0
+	}
+}

--- a/decoder/raw.go
+++ b/decoder/raw.go
@@ -71,10 +71,10 @@ type RawDecoder struct {
 // for validation now placed on the user-space.  The only thing that this validates is the reader should be a FIT
 // (FileHeader: has valid Size, bytes 8-12 is ".FIT", ProtocolVersion is supported and DataSize > 0).
 //
-// This is only intended to be used for performance and memory critical situation where every computation or
-// memory usage is constrained (RawDecoder itself is using constant memory < 131 KB and the Decode method has
-// zero heap alloc (except errors) while it may use additional small stack memory). The implementation of the
-// callback function is also expected to have minimal overhead.
+// The idea is to allow us to use a minimal viable decoder for performance and memory-critical situations,
+// where every computation or memory usage is constrained. RawDecoder itself is using constant memory < 131 KB and
+// the Decode method has zero heap alloc (except errors) while it may use additional small stack memory.
+// The implementation of the callback function is also expected to have minimal overhead.
 //
 // For general purpose usage, use Decoder instead.
 func NewRaw() *RawDecoder {

--- a/decoder/raw.go
+++ b/decoder/raw.go
@@ -69,7 +69,7 @@ type RawDecoder struct {
 //
 // However, this is still considered unsafe operation since we work with bytes directly and the responsibility
 // for validation now placed on the user-space.  The only thing that this validates is the reader should be a FIT
-// (FileHeader: has valid Size, bytes 8-12 is ".FIT", ProtocolVersion is supported and DataSize > 0).
+// (FileHeader: has valid Size and bytes 8-12 is ".FIT").
 //
 // The idea is to allow us to use a minimal viable decoder for performance and memory-critical situations,
 // where every computation or memory usage is constrained. RawDecoder itself is using constant memory < 131 KB and
@@ -122,14 +122,7 @@ func (d *RawDecoder) Decode(r io.Reader, fn func(flag RawFlag, b []byte) error) 
 			return n, ErrNotAFitFile
 		}
 
-		if err := proto.Validate(d.BytesArray[1]); err != nil {
-			return n, err
-		}
-
 		fileHeaderDataSize := binary.LittleEndian.Uint32(d.BytesArray[4:8])
-		if fileHeaderDataSize == 0 {
-			return n, ErrDataSizeZero
-		}
 
 		if err := fn(RawFlagFileHeader, d.BytesArray[:fileHeaderSize]); err != nil {
 			return n, err

--- a/decoder/raw_test.go
+++ b/decoder/raw_test.go
@@ -1,0 +1,583 @@
+// Copyright 2023 The Fit SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package decoder
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/kit/datetime"
+	"github.com/muktihari/fit/kit/hash/crc16"
+	"github.com/muktihari/fit/profile/basetype"
+	"github.com/muktihari/fit/profile/untyped/fieldnum"
+	"github.com/muktihari/fit/profile/untyped/mesgnum"
+	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
+)
+
+var fnDecodeRawOK = func(flag RawFlag, b []byte) error {
+	return nil
+}
+
+var fnDecodeRawErr = func(flag RawFlag, b []byte) error {
+	return io.EOF
+}
+
+func TestRawDecoderDecode(t *testing.T) {
+	_, buf := createFitForTest()
+	hash16 := crc16.New(crc16.MakeFitTable())
+
+	tt := []struct {
+		name string
+		fn   func(flag RawFlag, b []byte) error
+		r    io.Reader
+		b    []byte
+		err  error
+	}{
+		{
+			name: "happy flow",
+			r: func() io.Reader {
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn: func(flag RawFlag, b []byte) error {
+				// Test CRC Checksum
+				switch flag {
+				case RawFlagFileHeader:
+					if b[0] == 14 {
+						hash16.Write(b[:12])
+						if binary.LittleEndian.Uint16(b[12:14]) != hash16.Sum16() {
+							return ErrCRCChecksumMismatch
+						}
+						hash16.Reset()
+					}
+				case RawFlagMesgDef, RawFlagMesgData:
+					hash16.Write(b)
+				case RawFlagCRC:
+					if binary.LittleEndian.Uint16(b[:2]) != hash16.Sum16() {
+						return ErrCRCChecksumMismatch
+					}
+					hash16.Reset()
+				}
+				return nil
+			},
+			b: func() []byte {
+				return buf
+			}(),
+			err: nil,
+		},
+		{
+			name: "decode header 1st sequence return io.EOF",
+			r: func() io.Reader {
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == 0 {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn: func(flag RawFlag, b []byte) error {
+				if flag == RawFlagCRC {
+					return io.EOF
+				}
+				return nil
+			},
+			err: io.EOF,
+		},
+		{
+			name: "invalid FileHeader's Size",
+			r: func() io.Reader {
+				buf := slices.Clone(buf)
+				buf[0] = 100
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: ErrNotAFitFile,
+		},
+		{
+			name: "unexpected EOF when decode header",
+			r: func() io.Reader {
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == 1 {
+						return 0, io.ErrUnexpectedEOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: io.ErrUnexpectedEOF,
+		},
+		{
+			name: "bytes 8-12 is not .FIT",
+			r: func() io.Reader {
+				buf := slices.Clone(buf)
+				copy(buf[8:12], []byte(".FTT"))
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: ErrNotAFitFile,
+		},
+		{
+			name: "unsupported protocol version",
+			r: func() io.Reader {
+				buf := slices.Clone(buf)
+				buf[1] = 255
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: proto.ErrProtocolVersionNotSupported,
+		},
+		{
+			name: "FileHeader's DataSize is 0",
+			r: func() io.Reader {
+				buf := slices.Clone(buf)
+				copy(buf[4:8], []byte{0, 0, 0, 0})
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: ErrDataSizeZero,
+		},
+		{
+			name: "fn FileHeader returns io.EOF",
+			r: func() io.Reader {
+				buf := slices.Clone(buf)
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawErr,
+			err: io.EOF,
+		},
+		{
+			name: "decode mesgDef header return io.EOF",
+			r: func() io.Reader {
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == 14 {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: io.EOF,
+		},
+		{
+			name: "decode mesgDef bytes 1-5 return io.EOF",
+			r: func() io.Reader {
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == 15 {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: io.EOF,
+		},
+		{
+			name: "decode mesgDef fields return io.EOF",
+			r: func() io.Reader {
+				mesg := factory.CreateMesg(mesgnum.Record).WithFields(
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(time.Now())),
+				)
+				h := headerForTest()
+				buf, _ := h.MarshalBinary()
+				mesgDef := proto.CreateMessageDefinition(&mesg)
+				mesgDefb, _ := mesgDef.MarshalBinary()
+				buf = append(buf, mesgDefb...)
+
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf)-3 {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: io.EOF,
+		},
+		{
+			name: "decode mesgDef n developer fields return io.EOF",
+			r: func() io.Reader {
+				mesg := factory.CreateMesg(mesgnum.Record).WithFields(
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(time.Now())),
+				).WithDeveloperFields(
+					proto.DeveloperField{
+						DeveloperDataIndex: 0,
+						Num:                0,
+						Size:               1,
+						Name:               "Heart Rate",
+						NativeMesgNum:      mesgnum.Record,
+						NativeFieldNum:     fieldnum.RecordHeartRate,
+						Type:               basetype.Uint8,
+						Value:              uint8(100),
+					},
+				)
+				h := headerForTest()
+				buf, _ := h.MarshalBinary()
+				mesgDef := proto.CreateMessageDefinition(&mesg)
+				mesgDefb, _ := mesgDef.MarshalBinary()
+				buf = append(buf, mesgDefb...)
+
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf)-4 {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: io.EOF,
+		},
+		{
+			name: "decode mesgDef developer fields return io.EOF",
+			r: func() io.Reader {
+				mesg := factory.CreateMesg(mesgnum.Record).WithFields(
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(time.Now())),
+				).WithDeveloperFields(
+					proto.DeveloperField{
+						DeveloperDataIndex: 0,
+						Num:                0,
+						Size:               1,
+						Name:               "Heart Rate",
+						NativeMesgNum:      mesgnum.Record,
+						NativeFieldNum:     fieldnum.RecordHeartRate,
+						Type:               basetype.Uint8,
+						Value:              uint8(100),
+					},
+				)
+				h := headerForTest()
+				buf, _ := h.MarshalBinary()
+				mesgDef := proto.CreateMessageDefinition(&mesg)
+				mesgDefb, _ := mesgDef.MarshalBinary()
+				buf = append(buf, mesgDefb...)
+
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf)-3 {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: io.EOF,
+		},
+		{
+			name: "decode mesgDef fn return io.EOF",
+			r: func() io.Reader {
+				mesg := factory.CreateMesg(mesgnum.Record).WithFields(
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(time.Now())),
+				).WithDeveloperFields(
+					proto.DeveloperField{
+						DeveloperDataIndex: 0,
+						Num:                0,
+						Size:               1,
+						Name:               "Heart Rate",
+						NativeMesgNum:      mesgnum.Record,
+						NativeFieldNum:     fieldnum.RecordHeartRate,
+						Type:               basetype.Uint8,
+						Value:              uint8(100),
+					},
+				)
+				h := headerForTest()
+				buf, _ := h.MarshalBinary()
+				mesgDef := proto.CreateMessageDefinition(&mesg)
+				mesgDefb, _ := mesgDef.MarshalBinary()
+				buf = append(buf, mesgDefb...)
+
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn: func(flag RawFlag, b []byte) error {
+				if flag == RawFlagMesgDef {
+					return io.EOF
+				}
+				return nil
+			},
+			err: io.EOF,
+		},
+		{
+			name: "decode mesg, mesgDef not found",
+			r: func() io.Reader {
+				mesg := factory.CreateMesg(mesgnum.Record).WithFields(
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(time.Now())),
+				)
+				h := headerForTest()
+				buf, _ := h.MarshalBinary()
+				mesgb, _ := mesg.MarshalBinary()
+				buf = append(buf, mesgb...)
+
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: ErrMesgDefMissing,
+		},
+		{
+			name: "decode mesg, read return io.EOF",
+			r: func() io.Reader {
+				mesg := factory.CreateMesg(mesgnum.Record).WithFields(
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(time.Now())),
+				)
+				h := headerForTest()
+				buf, _ := h.MarshalBinary()
+				mesgDef := proto.CreateMessageDefinition(&mesg)
+				mesgDefb, _ := mesgDef.MarshalBinary()
+				buf = append(buf, mesgDefb...)
+				buf = append(buf, mesgDefb[0]&proto.LocalMesgNumMask)
+
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: io.EOF,
+		},
+		{
+			name: "decode mesg fn return io.EOF",
+			r: func() io.Reader {
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn: func(flag RawFlag, b []byte) error {
+				if flag == RawFlagMesgData {
+					return io.EOF
+				}
+				return nil
+			},
+			err: io.EOF,
+		},
+		{
+			name: "decode crc return io.EOF",
+			r: func() io.Reader {
+				mesg := factory.CreateMesg(mesgnum.Record).WithFields(
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(time.Now())),
+				)
+				h := headerForTest()
+				buf, _ := h.MarshalBinary()
+				mesgDef := proto.CreateMessageDefinition(&mesg)
+				mesgDefb, _ := mesgDef.MarshalBinary()
+				buf = append(buf, mesgDefb...)
+				mesgb, _ := mesg.MarshalBinary()
+				buf = append(buf, mesgb...)
+
+				binary.LittleEndian.PutUint32(buf[4:8], uint32(len(buf)-14))
+
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn:  fnDecodeRawOK,
+			err: io.EOF,
+		},
+		{
+			name: "decode crc return io.EOF",
+			r: func() io.Reader {
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					cur += copy(b, buf[cur:cur+len(b)])
+					return len(b), nil
+				})
+			}(),
+			fn: func(flag RawFlag, b []byte) error {
+				if flag == RawFlagCRC {
+					return io.EOF
+				}
+				return nil
+			},
+			err: io.EOF,
+		},
+	}
+
+	dec := NewRaw()
+	result := new(bytes.Buffer)
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			n, err := dec.Decode(tc.r, func(flag RawFlag, b []byte) error {
+				result.Write(b) // Inject to test correctness of bytes
+				return tc.fn(flag, b)
+			})
+
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("expected err: %v, got: %v", tc.err, err)
+			}
+
+			if err != nil {
+				return
+			}
+
+			if n != int64(result.Len()) {
+				t.Fatalf("expecteed n: %d, got: %d", result.Len(), n)
+			}
+
+			if diff := cmp.Diff(tc.b, result.Bytes()); diff != "" {
+				t.Fatal(diff)
+			}
+
+			result.Reset()
+			dec.reset()
+			hash16.Reset()
+		})
+	}
+}
+
+func BenchmarkDecodeRaw(b *testing.B) {
+	b.StopTimer()
+
+	// This is not a typical FIT in term of file size (2.3M) and the messages it contains (200.000 messages)
+	// But since it's big, it's should be good to benchmark.
+	f, err := os.Open("../testdata/big_activity.fit")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	all, err := io.ReadAll(f)
+	if err != nil {
+		panic(err)
+	}
+
+	buf := bytes.NewBuffer(all)
+	dec := NewRaw()
+	fmt.Println(unsafe.Sizeof(*dec))
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		buf.Write(all)
+		_, err = dec.Decode(buf, func(flag RawFlag, b []byte) error { return nil })
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestRawFlagString(t *testing.T) {
+	tt := []struct {
+		str string
+		f   RawFlag
+	}{
+		{
+			str: "file_header",
+			f:   RawFlagFileHeader,
+		},
+		{
+			str: "message_definition",
+			f:   RawFlagMesgDef,
+		},
+		{
+			str: "message_data",
+			f:   RawFlagMesgData,
+		},
+		{
+			str: "crc",
+			f:   RawFlagCRC,
+		},
+		{
+			str: "unknown(255)",
+			f:   255,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.str, func(t *testing.T) {
+			if diff := cmp.Diff(tc.f.String(), tc.str); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/decoder/raw_test.go
+++ b/decoder/raw_test.go
@@ -516,7 +516,7 @@ func TestRawDecoderDecode(t *testing.T) {
 	}
 }
 
-func BenchmarkDecodeRaw(b *testing.B) {
+func BenchmarkRawDecoderDecode(b *testing.B) {
 	b.StopTimer()
 
 	// This is not a typical FIT in term of file size (2.3M) and the messages it contains (200.000 messages)

--- a/decoder/raw_test.go
+++ b/decoder/raw_test.go
@@ -153,40 +153,6 @@ func TestRawDecoderDecode(t *testing.T) {
 			err: ErrNotAFitFile,
 		},
 		{
-			name: "unsupported protocol version",
-			r: func() io.Reader {
-				buf := slices.Clone(buf)
-				buf[1] = 255
-				cur := 0
-				return fnReader(func(b []byte) (n int, err error) {
-					if cur == len(buf) {
-						return 0, io.EOF
-					}
-					cur += copy(b, buf[cur:cur+len(b)])
-					return len(b), nil
-				})
-			}(),
-			fn:  fnDecodeRawOK,
-			err: proto.ErrProtocolVersionNotSupported,
-		},
-		{
-			name: "FileHeader's DataSize is 0",
-			r: func() io.Reader {
-				buf := slices.Clone(buf)
-				copy(buf[4:8], []byte{0, 0, 0, 0})
-				cur := 0
-				return fnReader(func(b []byte) (n int, err error) {
-					if cur == len(buf) {
-						return 0, io.EOF
-					}
-					cur += copy(b, buf[cur:cur+len(b)])
-					return len(b), nil
-				})
-			}(),
-			fn:  fnDecodeRawOK,
-			err: ErrDataSizeZero,
-		},
-		{
 			name: "fn FileHeader returns io.EOF",
 			r: func() io.Reader {
 				buf := slices.Clone(buf)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -447,6 +447,12 @@ func main() {
     _, err = dec.Decode(bufio.NewReader(f), func(flag decoder.RawFlag, b []byte) error {
         switch flag {
         case decoder.RawFlagFileHeader:
+            if err := proto.Validate(d.BytesArray[1]); err != nil {
+                return n, err
+            }
+            if binary.LittleEndian.Uint32(d.BytesArray[4:8]) == 0 {
+                return n, decoder.ErrDataSizeZero
+            }
             if b[0] == 14 {
                 hash16.Write(b[:12])
                 if binary.LittleEndian.Uint16(b[12:14]) != hash16.Sum16() {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -448,10 +448,10 @@ func main() {
         switch flag {
         case decoder.RawFlagFileHeader:
             if err := proto.Validate(b[1]); err != nil {
-                return n, err
+                return err
             }
             if binary.LittleEndian.Uint32(b[4:8]) == 0 {
-                return n, decoder.ErrDataSizeZero
+                return decoder.ErrDataSizeZero
             }
             if b[0] == 14 {
                 hash16.Write(b[:12])

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -447,10 +447,10 @@ func main() {
     _, err = dec.Decode(bufio.NewReader(f), func(flag decoder.RawFlag, b []byte) error {
         switch flag {
         case decoder.RawFlagFileHeader:
-            if err := proto.Validate(d.BytesArray[1]); err != nil {
+            if err := proto.Validate(b[1]); err != nil {
                 return n, err
             }
-            if binary.LittleEndian.Uint32(d.BytesArray[4:8]) == 0 {
+            if binary.LittleEndian.Uint32(b[4:8]) == 0 {
                 return n, decoder.ErrDataSizeZero
             }
             if b[0] == 14 {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,6 +8,7 @@ Table of Contents:
    - [Peek FileId](#Peek-FileId)
    - [Check Integrity](#Check-Integrity)
    - [Available Decode Options](#Available-Decode-Options)
+   - [RawDecoder (Low-Level Abstraction)](#RawDecoder-Low-Level-Abstraction)
 2. [Encoding](#Encoding)
    - [Encode RAW Protocol Messages](#Encode-RAW-Protocol-Messages)
    - [Encode Common File Types](#Encode-Common-File-Types)
@@ -291,11 +292,11 @@ More about this: [https://developer.garmin.com/fit/cookbook/isfit-checkintegrity
 package main
 
 import (
-	"bufio"
+    "bufio"
     "io"
-	"os"
+    "os"
 
-	"github.com/muktihari/fit/decoder"
+    "github.com/muktihari/fit/decoder"
 )
 
 func main() {
@@ -413,6 +414,64 @@ func main() {
    dec := decoder.New(f, decoder.WithNoComponentExpansion())
    ```
 
+### RawDecoder (Low-Level Abstraction)
+
+Raw Decoder provides a way to split the bytes based on its scope (File Header, Message Definition, Message Data and CRC) as the building block to work with the FIT data in its scoped bytes.
+
+The idea is to allow us to use a minimal viable decoder for performance and memory-critical situations, where every computation or memory usage is constrained. RawDecoder itself is using constant memory < 131 KB and the Decode method has zero heap alloc (except errors) while it may use additional small stack memory. The implementation of the callback function is also expected to have minimal overhead. Theoretically, from the memory usage alone, this can run on an embedded device, for instance, using [tinygo](https://tinygo.org) or other compilers, but no attempt has been made.
+
+Here is the simple example to check integrity using this building block:
+
+```go
+package main
+
+import (
+    "bufio"
+    "encoding/binary"
+    "os"
+
+    "github.com/muktihari/fit/decoder"
+    "github.com/muktihari/fit/kit/hash/crc16"
+)
+
+func main() {
+    f, err := os.Open("./testdata/from_garmin_forums/triathlon_summary_first.fit")
+    if err != nil {
+        panic(err)
+    }
+    defer f.Close()
+
+    dec := decoder.NewRaw()
+    hash16 := crc16.New(crc16.MakeFitTable())
+
+    _, err = dec.Decode(bufio.NewReader(f), func(flag decoder.RawFlag, b []byte) error {
+        switch flag {
+        case decoder.RawFlagFileHeader:
+            if b[0] == 14 {
+                hash16.Write(b[:12])
+                if binary.LittleEndian.Uint16(b[12:14]) != hash16.Sum16() {
+                    return decoder.ErrCRCChecksumMismatch
+                }
+                hash16.Reset()
+            }
+        case decoder.RawFlagMesgDef, decoder.RawFlagMesgData:
+            hash16.Write(b)
+        case decoder.RawFlagCRC:
+            if binary.LittleEndian.Uint16(b[:2]) != hash16.Sum16() {
+                return decoder.ErrCRCChecksumMismatch
+            }
+            hash16.Reset()
+        }
+        return nil
+    })
+
+    if err != nil {
+        panic(err)
+    }
+}
+
+```
+
 ## Encoding
 
 Note: By default, Encoder use protocol version 1.0 (proto.V1), if you want to use protocol version 2.0 (proto.V2), please specify it using Encode Option: WithProtocolVersion. See [Available Encode Options](#Available-Encode-Options)
@@ -426,18 +485,18 @@ Example of encoding fit by self declaring the protocol messages, this is to show
 package main
 
 import (
-	"context"
-	"os"
-	"time"
+    "context"
+    "os"
+    "time"
 
-	"github.com/muktihari/fit/encoder"
-	"github.com/muktihari/fit/factory"
-	"github.com/muktihari/fit/kit/bufferedwriter"
-	"github.com/muktihari/fit/kit/datetime"
-	"github.com/muktihari/fit/profile/typedef"
-	"github.com/muktihari/fit/profile/untyped/fieldnum"
-	"github.com/muktihari/fit/profile/untyped/mesgnum"
-	"github.com/muktihari/fit/proto"
+    "github.com/muktihari/fit/encoder"
+    "github.com/muktihari/fit/factory"
+    "github.com/muktihari/fit/kit/bufferedwriter"
+    "github.com/muktihari/fit/kit/datetime"
+    "github.com/muktihari/fit/profile/typedef"
+    "github.com/muktihari/fit/profile/untyped/fieldnum"
+    "github.com/muktihari/fit/profile/untyped/mesgnum"
+    "github.com/muktihari/fit/proto"
 )
 
 func main() {
@@ -460,7 +519,7 @@ func main() {
                 fieldnum.ActivityType:        typedef.ActivityManual,
                 fieldnum.ActivityTimestamp:   datetime.ToUint32(now),
                 fieldnum.ActivityNumSessions: uint16(1),
-			}),
+            }),
             factory.CreateMesg(mesgnum.Session).WithFieldValues(map[byte]any{
                 fieldnum.SessionAvgSpeed:     uint16(1000),
                 fieldnum.SessionAvgCadence:   uint8(78),
@@ -495,15 +554,15 @@ Example of encoding fit by self declaring the protocol messages but using common
 package main
 
 import (
-	"os"
-	"time"
+    "os"
+    "time"
 
-	"github.com/muktihari/fit/encoder"
-	"github.com/muktihari/fit/factory"
-	"github.com/muktihari/fit/kit/bufferedwriter"
-	"github.com/muktihari/fit/profile/filedef"
-	"github.com/muktihari/fit/profile/mesgdef"
-	"github.com/muktihari/fit/profile/typedef"
+    "github.com/muktihari/fit/encoder"
+    "github.com/muktihari/fit/factory"
+    "github.com/muktihari/fit/kit/bufferedwriter"
+    "github.com/muktihari/fit/profile/filedef"
+    "github.com/muktihari/fit/profile/mesgdef"
+    "github.com/muktihari/fit/profile/typedef"
 )
 
 func main() {


### PR DESCRIPTION
The idea is to allow us to use a minimal viable decoder for performance and memory-critical situations, where every computation or memory usage is constrained. RawDecoder itself is using constant memory < 131 KB and the Decode method has zero heap alloc (except errors) while it may use additional small stack memory. The implementation of the callback function is also expected to have minimal overhead. Theoretically, from the memory usage alone, this can run on an embedded device, for instance, using [tinygo](https://tinygo.org) or other compilers, but no attempt has been made.