### PR TITLE
perf: encoder reduce allocs

### DIFF
--- a/proto/marshaler.go
+++ b/proto/marshaler.go
@@ -18,8 +18,11 @@ import (
 
 // Marshaler should only do one thing: marshaling to its bytes representation, any validation should be done outside.
 
-// m.Header + ((max cap of m.Fields) * (n value)) + ((max cap of m.DeveloperFields) * (n value))
+// Header + ((max n Fields) * (n value)) + ((max n DeveloperFields) * (n value))
 const MaxBytesPerMessage = 1 + (255*255)*2
+
+// Header + Reserved + Architecture + MesgNum (2 bytes) + n Fields + (Max n Fields * 3) + n DevFields + (Max n DevFields * 3).
+const MaxBytesPerMessageDefinition = 5 + 1 + (255 * 3) + 1 + (255 * 3)
 
 var arrayPool = sync.Pool{
 	New: func() any {
@@ -55,7 +58,7 @@ func (h *FileHeader) MarshalBinary() ([]byte, error) {
 	binary.LittleEndian.PutUint16(b[2:4], h.ProfileVersion)
 	binary.LittleEndian.PutUint32(b[4:8], h.DataSize)
 
-	copy(b[8:12], []byte(h.DataType))
+	copy(b[8:12], h.DataType)
 
 	if h.Size < 14 {
 		return b, nil


### PR DESCRIPTION
This is a huge improvement as we reduce 99.99% allocations reducing GC overhead as well as we got improvement in sec/op 12.82% overall 🚀

benchstat:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/encoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                                             │    old.txt    │               new.txt                │
                                             │    sec/op     │    sec/op     vs base                │
Encode/normal_header_zero-4                     88.13m ± 12%   88.32m ± 64%        ~ (p=0.912 n=10)
Encode/normal_header_15-4                      101.01m ± 13%   81.96m ± 17%  -18.86% (p=0.023 n=10)
Encode/compressed_timestamp_header-4            75.24m ±  3%   73.90m ± 62%        ~ (p=0.353 n=10)
EncodeWriterAt/normal_header_zero-4             58.24m ± 23%   42.92m ± 19%  -26.30% (p=0.011 n=10)
EncodeWriterAt/normal_header_15-4               43.03m ± 42%   40.62m ±  9%        ~ (p=0.105 n=10)
EncodeWriterAt/compressed_timestamp_header-4    46.37m ± 15%   36.65m ± 32%  -20.97% (p=0.011 n=10)
geomean                                         65.34m         56.97m        -12.82%

                                             │     old.txt     │                new.txt                │
                                             │      B/op       │     B/op       vs base                │
Encode/normal_header_zero-4                    3126.766Ki ± 0%   9.726Ki ± 98%  -99.69% (p=0.000 n=10)
Encode/normal_header_15-4                      3131.953Ki ± 0%   9.991Ki ± 95%  -99.68% (p=0.000 n=10)
Encode/compressed_timestamp_header-4           2336.317Ki ± 0%   9.371Ki ± 98%  -99.60% (p=0.000 n=10)
EncodeWriterAt/normal_header_zero-4            1565.554Ki ± 0%   4.864Ki ± 97%  -99.69% (p=0.000 n=10)
EncodeWriterAt/normal_header_15-4              1563.140Ki ± 0%   4.826Ki ± 95%  -99.69% (p=0.000 n=10)
EncodeWriterAt/compressed_timestamp_header-4   1173.000Ki ± 0%   4.058Ki ± 97%  -99.65% (p=0.000 n=10)
geomean                                           1.962Mi        6.653Ki        -99.67%

                                             │     old.txt     │              new.txt               │
                                             │    allocs/op    │ allocs/op   vs base                │
Encode/normal_header_zero-4                    101002.000 ± 0%   6.000 ± 0%  -99.99% (p=0.000 n=10)
Encode/normal_header_15-4                       101012.00 ± 0%   16.00 ± 0%  -99.98% (p=0.000 n=10)
Encode/compressed_timestamp_header-4           101002.000 ± 0%   6.000 ± 0%  -99.99% (p=0.000 n=10)
EncodeWriterAt/normal_header_zero-4             50502.000 ± 0%   4.000 ± 0%  -99.99% (p=0.000 n=10)
EncodeWriterAt/normal_header_15-4               50507.000 ± 0%   9.000 ± 0%  -99.98% (p=0.000 n=10)
EncodeWriterAt/compressed_timestamp_header-4    50502.000 ± 0%   4.000 ± 0%  -99.99% (p=0.000 n=10)
geomean                                            71.42k        6.604       -99.99%

```