### PR TITLE
perf: proto memory alignment

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -686,9 +686,8 @@ func (d *Decoder) expandComponents(mesg *proto.Message, containingField *proto.F
 
 		componentScaled := scaleoffset.Apply(val, component.Scale, component.Offset)
 		val = uint32(scaleoffset.Discard(componentScaled, componentField.Scale, componentField.Offset))
-		value := valueFromBits(val, componentField.Type.BaseType())
+		componentField.Value = valueFromBits(val, componentField.Type.BaseType())
 
-		componentField.Value = value
 		mesg.Fields = append(mesg.Fields, componentField)
 
 		// The destination field (componentField) can itself contain components requiring expansion.
@@ -795,10 +794,8 @@ func (d *Decoder) read(b []byte) error {
 // readByte is shorthand for read([1]byte).
 func (d *Decoder) readByte() (byte, error) {
 	b := d.bytesArray[:1]
-	if err := d.read(b); err != nil {
-		return 0, err
-	}
-	return b[0], nil
+	err := d.read(b)
+	return b[0], err
 }
 
 // readValue reads message value bytes from reader and convert it into its corresponding type.

--- a/factory/factory_gen.go
+++ b/factory/factory_gen.go
@@ -961,7 +961,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "activity_tracker_enabled",
 					Num:        36,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -1006,7 +1006,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "move_alert_enabled",
 					Num:        46,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -1111,7 +1111,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "lactate_threshold_autodetect_enabled",
 					Num:        80,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -1126,7 +1126,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ble_auto_upload_enabled",
 					Num:        86,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -1691,7 +1691,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        0,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -1721,7 +1721,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "log_hrv",
 					Num:        2,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -1771,7 +1771,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        0,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -1831,7 +1831,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "speed_source",
 					Num:        4,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2076,7 +2076,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "auto_wheel_cal",
 					Num:        12,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2091,7 +2091,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "auto_power_zero",
 					Num:        13,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2121,7 +2121,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "spd_enabled",
 					Num:        15,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2136,7 +2136,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "cad_enabled",
 					Num:        16,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2151,7 +2151,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "spdcad_enabled",
 					Num:        17,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2166,7 +2166,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "power_enabled",
 					Num:        18,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2196,7 +2196,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        20,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2346,7 +2346,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "shimano_di2_enabled",
 					Num:        44,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2366,7 +2366,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bluetooth_enabled",
 					Num:        0,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2381,7 +2381,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "bluetooth_le_enabled",
 					Num:        1,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2396,7 +2396,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "ant_enabled",
 					Num:        2,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2426,7 +2426,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "live_tracking_enabled",
 					Num:        4,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2441,7 +2441,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "weather_conditions_enabled",
 					Num:        5,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2456,7 +2456,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "weather_alerts_enabled",
 					Num:        6,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2471,7 +2471,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "auto_activity_upload_enabled",
 					Num:        7,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2486,7 +2486,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "course_download_enabled",
 					Num:        8,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2501,7 +2501,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "workout_download_enabled",
 					Num:        9,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2516,7 +2516,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "gps_ephemeris_download_enabled",
 					Num:        10,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2531,7 +2531,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "incident_detection_enabled",
 					Num:        11,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -2546,7 +2546,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "grouptrack_enabled",
 					Num:        12,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -3484,7 +3484,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "safety_stop_enabled",
 					Num:        9,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -3529,7 +3529,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "apnea_countdown_enabled",
 					Num:        12,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -3797,7 +3797,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "up_key_enabled",
 					Num:        30,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -3907,7 +3907,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        2,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -3982,7 +3982,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "popup_enabled",
 					Num:        7,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -3997,7 +3997,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "trigger_on_descent",
 					Num:        8,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -4012,7 +4012,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "trigger_on_ascent",
 					Num:        9,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -4027,7 +4027,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "repeating",
 					Num:        10,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -4107,7 +4107,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        2,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -4182,7 +4182,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "popup_enabled",
 					Num:        7,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -4197,7 +4197,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "trigger_on_descent",
 					Num:        8,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -4212,7 +4212,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "trigger_on_ascent",
 					Num:        9,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -4227,7 +4227,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "repeating",
 					Num:        10,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -4447,7 +4447,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "repeat",
 					Num:        6,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -4507,7 +4507,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        10,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -14922,7 +14922,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "favorite",
 					Num:        8,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -14987,7 +14987,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        3,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -16777,7 +16777,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "enabled",
 					Num:        3,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -17806,7 +17806,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "completed",
 					Num:        4,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -19282,7 +19282,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "calibrated_data",
 					Num:        9,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -19797,7 +19797,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "screen_enabled",
 					Num:        3,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,
@@ -20068,7 +20068,7 @@ var mesgs = [...]proto.Message{
 				FieldBase: &proto.FieldBase{
 					Name:       "is_signed",
 					Num:        11,
-					Type:       profile.Bool, /* basetype.Bool (size: 0) */
+					Type:       profile.Bool, /* basetype.Enum (size: 1) */
 					Array:      false,
 					Components: nil,
 					Scale:      1,

--- a/internal/cmd/fitgen/factory/builder.go
+++ b/internal/cmd/fitgen/factory/builder.go
@@ -85,7 +85,7 @@ func (b *factoryBuilder) populateLookupData() {
 	}
 
 	// additional profile type which is not defined in basetype.
-	b.types = append(b.types, parser.Type{Name: "bool", BaseType: "bool"})
+	b.types = append(b.types, parser.Type{Name: "bool", BaseType: "enum"})
 
 	for _, _type := range b.types {
 		b.goTypesByProfileTypes[_type.Name] = goTypesByBaseTypes[_type.BaseType]
@@ -281,7 +281,11 @@ func (b *factoryBuilder) transformProfileType(fieldType string) string {
 }
 
 func (b *factoryBuilder) transformBaseType(fieldType string) string {
-	return "basetype." + strutil.ToTitle(b.baseTypeMapByProfileType[fieldType]) // basetype.Uint16z
+	baseType := b.baseTypeMapByProfileType[fieldType]
+	if baseType == "bool" {
+		baseType = "enum"
+	}
+	return "basetype." + strutil.ToTitle(baseType) // basetype.Uint16z
 }
 
 func (b *factoryBuilder) transformMesgnum(s string) string {

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -193,9 +193,8 @@ func (m *Message) FieldByNum(num byte) *Field {
 // FieldValueByNum returns the value of the Field in a Messsage, if not found return nil.
 func (m *Message) FieldValueByNum(num byte) any {
 	for i := range m.Fields {
-		field := &m.Fields[i]
-		if field.Num == num {
-			return field.Value
+		if m.Fields[i].Num == num {
+			return m.Fields[i].Value
 		}
 	}
 	return nil
@@ -203,33 +202,22 @@ func (m *Message) FieldValueByNum(num byte) any {
 
 // RemoveFieldByNum removes Field in a Message by num.
 func (m *Message) RemoveFieldByNum(num byte) {
-	var idx *int
 	for i := range m.Fields {
 		if m.Fields[i].Num == num {
-			idx = &i
-			break
+			m.Fields = append(m.Fields[:i], m.Fields[i+1:]...)
+			return
 		}
-	}
-
-	if idx != nil {
-		m.Fields = append(m.Fields[:*idx], m.Fields[*idx+1:]...)
 	}
 }
 
 // Clone clones Message.
 func (m Message) Clone() Message {
-	fields := make([]Field, 0)
 	for i := range m.Fields {
-		fields = append(fields, m.Fields[i].Clone())
+		m.Fields[i] = m.Fields[i].Clone()
 	}
-	m.Fields = fields
-
-	developerFields := make([]DeveloperField, 0)
 	for i := range m.DeveloperFields {
-		developerFields = append(developerFields, m.DeveloperFields[i].Clone())
+		m.DeveloperFields[i] = m.DeveloperFields[i].Clone()
 	}
-	m.DeveloperFields = developerFields
-
 	return m
 }
 
@@ -240,10 +228,10 @@ type FieldBase struct {
 	Num        byte                // Defined in the Global FIT profile for the specified FIT message, otherwise its a manufaturer specific number (defined by manufacturer). (255 == invalid)
 	Type       profile.ProfileType // Type is defined type that serves as an abstraction layer above base types (primitive-types), e.g. DateTime is a time representation in uint32.
 	Array      bool                // Flag whether the value of this field is an array
+	Accumulate bool                // Flag to indicate if the value of the field is accumulable.
 	Scale      float64             // A scale or offset specified in the FIT profile for binary fields (sint/uint etc.) only. the binary quantity is divided by the scale factor and then the offset is subtracted. (default: 1)
 	Offset     float64             // A scale or offset specified in the FIT profile for binary fields (sint/uint etc.) only. the binary quantity is divided by the scale factor and then the offset is subtracted. (default: 0)
 	Units      string              // Units of the value, such as m (meter), m/s (meter per second), s (second), etc.
-	Accumulate bool                // Flag to indicate if the value of the field is accumulable.
 	Components []Component         // List of components
 	SubFields  []SubField          // List of sub-fields
 }
@@ -331,8 +319,8 @@ type DeveloperField struct {
 	Size               byte
 	NativeMesgNum      typedef.MesgNum
 	NativeFieldNum     byte
-	Name               string
 	Type               basetype.BaseType
+	Name               string
 	Units              string
 	Value              any
 }
@@ -346,10 +334,10 @@ func (f DeveloperField) Clone() DeveloperField {
 // The component can be expanded as a main Field in a Message or to update the value of the destination main Field.
 type Component struct {
 	FieldNum   byte
-	Scale      float64
-	Offset     float64
 	Accumulate bool
 	Bits       byte // bit value max 32
+	Scale      float64
+	Offset     float64
 }
 
 // SubField is a dynamic interpretation of the main Field in a Message when the SubFieldMap mapping match. See SubFieldMap's docs.


### PR DESCRIPTION
Let's assume we compile our program for 64 bit machine, which memory block is every 8 bytes.
Previously, we have this proto.FieldBase struct having  112 bytes as follows:
```go
type FieldBase struct {
	Name       string // 16
	Num        byte // 1
	Type       profile.ProfileType // 2
	Array      bool // 1
        // +4 padding bytes
	Scale      float64 // 8
	Offset     float64 // 8
	Units      string // 16
	Accumulate bool // 1
        // +7 padding bytes
	Components []Component // 24
	SubFields  []SubField // 24
}
```

By re-arrange the struct order, we can save 8 bytes, so the size is now 104 bytes per proto.FieldBase:

```go
type FieldBase struct {
	Name       string // 16
	Num        byte // 1
	Type       profile.ProfileType // 2
	Array      bool // 1
	Accumulate bool // 1
        // +3 padding bytes 
	Scale      float64 // 8
	Offset     float64 // 8
	Units      string // 16
	Components []Component // 24
	SubFields  []SubField // 24
}
```

At the moment we have 394 predefined messages in the factory containing 1307 fields in total, we save **1307 * 8 = 10.456 bytes (10KB)**. We also aligning the proto.Component to save 8 bytes, we save approx. 600 bytes. And we also align proto.DeveloperField but this depend on user input. Total 11KB, sound small but it can accumulate if user add Product Profile (manufacturer specific message). In general, it's always good to save what we can save.

Aside from that change, we also make (*Decoder).readByte as inline call by reducing unnecessary condition cost:
- from `./decoder.go:796:6: cannot inline (*Decoder).readByte: function too complex: cost 86 exceeds budget 80`
- to `./decoder.go:796:6: can inline (*Decoder).readByte with cost 79`

It's ok to return the value of b[0] even if error occurs, since in our convention we will ignore the value when error occurs on reading bytes.