### PR TITLE
feat: add ability to reset so the object can be reused

### DIFF
--- a/decoder/accumulator_test.go
+++ b/decoder/accumulator_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 )
 
-func TestCollect(t *testing.T) {
+func TestAccumulatorCollect(t *testing.T) {
 	type value struct {
 		mesgNum      typedef.MesgNum
 		destFieldNum byte
@@ -86,7 +86,7 @@ func TestCollect(t *testing.T) {
 	}
 }
 
-func TestReset(t *testing.T) {
+func TestAccumulatorReset(t *testing.T) {
 	accumu := NewAccumulator()
 	accumu.Collect(mesgnum.Record, fieldnum.RecordSpeed, 1000)
 

--- a/encoder/lru.go
+++ b/encoder/lru.go
@@ -34,6 +34,17 @@ func (l *lru) Reset() {
 	l.bucket = l.bucket[:0]
 }
 
+// ResetWithNewSize sets new LRU size and then reset the LRU. If the new size is more than previous size it will re-allocs new storage
+// with the new capacity. If the new size is less than previous size it will reslice without re-allocs. Otherwise, only reset.
+func (l *lru) ResetWithNewSize(size byte) {
+	if size > byte(cap(l.items)) {
+		l.items = make([][]byte, size)
+	} else if size < byte(cap(l.items)) {
+		l.items = l.items[:size]
+	}
+	l.Reset()
+}
+
 // Put will compare the equality of item with lru' items and store the item accordingly.
 func (l *lru) Put(item []byte) (itemIndex byte, isNewItem bool) {
 	if bucketIndex := l.bucketIndex(item); bucketIndex != -1 {

--- a/encoder/stream.go
+++ b/encoder/stream.go
@@ -6,6 +6,7 @@ package encoder
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/muktihari/fit/proto"
 )
@@ -48,4 +49,18 @@ func (e *StreamEncoder) SequenceCompleted() error {
 	e.fileHeaderWritten = false
 	e.enc.reset()
 	return nil
+}
+
+// Reset resets the Stream Encoder and the underlying Encoder to write its output to w
+// and reset previous options to default options so any options needs to be inputed again.
+// It is similar to New() but it retains the underlying storage for use by future encode to reduce memory allocs.
+// If w does not implement io.WriterAt or io.WriteSeeker, error will be returned.
+func (e *StreamEncoder) Reset(w io.Writer, opts ...Option) error {
+	switch w.(type) {
+	case io.WriterAt, io.WriteSeeker:
+		e.enc.Reset(w, opts...)
+		e.fileHeaderWritten = false
+		return nil
+	}
+	return fmt.Errorf("could not reset: %w", ErrWriterAtOrWriteSeekerIsExpected)
 }

--- a/encoder/stream_test.go
+++ b/encoder/stream_test.go
@@ -161,3 +161,35 @@ func TestStreamEncoderUnhappyFlow(t *testing.T) {
 		t.Fatalf("expected err: %v, got: %v", io.EOF, err)
 	}
 }
+
+func TestStreamEncoderReset(t *testing.T) {
+	tt := []struct {
+		name string
+		w1   io.Writer
+		w2   io.Writer
+		err  error
+	}{
+		{
+			name: "io.WriteSeeker reset with io.WriteSeeker",
+			w1:   mockWriteSeeker{fnWriteOK, fnSeekOK},
+			w2:   mockWriteSeeker{fnWriteOK, fnSeekOK},
+			err:  nil,
+		},
+		{
+			name: "io.WriteSeeker reset with io.Writer",
+			w1:   mockWriteSeeker{fnWriteOK, fnSeekOK},
+			w2:   fnWriteOK,
+			err:  ErrWriterAtOrWriteSeekerIsExpected,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			streamEnc, _ := New(tc.w1).StreamEncoder()
+			err := streamEnc.Reset(tc.w2)
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("expected err: %v, got: %v", tc.err, err)
+			}
+		})
+	}
+}

--- a/encoder/validator.go
+++ b/encoder/validator.go
@@ -36,6 +36,9 @@ type MessageValidator interface {
 	//   3. Restoring float64-scaled field values to their binary forms (sint, uint, etc.).
 	//   4. Verifying whether the type and value are in alignment.
 	Validate(mesg *proto.Message) error
+
+	// Reset the message validator.
+	Reset()
 }
 
 type validatorOptions struct {
@@ -174,6 +177,11 @@ func (v *messageValidator) Validate(mesg *proto.Message) error {
 	}
 
 	return nil
+}
+
+func (v *messageValidator) Reset() {
+	v.developerDataIds = v.developerDataIds[:0]
+	v.fieldDescriptions = v.fieldDescriptions[:0]
 }
 
 // isValueTypeAligned checks whether the value is aligned with type. The value should be a concrete type not pointer to a value.

--- a/proto/validator.go
+++ b/proto/validator.go
@@ -36,3 +36,9 @@ func (p *Validator) ValidateMessageDefinition(mesgDef *MessageDefinition) error 
 	}
 	return nil
 }
+
+// ProtocolVersion returns the protocol version that this validator validates.
+func (p *Validator) ProtocolVersion() Version { return p.version }
+
+// SetProtocolVersion sets new protocol version to validate.
+func (p *Validator) SetProtocolVersion(version Version) { p.version = version }

--- a/proto/validator_test.go
+++ b/proto/validator_test.go
@@ -72,3 +72,12 @@ func TestValidateMessageDefinition(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatorSetProtocolVersion(t *testing.T) {
+	validator := proto.NewValidator(proto.V1)
+	validator.SetProtocolVersion(proto.V2)
+
+	if validator.ProtocolVersion() != proto.V2 {
+		t.Fatalf("expected: %v, got: %v", proto.V2, validator.ProtocolVersion())
+	}
+}


### PR DESCRIPTION
Now Decoder and Encoder have the ability to Reset, the underlying storage will be reused reducing memory allocation.

benchmark:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/decoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
BenchmarkReset/benchmark_New()-4          419300        2475   ns/op      9632 B/op       6 allocs/op
BenchmarkReset/benchmark_Reset()-4       6264751         207.6 ns/op       120 B/op       3 allocs/op
```

```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/encoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
BenchmarkReset/benchmark_New()-4          1000000      1155   ns/op       2283 B/op      13 allocs/op
BenchmarkReset/benchmark_Reset()-4        6866968       168.6 ns/op         97 B/op       3 allocs/op
```