### PR TITLE
perf: reduce alloc on decoder's component expansion

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -664,10 +664,14 @@ func (d *Decoder) expandComponents(mesg *proto.Message, containingField *proto.F
 		return
 	}
 
+	// PERF: Reuse a single variable 'componentField' instead of declaring it inside the loop to prevent
+	// the Compiler's escape analysis from moving it to the heap, which could occur due to the risk of
+	// stack overflow caused by repeatedly creating the variable.
+	var componentField proto.Field
 	for i := range components {
 		component := &components[i]
 
-		componentField := d.factory.CreateField(mesg.Num, component.FieldNum)
+		componentField = d.factory.CreateField(mesg.Num, component.FieldNum)
 		componentField.IsExpandedField = true
 
 		if component.Accumulate {


### PR DESCRIPTION
Escape analysis was deciding to move `componentField` into the heap, which could occur due to the risk of stack overflow caused by repeatedly creating the variable inside the loop.
<img width="1134" alt="Screen Shot 2024-03-14 at 10 49 15" src="https://github.com/muktihari/fit/assets/15964188/8c18f675-6291-4eb9-a0b6-5df764e933d6">

So I decide to move the variable declaration outside the loop so we only have one reusable variable and it's no longer escape to the heap. This reduces significant amount of memory usage and allocation, and also improve the decoding speed:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/decoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
         │   old.txt    │            new.txt             │
         │    sec/op    │    sec/op     vs base          │
Decode-4   147.8m ± 16%   130.0m ± 39%  ~ (p=0.089 n=10)

         │   old.txt    │               new.txt               │
         │     B/op     │     B/op      vs base               │
Decode-4   73.49Mi ± 0%   67.39Mi ± 0%  -8.31% (p=0.000 n=10)

         │   old.txt    │               new.txt               │
         │  allocs/op   │  allocs/op   vs base                │
Decode-4   1100.0k ± 0%   900.0k ± 0%  -18.18% (p=0.000 n=10)
```