### PR TITLE
feat: add size validation on encode

### DIFF
--- a/profile/typedef/marshal.go
+++ b/profile/typedef/marshal.go
@@ -196,9 +196,7 @@ func MarshalTo(dest *[]byte, value any, bo binary.ByteOrder) error {
 	case []string:
 		for i := range val {
 			if len(val[i]) == 0 {
-				continue
-			}
-			if len(val[i]) == 1 && val[i][0] == '\x00' {
+				*dest = append(*dest, '\x00')
 				continue
 			}
 			*dest = append(*dest, val[i]...)

--- a/profile/typedef/marshal_test.go
+++ b/profile/typedef/marshal_test.go
@@ -17,21 +17,19 @@ import (
 	"github.com/muktihari/fit/kit"
 )
 
-type DefinedBool bool
-type DefinedInt8 int8
-type DefinedUint8 uint8
-type DefinedInt16 int16
-type DefinedUint16 uint16
-type DefinedInt32 int32
-type DefinedUint32 uint32
-type DefinedInt64 int64
-type DefinedUint64 uint64
-type DefinedFloat32 float32
-type DefinedFloat64 float64
-type DefinedString string
-type DefinedAny any
-
-type privateDefinedFloat64 float64
+type test_bool bool
+type test_int8 int8
+type test_uint8 uint8
+type test_int16 int16
+type test_uint16 uint16
+type test_int32 int32
+type test_uint32 uint32
+type test_int64 int64
+type test_uint64 uint64
+type test_float32 float32
+type test_float64 float64
+type test_string string
+type test_any any
 
 func TestMarshal(t *testing.T) {
 	tt := []struct {
@@ -105,6 +103,8 @@ func TestMarshalTo(t *testing.T) {
 		{b: kit.Ptr([]byte{}), value: []uint32{9929}},
 		{b: kit.Ptr([]byte{}), value: []string{"supported"}},
 		{b: kit.Ptr([]byte{}), value: []string{""}},
+		{b: kit.Ptr([]byte{}), value: []string{"\x00"}},
+		{b: kit.Ptr([]byte{}), value: []string{"\x00", "\x00"}},
 		{b: kit.Ptr([]byte{}), value: []string{string([]byte{'\x00'})}},
 		{b: kit.Ptr([]byte{}), value: []int64{819293429}},
 		{b: kit.Ptr([]byte{}), value: []int64{-8979123}},
@@ -115,8 +115,8 @@ func TestMarshalTo(t *testing.T) {
 		{b: kit.Ptr([]byte{}), value: []float64{-897912398989898.546734}},
 		{b: kit.Ptr([]byte{}), value: []any{-897912398989898.546734}, err: ErrTypeNotSupported},
 
-		// Defined Types
-		{b: kit.Ptr([]byte{}), value: []DefinedInt8{DefinedInt8(1), DefinedInt8(2)}},
+		// test_ Types
+		{b: kit.Ptr([]byte{}), value: []test_int8{test_int8(1), test_int8(2)}},
 
 		// Types genenerated by fitgen:
 		{b: kit.Ptr([]byte{}), value: File(1)},
@@ -124,20 +124,20 @@ func TestMarshalTo(t *testing.T) {
 		{b: kit.Ptr([]byte{}), value: Checksum(1)},
 		{b: kit.Ptr([]byte{}), value: FileFlags(1)},
 
-		// User defined type marshaled using reflection:
-		{b: kit.Ptr([]byte{}), value: DefinedBool(true)},
-		{b: kit.Ptr([]byte{}), value: DefinedInt8(123)},
-		{b: kit.Ptr([]byte{}), value: DefinedUint8(123)},
-		{b: kit.Ptr([]byte{}), value: DefinedInt16(123)},
-		{b: kit.Ptr([]byte{}), value: DefinedUint16(123)},
-		{b: kit.Ptr([]byte{}), value: DefinedInt32(123)},
-		{b: kit.Ptr([]byte{}), value: DefinedUint32(123)},
-		{b: kit.Ptr([]byte{}), value: DefinedInt64(123)},
-		{b: kit.Ptr([]byte{}), value: DefinedUint64(123)},
-		{b: kit.Ptr([]byte{}), value: DefinedFloat32(123)},
-		{b: kit.Ptr([]byte{}), value: DefinedFloat64(123)},
-		{b: kit.Ptr([]byte{}), value: DefinedString("Fit SDK")},
-		{b: kit.Ptr([]byte{}), value: DefinedString("")},
+		// User test_ type marshaled using reflection:
+		{b: kit.Ptr([]byte{}), value: test_bool(true)},
+		{b: kit.Ptr([]byte{}), value: test_int8(123)},
+		{b: kit.Ptr([]byte{}), value: test_uint8(123)},
+		{b: kit.Ptr([]byte{}), value: test_int16(123)},
+		{b: kit.Ptr([]byte{}), value: test_uint16(123)},
+		{b: kit.Ptr([]byte{}), value: test_int32(123)},
+		{b: kit.Ptr([]byte{}), value: test_uint32(123)},
+		{b: kit.Ptr([]byte{}), value: test_int64(123)},
+		{b: kit.Ptr([]byte{}), value: test_uint64(123)},
+		{b: kit.Ptr([]byte{}), value: test_float32(123)},
+		{b: kit.Ptr([]byte{}), value: test_float64(123)},
+		{b: kit.Ptr([]byte{}), value: test_string("Fit SDK")},
+		{b: kit.Ptr([]byte{}), value: test_string("")},
 
 		// Unsupported types:
 		{b: kit.Ptr([]byte{}), value: nil, err: ErrNilValue},
@@ -148,11 +148,11 @@ func TestMarshalTo(t *testing.T) {
 		{b: kit.Ptr([]byte{}), value: []*int16{&i16}},
 		{b: kit.Ptr([]byte{}), value: []*int16{nilptri16}, err: ErrTypeNotSupported},
 		{b: kit.Ptr([]byte{}), value: []*int16{nil}, err: ErrTypeNotSupported},
-		{b: kit.Ptr([]byte{}), value: []DefinedAny{int16(129)}},
-		{b: kit.Ptr([]byte{}), value: []DefinedAny{func() {}}, err: ErrTypeNotSupported},
-		{b: kit.Ptr([]byte{}), value: []DefinedAny{DefinedAny(nil)}, err: ErrTypeNotSupported},
-		{b: kit.Ptr([]byte{}), value: []DefinedAny{[]DefinedAny{}}, err: ErrTypeNotSupported},
-		{b: kit.Ptr([]byte{}), value: []privateDefinedFloat64{8.234}},
+		{b: kit.Ptr([]byte{}), value: []test_any{int16(129)}},
+		{b: kit.Ptr([]byte{}), value: []test_any{func() {}}, err: ErrTypeNotSupported},
+		{b: kit.Ptr([]byte{}), value: []test_any{test_any(nil)}, err: ErrTypeNotSupported},
+		{b: kit.Ptr([]byte{}), value: []test_any{[]test_any{}}, err: ErrTypeNotSupported},
+		{b: kit.Ptr([]byte{}), value: []test_float64{8.234}},
 
 		{b: nil, value: uint8(129), err: ErrNilDest},
 	}
@@ -203,10 +203,7 @@ func marshalWithReflectionForTest(w io.Writer, value any) error {
 			if rv.Index(i).Kind() == reflect.String {
 				value := rv.Index(i).String()
 				if len(value) == 0 {
-					continue
-				}
-				if value[len(value)-1] == '\x00' {
-					continue
+					rv.Index(i).SetString("\x00")
 				}
 			}
 			if err := marshalWithReflectionForTest(w, rv.Index(i).Interface()); err != nil {

--- a/profile/typedef/typedef.go
+++ b/profile/typedef/typedef.go
@@ -6,54 +6,100 @@ package typedef
 
 import (
 	"reflect"
+
+	"github.com/muktihari/fit/profile/basetype"
 )
 
-// Len returns how many element of slice val. It val is not a slice, return 1.
-func Len(val any) byte {
+// Sizeof returns the size of val in bytes.
+func Sizeof(val any, baseType basetype.BaseType) int {
+	return lenOf(val) * int(baseType.Size())
+}
+
+func lenOf(val any) int {
 	switch vs := val.(type) { // Fast Path
 	case int8, uint8, int16, uint16, int32, uint32, float32, float64, int64, uint64:
 		return 1
 	case string:
-		return byte(len(vs)) + 1
+		if len(vs) == 0 {
+			return 1 // utf-8 null terminated string
+		}
+		if l := len(vs); l > 0 && vs[l-1] == '\x00' {
+			return l
+		}
+		return len(vs) + 1
 	case []string:
-		var size byte
+		var size int
 		for i := range vs {
 			if len(vs[i]) == 0 {
+				size += 1 // utf-8 null terminated string
 				continue
 			}
-			if len(vs[i]) == 1 && vs[i][len(vs[i])-1] == '\x00' {
+			if l := len(vs[i]); l > 0 && vs[i][l-1] == '\x00' {
+				size += l
 				continue
 			}
-			size += byte(len(vs[i])) + 1
+			size += len(vs[i]) + 1
+		}
+		if size == 0 {
+			return 1 // utf-8 null terminated string
 		}
 		return size
 	case []int8:
-		return byte(len(vs))
+		return len(vs)
 	case []uint8:
-		return byte(len(vs))
+		return len(vs)
 	case []int16:
-		return byte(len(vs))
+		return len(vs)
 	case []uint16:
-		return byte(len(vs))
+		return len(vs)
 	case []int32:
-		return byte(len(vs))
+		return len(vs)
 	case []uint32:
-		return byte(len(vs))
+		return len(vs)
 	case []float32:
-		return byte(len(vs))
+		return len(vs)
 	case []float64:
-		return byte(len(vs))
+		return len(vs)
 	case []int64:
-		return byte(len(vs))
+		return len(vs)
 	case []uint64:
-		return byte(len(vs))
+		return len(vs)
 	}
 
 	// Fallback to reflection
 	rv := reflect.ValueOf(val)
-	if rv.Kind() != reflect.Slice {
+	switch rv.Kind() {
+	case reflect.String:
+		val := rv.String()
+		if len(val) == 0 {
+			return 1 // utf-8 null terminated string
+		}
+		if l := len(val); l > 0 && val[l-1] == '\x00' {
+			return l
+		}
+		return len(val) + 1
+	case reflect.Slice:
+		if rv.Type().Elem().Kind() == reflect.String {
+			var size int
+			for i := 0; i < rv.Len(); i++ {
+				val := rv.Index(i).String()
+				if len(val) == 0 {
+					size += 1 // utf-8 null terminated string
+					continue
+				}
+				if l := len(val); l > 0 && val[l-1] == '\x00' {
+					size += l
+					continue
+				}
+				size += len(val) + 1
+			}
+			if size == 0 {
+				return 1 // utf-8 null terminated string
+			}
+			return size
+		}
+		return rv.Len()
+	default:
 		return 1
 	}
-
-	return byte(rv.Len())
 }

--- a/profile/typedef/typedef_test.go
+++ b/profile/typedef/typedef_test.go
@@ -8,50 +8,66 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 )
 
-type Uint8 uint8
+type test_uint8 uint8
+type test_string string
 
 func TestLen(t *testing.T) {
 	tt := []struct {
-		value any
-		size  byte
+		value       any
+		baseType    basetype.BaseType
+		sizeInBytes int
 	}{
-		{value: int8(10), size: 1},
-		{value: uint8(10), size: 1},
-		{value: int16(10), size: 1},
-		{value: uint16(10), size: 1},
-		{value: int32(10), size: 1},
-		{value: uint32(10), size: 1},
-		{value: float32(10), size: 1},
-		{value: float64(10), size: 1},
-		{value: int64(10), size: 1},
-		{value: uint64(10), size: 1},
-		{value: []int8{10, 9, 8, 7}, size: 4},
-		{value: []uint8{10, 9, 8, 7}, size: 4},
-		{value: []int16{10, 9, 8, 7}, size: 4},
-		{value: []uint16{10, 9, 8, 7}, size: 4},
-		{value: []int32{10, 9, 8, 7}, size: 4},
-		{value: []uint32{10, 9, 8, 7}, size: 4},
-		{value: string("fit sdk"), size: 8},
-		{value: []string{"fit sdk"}, size: 8},
-		{value: []string{}, size: 0},
-		{value: []string{""}, size: 0},
-		{value: []string{"\x00"}, size: 0},
-		{value: []string{"fit sdk", "a"}, size: 10},
-		{value: []float32{10, 9, 8, 7}, size: 4},
-		{value: []float64{10, 9, 8, 7}, size: 4},
-		{value: []int64{10, 9, 8, 7}, size: 4},
-		{value: []uint64{10, 9, 8, 7}, size: 4},
-		{value: Uint8(7), size: 1},
-		{value: []Uint8{10, 9, 8, 7}, size: 4},
+		{value: int8(10), sizeInBytes: 1, baseType: basetype.Sint8},
+		{value: uint8(10), sizeInBytes: 1, baseType: basetype.Uint8},
+		{value: int16(10), sizeInBytes: 2, baseType: basetype.Sint16},
+		{value: uint16(10), sizeInBytes: 2, baseType: basetype.Uint16},
+		{value: int32(10), sizeInBytes: 4, baseType: basetype.Sint32},
+		{value: uint32(10), sizeInBytes: 4, baseType: basetype.Uint32},
+		{value: float32(10), sizeInBytes: 4, baseType: basetype.Float32},
+		{value: float64(10), sizeInBytes: 8, baseType: basetype.Float64},
+		{value: int64(10), sizeInBytes: 8, baseType: basetype.Sint64},
+		{value: uint64(10), sizeInBytes: 8, baseType: basetype.Uint64},
+		{value: []int8{10, 9, 8, 7}, sizeInBytes: 4, baseType: basetype.Sint8},
+		{value: []uint8{10, 9, 8, 7}, sizeInBytes: 4, baseType: basetype.Uint8},
+		{value: []int16{10, 9, 8, 7}, sizeInBytes: 4 * 2, baseType: basetype.Uint16},
+		{value: []uint16{10, 9, 8, 7}, sizeInBytes: 4 * 2, baseType: basetype.Uint16},
+		{value: []int32{10, 9, 8, 7}, sizeInBytes: 4 * 4, baseType: basetype.Sint32},
+		{value: []uint32{10, 9, 8, 7}, sizeInBytes: 4 * 4, baseType: basetype.Uint32},
+		{value: string(""), sizeInBytes: 1, baseType: basetype.String},
+		{value: string("\x00"), sizeInBytes: 1, baseType: basetype.String},
+		{value: string("fit sdk"), sizeInBytes: 8, baseType: basetype.String},
+		{value: string("fit sdk\x00"), sizeInBytes: 8, baseType: basetype.String},
+		{value: []string{"fit sdk"}, sizeInBytes: 8, baseType: basetype.String},
+		{value: []string{}, sizeInBytes: 1, baseType: basetype.String},
+		{value: []string{""}, sizeInBytes: 1, baseType: basetype.String},
+		{value: []string{"\x00"}, sizeInBytes: 1, baseType: basetype.String},
+		{value: []string{"\x00\x00\x00"}, sizeInBytes: 3, baseType: basetype.String},
+		{value: []string{"\x00", "\x00", "\x00"}, sizeInBytes: 3, baseType: basetype.String},
+		{value: []string{"fit sdk", "a"}, sizeInBytes: 10, baseType: basetype.String},
+		{value: []string{"fit sdk\x00", "a\x00"}, sizeInBytes: 10, baseType: basetype.String},
+		{value: []float32{10, 9, 8, 7}, sizeInBytes: 4 * 4, baseType: basetype.Float32},
+		{value: []float64{10, 9, 8, 7}, sizeInBytes: 4 * 8, baseType: basetype.Float64},
+		{value: []int64{10, 9, 8, 7}, sizeInBytes: 4 * 8, baseType: basetype.Sint64},
+		{value: []uint64{10, 9, 8, 7}, sizeInBytes: 4 * 8, baseType: basetype.Uint64},
+		{value: test_uint8(7), sizeInBytes: 1, baseType: basetype.Uint8},
+		{value: []test_uint8{10, 9, 8, 7}, sizeInBytes: 4, baseType: basetype.Uint8},
+		{value: test_string(""), sizeInBytes: 1, baseType: basetype.String},
+		{value: test_string("\x00"), sizeInBytes: 1, baseType: basetype.String},
+		{value: test_string("abc"), sizeInBytes: 4, baseType: basetype.String},
+		{value: []test_string{}, sizeInBytes: 1, baseType: basetype.String},
+		{value: []test_string{""}, sizeInBytes: 1, baseType: basetype.String},
+		{value: []test_string{"\x00"}, sizeInBytes: 1, baseType: basetype.String},
+		{value: []test_string{"abc"}, sizeInBytes: 4, baseType: basetype.String},
 	}
 	for _, tc := range tt {
 		t.Run(fmt.Sprintf("%T(%v)", tc.value, tc.value), func(t *testing.T) {
-			size := typedef.Len(tc.value)
-			if size != tc.size {
-				t.Fatalf("expected: %d, got: %d", tc.size, size)
+			size := typedef.Sizeof(tc.value, tc.baseType)
+			if size != tc.sizeInBytes {
+				t.Fatalf("expected: %d, got: %d", tc.sizeInBytes, size)
 			}
 		})
 	}

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -62,7 +62,7 @@ func CreateMessageDefinitionTo(target *MessageDefinition, mesg *Message) {
 	for i := range mesg.Fields {
 		target.FieldDefinitions = append(target.FieldDefinitions, FieldDefinition{
 			Num:      mesg.Fields[i].Num,
-			Size:     mesg.Fields[i].Type.BaseType().Size() * typedef.Len(mesg.Fields[i].Value),
+			Size:     byte(typedef.Sizeof(mesg.Fields[i].Value, mesg.Fields[i].Type.BaseType())),
 			BaseType: mesg.Fields[i].Type.BaseType(),
 		})
 	}


### PR DESCRIPTION
Now encoder's validator will validate the `n of fields`, `n of developer fields` as well as size of its value in bytes should not exceed 255. We are more confident in the resulting FIT file validity.