### PR TITLE
feat!: mesgdef convert to mesg now has options as param

### DIFF
--- a/cmd/fitactivity/combiner/combiner.go
+++ b/cmd/fitactivity/combiner/combiner.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/muktihari/fit/cmd/fitactivity/finder"
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
@@ -96,7 +95,7 @@ func Combine(fits ...proto.Fit) (*proto.Fit, error) {
 		}
 
 		combineSession(session, nextSession)
-		sessionMesg = session.ToMesg(factory.StandardFactory())
+		sessionMesg = session.ToMesg(nil)
 
 		// Let's make "summary last sequence" order by updating session's timestamp with last lastRecord's timestamp
 		lastRecord := fits[i].Messages[nextSessionInfo.RecordLastIndex]

--- a/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
+++ b/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
@@ -8,6 +8,7 @@
 package {{ .Package }}
 
 import (
+    "github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -77,8 +78,16 @@ func New{{ .Name }}(mesg *proto.Message) *{{ .Name }} {
 	}
 }
 
-// ToMesg converts {{ .Name }} into proto.Message.
-func (m *{{ .Name }}) ToMesg(fac Factory) proto.Message {
+// ToMesg converts {{ .Name }} into proto.Message. If options is nil, default options will be used.
+func (m *{{ .Name }}) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+        options.Factory = factory.StandardFactory()
+    }
+
+    fac := options.Factory
+
     fieldsArray := fieldsPool.Get().(*[256]proto.Field)
     defer fieldsPool.Put(fieldsArray)
     
@@ -86,7 +95,7 @@ func (m *{{ .Name }}) ToMesg(fac Factory) proto.Message {
     mesg := fac.CreateMesgOnly(typedef.MesgNum{{ .Name }})
 	
     {{ range .Fields -}}
-        if {{ .ComparableValue }} != {{ .InvalidValue }} {
+        if {{ .ComparableValue }} != {{ .InvalidValue }} {{ if eq .CanExpand true -}} && ((m.IsExpandedFields[{{ .Num }}] && options.IncludeExpandedFields) || !m.IsExpandedFields[{{ .Num }}]) {{ end }} {
 			field := fac.CreateField(mesg.Num, {{ .Num }})
 			field.Value = {{ .PrimitiveValue }}
 			{{ if eq .CanExpand true -}}

--- a/profile/filedef/activity.go
+++ b/profile/filedef/activity.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -48,6 +47,7 @@ type Activity struct {
 
 var _ File = &Activity{}
 
+// NewActivity creates new Activity File.
 func NewActivity(mesgs ...proto.Message) *Activity {
 	f := &Activity{}
 	for i := range mesgs {
@@ -57,6 +57,7 @@ func NewActivity(mesgs ...proto.Message) *Activity {
 	return f
 }
 
+// Add adds mesg to the Activity.
 func (f *Activity) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -98,11 +99,8 @@ func (f *Activity) Add(mesg proto.Message) {
 	}
 }
 
-func (f *Activity) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts Activity to proto.Fit. If options is nil, default options will be used.
+func (f *Activity) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 3 // non slice fields
 
 	size += len(f.Sessions) + len(f.Laps) + len(f.Records) + len(f.DeviceInfos) +
@@ -115,32 +113,32 @@ func (f *Activity) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeviceInfo, f.DeviceInfos)
+	ToMesgs(&fit.Messages, options, mesgnum.DeviceInfo, f.DeviceInfos)
 
 	if f.UserProfile != nil {
-		fit.Messages = append(fit.Messages, f.UserProfile.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.UserProfile.ToMesg(options))
 	}
 
 	if f.Activity != nil {
-		fit.Messages = append(fit.Messages, f.Activity.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.Activity.ToMesg(options))
 	}
 
-	ToMesgs(&fit.Messages, fac, mesgnum.Session, f.Sessions)
-	ToMesgs(&fit.Messages, fac, mesgnum.Lap, f.Laps)
-	ToMesgs(&fit.Messages, fac, mesgnum.Record, f.Records)
-	ToMesgs(&fit.Messages, fac, mesgnum.Event, f.Events)
-	ToMesgs(&fit.Messages, fac, mesgnum.Length, f.Lengths)
-	ToMesgs(&fit.Messages, fac, mesgnum.SegmentLap, f.SegmentLap)
-	ToMesgs(&fit.Messages, fac, mesgnum.ZonesTarget, f.ZonesTargets)
-	ToMesgs(&fit.Messages, fac, mesgnum.Workout, f.Workouts)
-	ToMesgs(&fit.Messages, fac, mesgnum.WorkoutStep, f.WorkoutSteps)
-	ToMesgs(&fit.Messages, fac, mesgnum.Hr, f.HRs)
-	ToMesgs(&fit.Messages, fac, mesgnum.Hrv, f.HRVs)
+	ToMesgs(&fit.Messages, options, mesgnum.Session, f.Sessions)
+	ToMesgs(&fit.Messages, options, mesgnum.Lap, f.Laps)
+	ToMesgs(&fit.Messages, options, mesgnum.Record, f.Records)
+	ToMesgs(&fit.Messages, options, mesgnum.Event, f.Events)
+	ToMesgs(&fit.Messages, options, mesgnum.Length, f.Lengths)
+	ToMesgs(&fit.Messages, options, mesgnum.SegmentLap, f.SegmentLap)
+	ToMesgs(&fit.Messages, options, mesgnum.ZonesTarget, f.ZonesTargets)
+	ToMesgs(&fit.Messages, options, mesgnum.Workout, f.Workouts)
+	ToMesgs(&fit.Messages, options, mesgnum.WorkoutStep, f.WorkoutSteps)
+	ToMesgs(&fit.Messages, options, mesgnum.Hr, f.HRs)
+	ToMesgs(&fit.Messages, options, mesgnum.Hrv, f.HRVs)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/activity_summary.go
+++ b/profile/filedef/activity_summary.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -28,6 +27,7 @@ type ActivitySummary struct {
 
 var _ File = &ActivitySummary{}
 
+// NewActivitySummary creates new ActivitySummary File.
 func NewActivitySummary(mesgs ...proto.Message) *ActivitySummary {
 	f := &ActivitySummary{}
 	for i := range mesgs {
@@ -37,6 +37,7 @@ func NewActivitySummary(mesgs ...proto.Message) *ActivitySummary {
 	return f
 }
 
+// Add adds mesg to the ActivitySummary.
 func (f *ActivitySummary) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -56,11 +57,8 @@ func (f *ActivitySummary) Add(mesg proto.Message) {
 	}
 }
 
-func (f *ActivitySummary) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts ActivitySummary to proto.Fit. If options is nil, default options will be used.
+func (f *ActivitySummary) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 2 // non slice fields
 
 	size += len(f.Sessions) + len(f.Laps) + len(f.DeveloperDataIds) +
@@ -71,17 +69,17 @@ func (f *ActivitySummary) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
 	if f.Activity != nil {
-		fit.Messages = append(fit.Messages, f.Activity.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.Activity.ToMesg(options))
 	}
 
-	ToMesgs(&fit.Messages, fac, mesgnum.Session, f.Sessions)
-	ToMesgs(&fit.Messages, fac, mesgnum.Lap, f.Laps)
+	ToMesgs(&fit.Messages, options, mesgnum.Session, f.Sessions)
+	ToMesgs(&fit.Messages, options, mesgnum.Lap, f.Laps)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/blood_pressure.go
+++ b/profile/filedef/blood_pressure.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -28,6 +27,7 @@ type BloodPressure struct {
 
 var _ File = &BloodPressure{}
 
+// NewBloodPressure creates new BloodPressure File.
 func NewBloodPressure(mesgs ...proto.Message) *BloodPressure {
 	f := &BloodPressure{}
 	for i := range mesgs {
@@ -37,6 +37,7 @@ func NewBloodPressure(mesgs ...proto.Message) *BloodPressure {
 	return f
 }
 
+// Add adds mesg to the BloodPressure.
 func (f *BloodPressure) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -56,11 +57,8 @@ func (f *BloodPressure) Add(mesg proto.Message) {
 	}
 }
 
-func (f *BloodPressure) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts BloodPressure to proto.Fit. If options is nil, default options will be used.
+func (f *BloodPressure) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 2 // non slice fields
 
 	size += len(f.BloodPressures) + len(f.DeviceInfos) +
@@ -71,17 +69,17 @@ func (f *BloodPressure) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
 	if f.UserProfile != nil {
-		fit.Messages = append(fit.Messages, f.UserProfile.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.UserProfile.ToMesg(options))
 	}
 
-	ToMesgs(&fit.Messages, fac, mesgnum.BloodPressure, f.BloodPressures)
-	ToMesgs(&fit.Messages, fac, mesgnum.DeviceInfo, f.DeviceInfos)
+	ToMesgs(&fit.Messages, options, mesgnum.BloodPressure, f.BloodPressures)
+	ToMesgs(&fit.Messages, options, mesgnum.DeviceInfo, f.DeviceInfos)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/course.go
+++ b/profile/filedef/course.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -40,6 +39,7 @@ type Course struct {
 
 var _ File = &Course{}
 
+// NewCourse creates new Course File.
 func NewCourse(mesgs ...proto.Message) *Course {
 	f := &Course{}
 	for i := range mesgs {
@@ -49,6 +49,7 @@ func NewCourse(mesgs ...proto.Message) *Course {
 	return f
 }
 
+// Add adds mesg to the Course.
 func (f *Course) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -72,11 +73,8 @@ func (f *Course) Add(mesg proto.Message) {
 	}
 }
 
-func (f *Course) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts Course to proto.Fit. If options is nil, default options will be used.
+func (f *Course) ToFit(options *mesgdef.Options) proto.Fit {
 	size := 3 /* non slice fields */
 
 	size += len(f.Records) + len(f.Events) + len(f.CoursePoints) +
@@ -87,22 +85,22 @@ func (f *Course) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
 	if f.Course != nil {
-		fit.Messages = append(fit.Messages, f.Course.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.Course.ToMesg(options))
 	}
 
 	if f.Lap != nil {
-		fit.Messages = append(fit.Messages, f.Lap.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.Lap.ToMesg(options))
 	}
 
-	ToMesgs(&fit.Messages, fac, mesgnum.Record, f.Records)
-	ToMesgs(&fit.Messages, fac, mesgnum.Event, f.Events)
-	ToMesgs(&fit.Messages, fac, mesgnum.CoursePoint, f.CoursePoints)
+	ToMesgs(&fit.Messages, options, mesgnum.Record, f.Records)
+	ToMesgs(&fit.Messages, options, mesgnum.Event, f.Events)
+	ToMesgs(&fit.Messages, options, mesgnum.CoursePoint, f.CoursePoints)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/device.go
+++ b/profile/filedef/device.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -30,6 +29,7 @@ type Device struct {
 
 var _ File = &Device{}
 
+// NewDevice creates new Device File.
 func NewDevice(mesgs ...proto.Message) *Device {
 	f := &Device{}
 	for i := range mesgs {
@@ -39,6 +39,7 @@ func NewDevice(mesgs ...proto.Message) *Device {
 	return f
 }
 
+// Add adds mesg to the Device.
 func (f *Device) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -62,11 +63,8 @@ func (f *Device) Add(mesg proto.Message) {
 	}
 }
 
-func (f *Device) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts Device to proto.Fit. If options is nil, default options will be used.
+func (f *Device) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 1 // non slice fields
 
 	size += len(f.Softwares) + len(f.Capabilities) + len(f.FileCapabilities) +
@@ -78,16 +76,16 @@ func (f *Device) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
-	ToMesgs(&fit.Messages, fac, mesgnum.Software, f.Softwares)
-	ToMesgs(&fit.Messages, fac, mesgnum.Capabilities, f.Capabilities)
-	ToMesgs(&fit.Messages, fac, mesgnum.FileCapabilities, f.FileCapabilities)
-	ToMesgs(&fit.Messages, fac, mesgnum.MesgCapabilities, f.MesgCapabilities)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldCapabilities, f.FieldCapabilities)
+	ToMesgs(&fit.Messages, options, mesgnum.Software, f.Softwares)
+	ToMesgs(&fit.Messages, options, mesgnum.Capabilities, f.Capabilities)
+	ToMesgs(&fit.Messages, options, mesgnum.FileCapabilities, f.FileCapabilities)
+	ToMesgs(&fit.Messages, options, mesgnum.MesgCapabilities, f.MesgCapabilities)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldCapabilities, f.FieldCapabilities)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/filedef.go
+++ b/profile/filedef/filedef.go
@@ -18,19 +18,19 @@ type File interface {
 	// Add adds message into file structure.
 	Add(mesg proto.Message)
 	// ToFit converts file back to proto.Fit structure.
-	ToFit(fac mesgdef.Factory) proto.Fit
+	ToFit(options *mesgdef.Options) proto.Fit
 }
 
 // ToMesgs bulks convert mesgdef into proto.Message and append it to messages
-func ToMesgs[S []E, E ToMesg](messages *[]proto.Message, fac mesgdef.Factory, mesgNum typedef.MesgNum, s S) {
+func ToMesgs[S []E, E ToMesg](messages *[]proto.Message, options *mesgdef.Options, mesgNum typedef.MesgNum, s S) {
 	for i := range s {
-		*messages = append(*messages, s[i].ToMesg(fac))
+		*messages = append(*messages, s[i].ToMesg(options))
 	}
 }
 
 // ToMesg is a type constraint to retrieve all mesgdef structures which implement ToMesg method.
 type ToMesg interface {
-	ToMesg(fac mesgdef.Factory) proto.Message
+	ToMesg(options *mesgdef.Options) proto.Message
 }
 
 // SortMessagesByTimestamp sorts messages by timestamp only if the message has timestamp field.

--- a/profile/filedef/goals.go
+++ b/profile/filedef/goals.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -26,6 +25,7 @@ type Goals struct {
 
 var _ File = &Goals{}
 
+// NewGoals creates new Goals File.
 func NewGoals(mesgs ...proto.Message) *Goals {
 	f := &Goals{}
 	for i := range mesgs {
@@ -35,6 +35,7 @@ func NewGoals(mesgs ...proto.Message) *Goals {
 	return f
 }
 
+// Add adds mesg to the Goals.
 func (f *Goals) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -50,11 +51,8 @@ func (f *Goals) Add(mesg proto.Message) {
 	}
 }
 
-func (f *Goals) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts Goals to proto.Fit. If options is nil, default options will be used.
+func (f *Goals) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 1 // non slice fields
 
 	size += len(f.Goals) + len(f.DeveloperDataIds) +
@@ -65,12 +63,12 @@ func (f *Goals) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
-	ToMesgs(&fit.Messages, fac, mesgnum.Goal, f.Goals)
+	ToMesgs(&fit.Messages, options, mesgnum.Goal, f.Goals)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/monitoring_ab.go
+++ b/profile/filedef/monitoring_ab.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -32,6 +31,7 @@ type MonitoringAB struct {
 
 var _ File = &MonitoringAB{}
 
+// NewMonitoringAB creates new MonitoringAB File.
 func NewMonitoringAB(mesgs ...proto.Message) *MonitoringAB {
 	f := &MonitoringAB{}
 	for i := range mesgs {
@@ -41,6 +41,7 @@ func NewMonitoringAB(mesgs ...proto.Message) *MonitoringAB {
 	return f
 }
 
+// Add adds mesg to the MonitoringAB.
 func (f *MonitoringAB) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -60,11 +61,8 @@ func (f *MonitoringAB) Add(mesg proto.Message) {
 	}
 }
 
-func (f *MonitoringAB) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts MonitoringAB to proto.Fit. If options is nil, default options will be used.
+func (f *MonitoringAB) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 2 // non slice fields
 
 	size += len(f.Monitorings) + len(f.DeviceInfos) +
@@ -75,17 +73,17 @@ func (f *MonitoringAB) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
 	if f.MonitoringInfo != nil {
-		fit.Messages = append(fit.Messages, f.MonitoringInfo.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.MonitoringInfo.ToMesg(options))
 	}
 
-	ToMesgs(&fit.Messages, fac, mesgnum.Monitoring, f.Monitorings)
-	ToMesgs(&fit.Messages, fac, mesgnum.DeviceInfo, f.DeviceInfos)
+	ToMesgs(&fit.Messages, options, mesgnum.Monitoring, f.Monitorings)
+	ToMesgs(&fit.Messages, options, mesgnum.DeviceInfo, f.DeviceInfos)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/monitoring_daily.go
+++ b/profile/filedef/monitoring_daily.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -28,6 +27,7 @@ type MonitoringDaily struct {
 
 var _ File = &MonitoringDaily{}
 
+// NewMonitoringDaily creates new MonitoringDaily File.
 func NewMonitoringDaily(mesgs ...proto.Message) *MonitoringDaily {
 	f := &MonitoringDaily{}
 	for i := range mesgs {
@@ -37,6 +37,7 @@ func NewMonitoringDaily(mesgs ...proto.Message) *MonitoringDaily {
 	return f
 }
 
+// Add adds mesg to the MonitoringDaily.
 func (f *MonitoringDaily) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -56,11 +57,8 @@ func (f *MonitoringDaily) Add(mesg proto.Message) {
 	}
 }
 
-func (f *MonitoringDaily) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts MonitoringDaily to proto.Fit. If options is nil, default options will be used.
+func (f *MonitoringDaily) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 2 // non slice fields
 
 	size += len(f.Monitorings) + len(f.DeviceInfos) +
@@ -71,17 +69,17 @@ func (f *MonitoringDaily) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
 	if f.MonitoringInfo != nil {
-		fit.Messages = append(fit.Messages, f.MonitoringInfo.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.MonitoringInfo.ToMesg(options))
 	}
 
-	ToMesgs(&fit.Messages, fac, mesgnum.Monitoring, f.Monitorings)
-	ToMesgs(&fit.Messages, fac, mesgnum.DeviceInfo, f.DeviceInfos)
+	ToMesgs(&fit.Messages, options, mesgnum.Monitoring, f.Monitorings)
+	ToMesgs(&fit.Messages, options, mesgnum.DeviceInfo, f.DeviceInfos)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/schedules.go
+++ b/profile/filedef/schedules.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -26,6 +25,7 @@ type Schedules struct {
 
 var _ File = &Schedules{}
 
+// NewSchedules creates new Schedules File.
 func NewSchedules(mesgs ...proto.Message) *Schedules {
 	f := &Schedules{}
 	for i := range mesgs {
@@ -35,6 +35,7 @@ func NewSchedules(mesgs ...proto.Message) *Schedules {
 	return f
 }
 
+// Add adds mesg to the Schedules.
 func (f *Schedules) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -50,11 +51,8 @@ func (f *Schedules) Add(mesg proto.Message) {
 	}
 }
 
-func (f *Schedules) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts Schedules to proto.Fit. If options is nil, default options will be used.
+func (f *Schedules) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 1 // non slice fields
 
 	size += len(f.Schedules) + len(f.DeveloperDataIds) +
@@ -65,12 +63,12 @@ func (f *Schedules) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
-	ToMesgs(&fit.Messages, fac, mesgnum.Schedule, f.Schedules)
+	ToMesgs(&fit.Messages, options, mesgnum.Schedule, f.Schedules)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/segment.go
+++ b/profile/filedef/segment.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -29,6 +28,7 @@ type Segment struct {
 
 var _ File = &Segment{}
 
+// NewSegment creates new Segment File.
 func NewSegment(mesgs ...proto.Message) *Segment {
 	f := &Segment{}
 	for i := range mesgs {
@@ -38,6 +38,7 @@ func NewSegment(mesgs ...proto.Message) *Segment {
 	return f
 }
 
+// Add adds mesg to the Segment.
 func (f *Segment) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -59,11 +60,8 @@ func (f *Segment) Add(mesg proto.Message) {
 	}
 }
 
-func (f *Segment) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts Segment to proto.Fit. If options is nil, default options will be used.
+func (f *Segment) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 4 // non slice fields
 
 	size += len(f.SegmentPoints) + len(f.DeveloperDataIds) +
@@ -74,24 +72,24 @@ func (f *Segment) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
 	if f.SegmentId != nil {
-		fit.Messages = append(fit.Messages, f.SegmentId.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.SegmentId.ToMesg(options))
 	}
 
 	if f.SegmentLeaderboardEntry != nil {
-		fit.Messages = append(fit.Messages, f.SegmentLeaderboardEntry.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.SegmentLeaderboardEntry.ToMesg(options))
 	}
 
 	if f.SegmentLap != nil {
-		fit.Messages = append(fit.Messages, f.SegmentLap.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.SegmentLap.ToMesg(options))
 	}
 
-	ToMesgs(&fit.Messages, fac, mesgnum.SegmentPoint, f.SegmentPoints)
+	ToMesgs(&fit.Messages, options, mesgnum.SegmentPoint, f.SegmentPoints)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/segment_list.go
+++ b/profile/filedef/segment_list.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -27,6 +26,7 @@ type SegmentList struct {
 
 var _ File = &SegmentList{}
 
+// NewSegmentList creates new SegmentList File.
 func NewSegmentList(mesgs ...proto.Message) *SegmentList {
 	f := &SegmentList{}
 	for i := range mesgs {
@@ -36,6 +36,7 @@ func NewSegmentList(mesgs ...proto.Message) *SegmentList {
 	return f
 }
 
+// Add adds mesg to the SegmentList.
 func (f *SegmentList) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -53,11 +54,8 @@ func (f *SegmentList) Add(mesg proto.Message) {
 	}
 }
 
-func (f *SegmentList) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts SegmentList to proto.Fit. If options is nil, default options will be used.
+func (f *SegmentList) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 2 // non slice fields
 
 	size += len(f.SegmentFiles) + len(f.DeveloperDataIds) +
@@ -68,16 +66,16 @@ func (f *SegmentList) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
 	if f.FileCreator != nil {
-		fit.Messages = append(fit.Messages, f.FileCreator.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.FileCreator.ToMesg(options))
 	}
 
-	ToMesgs(&fit.Messages, fac, mesgnum.SegmentFile, f.SegmentFiles)
+	ToMesgs(&fit.Messages, options, mesgnum.SegmentFile, f.SegmentFiles)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/settings.go
+++ b/profile/filedef/settings.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -30,6 +29,7 @@ type Settings struct {
 
 var _ File = &Settings{}
 
+// NewSettings creates new Settings File.
 func NewSettings(mesgs ...proto.Message) *Settings {
 	f := &Settings{}
 	for i := range mesgs {
@@ -39,6 +39,7 @@ func NewSettings(mesgs ...proto.Message) *Settings {
 	return f
 }
 
+// Add adds mesg to the Settings.
 func (f *Settings) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -62,11 +63,8 @@ func (f *Settings) Add(mesg proto.Message) {
 	}
 }
 
-func (f *Settings) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts Settings to proto.Fit. If options is nil, default options will be used.
+func (f *Settings) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 1 // non slice fields
 
 	size += len(f.UserProfiles) + len(f.HrmProfiles) + len(f.SdmProfiles) +
@@ -78,16 +76,16 @@ func (f *Settings) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
-	ToMesgs(&fit.Messages, fac, mesgnum.UserProfile, f.UserProfiles)
-	ToMesgs(&fit.Messages, fac, mesgnum.HrmProfile, f.HrmProfiles)
-	ToMesgs(&fit.Messages, fac, mesgnum.SdmProfile, f.SdmProfiles)
-	ToMesgs(&fit.Messages, fac, mesgnum.BikeProfile, f.BikeProfiles)
-	ToMesgs(&fit.Messages, fac, mesgnum.DeviceSettings, f.DeviceSettings)
+	ToMesgs(&fit.Messages, options, mesgnum.UserProfile, f.UserProfiles)
+	ToMesgs(&fit.Messages, options, mesgnum.HrmProfile, f.HrmProfiles)
+	ToMesgs(&fit.Messages, options, mesgnum.SdmProfile, f.SdmProfiles)
+	ToMesgs(&fit.Messages, options, mesgnum.BikeProfile, f.BikeProfiles)
+	ToMesgs(&fit.Messages, options, mesgnum.DeviceSettings, f.DeviceSettings)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/sport.go
+++ b/profile/filedef/sport.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -32,6 +31,7 @@ type Sport struct {
 
 var _ File = &Sport{}
 
+// NewSport creates new Sport File.
 func NewSport(mesgs ...proto.Message) *Sport {
 	f := &Sport{}
 	for i := range mesgs {
@@ -41,6 +41,7 @@ func NewSport(mesgs ...proto.Message) *Sport {
 	return f
 }
 
+// Add adds mesg to the Sport.
 func (f *Sport) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -68,11 +69,8 @@ func (f *Sport) Add(mesg proto.Message) {
 	}
 }
 
-func (f *Sport) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts Sport to proto.Fit. If options is nil, default options will be used.
+func (f *Sport) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 2 // non slice fields
 
 	size += len(f.ZonesTargets) + len(f.HrZones) + len(f.PowerZones) +
@@ -84,22 +82,22 @@ func (f *Sport) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
-	ToMesgs(&fit.Messages, fac, mesgnum.ZonesTarget, f.ZonesTargets)
+	ToMesgs(&fit.Messages, options, mesgnum.ZonesTarget, f.ZonesTargets)
 
 	if f.Sport != nil {
-		fit.Messages = append(fit.Messages, f.Sport.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.Sport.ToMesg(options))
 	}
 
-	ToMesgs(&fit.Messages, fac, mesgnum.HrZone, f.HrZones)
-	ToMesgs(&fit.Messages, fac, mesgnum.PowerZone, f.PowerZones)
-	ToMesgs(&fit.Messages, fac, mesgnum.MetZone, f.MetZones)
-	ToMesgs(&fit.Messages, fac, mesgnum.SpeedZone, f.SpeedZones)
-	ToMesgs(&fit.Messages, fac, mesgnum.CadenceZone, f.CadenceZones)
+	ToMesgs(&fit.Messages, options, mesgnum.HrZone, f.HrZones)
+	ToMesgs(&fit.Messages, options, mesgnum.PowerZone, f.PowerZones)
+	ToMesgs(&fit.Messages, options, mesgnum.MetZone, f.MetZones)
+	ToMesgs(&fit.Messages, options, mesgnum.SpeedZone, f.SpeedZones)
+	ToMesgs(&fit.Messages, options, mesgnum.CadenceZone, f.CadenceZones)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/totals.go
+++ b/profile/filedef/totals.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -27,6 +26,7 @@ type Totals struct {
 
 var _ File = &Totals{}
 
+// NewTotals creates new Totals File.
 func NewTotals(mesgs ...proto.Message) *Totals {
 	f := &Totals{}
 	for i := range mesgs {
@@ -36,6 +36,7 @@ func NewTotals(mesgs ...proto.Message) *Totals {
 	return f
 }
 
+// Add adds mesg to the Totals.
 func (f *Totals) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -51,11 +52,8 @@ func (f *Totals) Add(mesg proto.Message) {
 	}
 }
 
-func (f *Totals) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts Totals to proto.Fit. If options is nil, default options will be used.
+func (f *Totals) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 3 // non slice fields
 
 	size += len(f.Totals) + len(f.DeveloperDataIds) +
@@ -66,12 +64,12 @@ func (f *Totals) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
-	ToMesgs(&fit.Messages, fac, mesgnum.Totals, f.Totals)
+	ToMesgs(&fit.Messages, options, mesgnum.Totals, f.Totals)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/weight.go
+++ b/profile/filedef/weight.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -28,6 +27,7 @@ type Weight struct {
 
 var _ File = &Weight{}
 
+// NewWeight creates new Weight File.
 func NewWeight(mesgs ...proto.Message) *Weight {
 	f := &Weight{}
 	for i := range mesgs {
@@ -37,6 +37,7 @@ func NewWeight(mesgs ...proto.Message) *Weight {
 	return f
 }
 
+// Add adds mesg to the Weight.
 func (f *Weight) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -56,11 +57,8 @@ func (f *Weight) Add(mesg proto.Message) {
 	}
 }
 
-func (f *Weight) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts Weight to proto.Fit. If options is nil, default options will be used.
+func (f *Weight) ToFit(options *mesgdef.Options) proto.Fit {
 	var size = 2 // non slice fields
 
 	size += len(f.WeightScales) + len(f.DeviceInfos) +
@@ -71,17 +69,17 @@ func (f *Weight) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
 	if f.UserProfile != nil {
-		fit.Messages = append(fit.Messages, f.UserProfile.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.UserProfile.ToMesg(options))
 	}
 
-	ToMesgs(&fit.Messages, fac, mesgnum.WeightScale, f.WeightScales)
-	ToMesgs(&fit.Messages, fac, mesgnum.DeviceInfo, f.DeviceInfos)
+	ToMesgs(&fit.Messages, options, mesgnum.WeightScale, f.WeightScales)
+	ToMesgs(&fit.Messages, options, mesgnum.DeviceInfo, f.DeviceInfos)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/workout.go
+++ b/profile/filedef/workout.go
@@ -5,7 +5,6 @@
 package filedef
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -31,6 +30,7 @@ type Workout struct {
 
 var _ File = &Workout{}
 
+// NewWorkout creates new Workout File.
 func NewWorkout(mesgs ...proto.Message) *Workout {
 	f := &Workout{}
 	for i := range mesgs {
@@ -40,6 +40,7 @@ func NewWorkout(mesgs ...proto.Message) *Workout {
 	return f
 }
 
+// Add adds mesg to the Workout.
 func (f *Workout) Add(mesg proto.Message) {
 	switch mesg.Num {
 	case mesgnum.FileId:
@@ -57,11 +58,8 @@ func (f *Workout) Add(mesg proto.Message) {
 	}
 }
 
-func (f *Workout) ToFit(fac mesgdef.Factory) proto.Fit {
-	if fac == nil {
-		fac = factory.StandardFactory()
-	}
-
+// ToFit converts Workout to proto.Fit. If options is nil, default options will be used.
+func (f *Workout) ToFit(options *mesgdef.Options) proto.Fit {
 	size := 2 /* non slice fields */
 
 	size += len(f.WorkoutSteps) + len(f.DeveloperDataIds) + len(f.FieldDescriptions) + len(f.UnrelatedMessages)
@@ -71,16 +69,16 @@ func (f *Workout) ToFit(fac mesgdef.Factory) proto.Fit {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
-	fit.Messages = append(fit.Messages, f.FileId.ToMesg(fac))
+	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, fac, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, fac, mesgnum.FieldDescription, f.FieldDescriptions)
+	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
+	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
 
 	if f.Workout != nil {
-		fit.Messages = append(fit.Messages, f.Workout.ToMesg(fac))
+		fit.Messages = append(fit.Messages, f.Workout.ToMesg(options))
 	}
 
-	ToMesgs(&fit.Messages, fac, mesgnum.WorkoutStep, f.WorkoutSteps)
+	ToMesgs(&fit.Messages, options, mesgnum.WorkoutStep, f.WorkoutSteps)
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/mesgdef/aad_accel_features_gen.go
+++ b/profile/mesgdef/aad_accel_features_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -58,8 +59,16 @@ func NewAadAccelFeatures(mesg *proto.Message) *AadAccelFeatures {
 	}
 }
 
-// ToMesg converts AadAccelFeatures into proto.Message.
-func (m *AadAccelFeatures) ToMesg(fac Factory) proto.Message {
+// ToMesg converts AadAccelFeatures into proto.Message. If options is nil, default options will be used.
+func (m *AadAccelFeatures) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/accelerometer_data_gen.go
+++ b/profile/mesgdef/accelerometer_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -69,8 +70,16 @@ func NewAccelerometerData(mesg *proto.Message) *AccelerometerData {
 	}
 }
 
-// ToMesg converts AccelerometerData into proto.Message.
-func (m *AccelerometerData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts AccelerometerData into proto.Message. If options is nil, default options will be used.
+func (m *AccelerometerData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/activity_gen.go
+++ b/profile/mesgdef/activity_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -62,8 +63,16 @@ func NewActivity(mesg *proto.Message) *Activity {
 	}
 }
 
-// ToMesg converts Activity into proto.Message.
-func (m *Activity) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Activity into proto.Message. If options is nil, default options will be used.
+func (m *Activity) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/ant_channel_id_gen.go
+++ b/profile/mesgdef/ant_channel_id_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -53,8 +54,16 @@ func NewAntChannelId(mesg *proto.Message) *AntChannelId {
 	}
 }
 
-// ToMesg converts AntChannelId into proto.Message.
-func (m *AntChannelId) ToMesg(fac Factory) proto.Message {
+// ToMesg converts AntChannelId into proto.Message. If options is nil, default options will be used.
+func (m *AntChannelId) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/ant_rx_gen.go
+++ b/profile/mesgdef/ant_rx_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -66,8 +67,16 @@ func NewAntRx(mesg *proto.Message) *AntRx {
 	}
 }
 
-// ToMesg converts AntRx into proto.Message.
-func (m *AntRx) ToMesg(fac Factory) proto.Message {
+// ToMesg converts AntRx into proto.Message. If options is nil, default options will be used.
+func (m *AntRx) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -84,7 +93,7 @@ func (m *AntRx) ToMesg(fac Factory) proto.Message {
 		field.Value = m.MesgData
 		fields = append(fields, field)
 	}
-	if m.Data != nil {
+	if m.Data != nil && ((m.IsExpandedFields[4] && options.IncludeExpandedFields) || !m.IsExpandedFields[4]) {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Data
 		field.IsExpandedField = m.IsExpandedFields[4]
@@ -100,7 +109,7 @@ func (m *AntRx) ToMesg(fac Factory) proto.Message {
 		field.Value = m.MesgId
 		fields = append(fields, field)
 	}
-	if m.ChannelNumber != basetype.Uint8Invalid {
+	if m.ChannelNumber != basetype.Uint8Invalid && ((m.IsExpandedFields[3] && options.IncludeExpandedFields) || !m.IsExpandedFields[3]) {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ChannelNumber
 		field.IsExpandedField = m.IsExpandedFields[3]

--- a/profile/mesgdef/ant_tx_gen.go
+++ b/profile/mesgdef/ant_tx_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -66,8 +67,16 @@ func NewAntTx(mesg *proto.Message) *AntTx {
 	}
 }
 
-// ToMesg converts AntTx into proto.Message.
-func (m *AntTx) ToMesg(fac Factory) proto.Message {
+// ToMesg converts AntTx into proto.Message. If options is nil, default options will be used.
+func (m *AntTx) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -84,7 +93,7 @@ func (m *AntTx) ToMesg(fac Factory) proto.Message {
 		field.Value = m.MesgData
 		fields = append(fields, field)
 	}
-	if m.Data != nil {
+	if m.Data != nil && ((m.IsExpandedFields[4] && options.IncludeExpandedFields) || !m.IsExpandedFields[4]) {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Data
 		field.IsExpandedField = m.IsExpandedFields[4]
@@ -100,7 +109,7 @@ func (m *AntTx) ToMesg(fac Factory) proto.Message {
 		field.Value = m.MesgId
 		fields = append(fields, field)
 	}
-	if m.ChannelNumber != basetype.Uint8Invalid {
+	if m.ChannelNumber != basetype.Uint8Invalid && ((m.IsExpandedFields[3] && options.IncludeExpandedFields) || !m.IsExpandedFields[3]) {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ChannelNumber
 		field.IsExpandedField = m.IsExpandedFields[3]

--- a/profile/mesgdef/aviation_attitude_gen.go
+++ b/profile/mesgdef/aviation_attitude_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -70,8 +71,16 @@ func NewAviationAttitude(mesg *proto.Message) *AviationAttitude {
 	}
 }
 
-// ToMesg converts AviationAttitude into proto.Message.
-func (m *AviationAttitude) ToMesg(fac Factory) proto.Message {
+// ToMesg converts AviationAttitude into proto.Message. If options is nil, default options will be used.
+func (m *AviationAttitude) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/barometer_data_gen.go
+++ b/profile/mesgdef/barometer_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -53,8 +54,16 @@ func NewBarometerData(mesg *proto.Message) *BarometerData {
 	}
 }
 
-// ToMesg converts BarometerData into proto.Message.
-func (m *BarometerData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts BarometerData into proto.Message. If options is nil, default options will be used.
+func (m *BarometerData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/beat_intervals_gen.go
+++ b/profile/mesgdef/beat_intervals_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -51,8 +52,16 @@ func NewBeatIntervals(mesg *proto.Message) *BeatIntervals {
 	}
 }
 
-// ToMesg converts BeatIntervals into proto.Message.
-func (m *BeatIntervals) ToMesg(fac Factory) proto.Message {
+// ToMesg converts BeatIntervals into proto.Message. If options is nil, default options will be used.
+func (m *BeatIntervals) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/bike_profile_gen.go
+++ b/profile/mesgdef/bike_profile_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -108,8 +109,16 @@ func NewBikeProfile(mesg *proto.Message) *BikeProfile {
 	}
 }
 
-// ToMesg converts BikeProfile into proto.Message.
-func (m *BikeProfile) ToMesg(fac Factory) proto.Message {
+// ToMesg converts BikeProfile into proto.Message. If options is nil, default options will be used.
+func (m *BikeProfile) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/blood_pressure_gen.go
+++ b/profile/mesgdef/blood_pressure_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -67,8 +68,16 @@ func NewBloodPressure(mesg *proto.Message) *BloodPressure {
 	}
 }
 
-// ToMesg converts BloodPressure into proto.Message.
-func (m *BloodPressure) ToMesg(fac Factory) proto.Message {
+// ToMesg converts BloodPressure into proto.Message. If options is nil, default options will be used.
+func (m *BloodPressure) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/cadence_zone_gen.go
+++ b/profile/mesgdef/cadence_zone_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -49,8 +50,16 @@ func NewCadenceZone(mesg *proto.Message) *CadenceZone {
 	}
 }
 
-// ToMesg converts CadenceZone into proto.Message.
-func (m *CadenceZone) ToMesg(fac Factory) proto.Message {
+// ToMesg converts CadenceZone into proto.Message. If options is nil, default options will be used.
+func (m *CadenceZone) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/camera_event_gen.go
+++ b/profile/mesgdef/camera_event_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -55,8 +56,16 @@ func NewCameraEvent(mesg *proto.Message) *CameraEvent {
 	}
 }
 
-// ToMesg converts CameraEvent into proto.Message.
-func (m *CameraEvent) ToMesg(fac Factory) proto.Message {
+// ToMesg converts CameraEvent into proto.Message. If options is nil, default options will be used.
+func (m *CameraEvent) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/capabilities_gen.go
+++ b/profile/mesgdef/capabilities_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -51,8 +52,16 @@ func NewCapabilities(mesg *proto.Message) *Capabilities {
 	}
 }
 
-// ToMesg converts Capabilities into proto.Message.
-func (m *Capabilities) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Capabilities into proto.Message. If options is nil, default options will be used.
+func (m *Capabilities) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/chrono_shot_data_gen.go
+++ b/profile/mesgdef/chrono_shot_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -52,8 +53,16 @@ func NewChronoShotData(mesg *proto.Message) *ChronoShotData {
 	}
 }
 
-// ToMesg converts ChronoShotData into proto.Message.
-func (m *ChronoShotData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts ChronoShotData into proto.Message. If options is nil, default options will be used.
+func (m *ChronoShotData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/chrono_shot_session_gen.go
+++ b/profile/mesgdef/chrono_shot_session_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -60,8 +61,16 @@ func NewChronoShotSession(mesg *proto.Message) *ChronoShotSession {
 	}
 }
 
-// ToMesg converts ChronoShotSession into proto.Message.
-func (m *ChronoShotSession) ToMesg(fac Factory) proto.Message {
+// ToMesg converts ChronoShotSession into proto.Message. If options is nil, default options will be used.
+func (m *ChronoShotSession) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/climb_pro_gen.go
+++ b/profile/mesgdef/climb_pro_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -59,8 +60,16 @@ func NewClimbPro(mesg *proto.Message) *ClimbPro {
 	}
 }
 
-// ToMesg converts ClimbPro into proto.Message.
-func (m *ClimbPro) ToMesg(fac Factory) proto.Message {
+// ToMesg converts ClimbPro into proto.Message. If options is nil, default options will be used.
+func (m *ClimbPro) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/connectivity_gen.go
+++ b/profile/mesgdef/connectivity_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -69,8 +70,16 @@ func NewConnectivity(mesg *proto.Message) *Connectivity {
 	}
 }
 
-// ToMesg converts Connectivity into proto.Message.
-func (m *Connectivity) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Connectivity into proto.Message. If options is nil, default options will be used.
+func (m *Connectivity) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/course_gen.go
+++ b/profile/mesgdef/course_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -51,8 +52,16 @@ func NewCourse(mesg *proto.Message) *Course {
 	}
 }
 
-// ToMesg converts Course into proto.Message.
-func (m *Course) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Course into proto.Message. If options is nil, default options will be used.
+func (m *Course) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/course_point_gen.go
+++ b/profile/mesgdef/course_point_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -62,8 +63,16 @@ func NewCoursePoint(mesg *proto.Message) *CoursePoint {
 	}
 }
 
-// ToMesg converts CoursePoint into proto.Message.
-func (m *CoursePoint) ToMesg(fac Factory) proto.Message {
+// ToMesg converts CoursePoint into proto.Message. If options is nil, default options will be used.
+func (m *CoursePoint) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/developer_data_id_gen.go
+++ b/profile/mesgdef/developer_data_id_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -45,8 +46,16 @@ func NewDeveloperDataId(mesg *proto.Message) *DeveloperDataId {
 	}
 }
 
-// ToMesg converts DeveloperDataId into proto.Message.
-func (m *DeveloperDataId) ToMesg(fac Factory) proto.Message {
+// ToMesg converts DeveloperDataId into proto.Message. If options is nil, default options will be used.
+func (m *DeveloperDataId) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/device_aux_battery_info_gen.go
+++ b/profile/mesgdef/device_aux_battery_info_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -56,8 +57,16 @@ func NewDeviceAuxBatteryInfo(mesg *proto.Message) *DeviceAuxBatteryInfo {
 	}
 }
 
-// ToMesg converts DeviceAuxBatteryInfo into proto.Message.
-func (m *DeviceAuxBatteryInfo) ToMesg(fac Factory) proto.Message {
+// ToMesg converts DeviceAuxBatteryInfo into proto.Message. If options is nil, default options will be used.
+func (m *DeviceAuxBatteryInfo) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/device_info_gen.go
+++ b/profile/mesgdef/device_info_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -84,8 +85,16 @@ func NewDeviceInfo(mesg *proto.Message) *DeviceInfo {
 	}
 }
 
-// ToMesg converts DeviceInfo into proto.Message.
-func (m *DeviceInfo) ToMesg(fac Factory) proto.Message {
+// ToMesg converts DeviceInfo into proto.Message. If options is nil, default options will be used.
+func (m *DeviceInfo) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/device_settings_gen.go
+++ b/profile/mesgdef/device_settings_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -94,8 +95,16 @@ func NewDeviceSettings(mesg *proto.Message) *DeviceSettings {
 	}
 }
 
-// ToMesg converts DeviceSettings into proto.Message.
-func (m *DeviceSettings) ToMesg(fac Factory) proto.Message {
+// ToMesg converts DeviceSettings into proto.Message. If options is nil, default options will be used.
+func (m *DeviceSettings) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/dive_alarm_gen.go
+++ b/profile/mesgdef/dive_alarm_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -70,8 +71,16 @@ func NewDiveAlarm(mesg *proto.Message) *DiveAlarm {
 	}
 }
 
-// ToMesg converts DiveAlarm into proto.Message.
-func (m *DiveAlarm) ToMesg(fac Factory) proto.Message {
+// ToMesg converts DiveAlarm into proto.Message. If options is nil, default options will be used.
+func (m *DiveAlarm) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/dive_apnea_alarm_gen.go
+++ b/profile/mesgdef/dive_apnea_alarm_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -70,8 +71,16 @@ func NewDiveApneaAlarm(mesg *proto.Message) *DiveApneaAlarm {
 	}
 }
 
-// ToMesg converts DiveApneaAlarm into proto.Message.
-func (m *DiveApneaAlarm) ToMesg(fac Factory) proto.Message {
+// ToMesg converts DiveApneaAlarm into proto.Message. If options is nil, default options will be used.
+func (m *DiveApneaAlarm) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/dive_gas_gen.go
+++ b/profile/mesgdef/dive_gas_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -53,8 +54,16 @@ func NewDiveGas(mesg *proto.Message) *DiveGas {
 	}
 }
 
-// ToMesg converts DiveGas into proto.Message.
-func (m *DiveGas) ToMesg(fac Factory) proto.Message {
+// ToMesg converts DiveGas into proto.Message. If options is nil, default options will be used.
+func (m *DiveGas) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/dive_settings_gen.go
+++ b/profile/mesgdef/dive_settings_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -116,8 +117,16 @@ func NewDiveSettings(mesg *proto.Message) *DiveSettings {
 	}
 }
 
-// ToMesg converts DiveSettings into proto.Message.
-func (m *DiveSettings) ToMesg(fac Factory) proto.Message {
+// ToMesg converts DiveSettings into proto.Message. If options is nil, default options will be used.
+func (m *DiveSettings) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/dive_summary_gen.go
+++ b/profile/mesgdef/dive_summary_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -92,8 +93,16 @@ func NewDiveSummary(mesg *proto.Message) *DiveSummary {
 	}
 }
 
-// ToMesg converts DiveSummary into proto.Message.
-func (m *DiveSummary) ToMesg(fac Factory) proto.Message {
+// ToMesg converts DiveSummary into proto.Message. If options is nil, default options will be used.
+func (m *DiveSummary) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/event_gen.go
+++ b/profile/mesgdef/event_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -92,8 +93,16 @@ func NewEvent(mesg *proto.Message) *Event {
 	}
 }
 
-// ToMesg converts Event into proto.Message.
-func (m *Event) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Event into proto.Message. If options is nil, default options will be used.
+func (m *Event) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -110,7 +119,7 @@ func (m *Event) ToMesg(fac Factory) proto.Message {
 		field.Value = datetime.ToUint32(m.StartTimestamp)
 		fields = append(fields, field)
 	}
-	if m.Data != basetype.Uint32Invalid {
+	if m.Data != basetype.Uint32Invalid && ((m.IsExpandedFields[3] && options.IncludeExpandedFields) || !m.IsExpandedFields[3]) {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Data
 		field.IsExpandedField = m.IsExpandedFields[3]
@@ -121,13 +130,13 @@ func (m *Event) ToMesg(fac Factory) proto.Message {
 		field.Value = m.Data16
 		fields = append(fields, field)
 	}
-	if m.Score != basetype.Uint16Invalid {
+	if m.Score != basetype.Uint16Invalid && ((m.IsExpandedFields[7] && options.IncludeExpandedFields) || !m.IsExpandedFields[7]) {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = m.Score
 		field.IsExpandedField = m.IsExpandedFields[7]
 		fields = append(fields, field)
 	}
-	if m.OpponentScore != basetype.Uint16Invalid {
+	if m.OpponentScore != basetype.Uint16Invalid && ((m.IsExpandedFields[8] && options.IncludeExpandedFields) || !m.IsExpandedFields[8]) {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.OpponentScore
 		field.IsExpandedField = m.IsExpandedFields[8]
@@ -148,25 +157,25 @@ func (m *Event) ToMesg(fac Factory) proto.Message {
 		field.Value = m.EventGroup
 		fields = append(fields, field)
 	}
-	if uint8(m.FrontGearNum) != basetype.Uint8zInvalid {
+	if uint8(m.FrontGearNum) != basetype.Uint8zInvalid && ((m.IsExpandedFields[9] && options.IncludeExpandedFields) || !m.IsExpandedFields[9]) {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = uint8(m.FrontGearNum)
 		field.IsExpandedField = m.IsExpandedFields[9]
 		fields = append(fields, field)
 	}
-	if uint8(m.FrontGear) != basetype.Uint8zInvalid {
+	if uint8(m.FrontGear) != basetype.Uint8zInvalid && ((m.IsExpandedFields[10] && options.IncludeExpandedFields) || !m.IsExpandedFields[10]) {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = uint8(m.FrontGear)
 		field.IsExpandedField = m.IsExpandedFields[10]
 		fields = append(fields, field)
 	}
-	if uint8(m.RearGearNum) != basetype.Uint8zInvalid {
+	if uint8(m.RearGearNum) != basetype.Uint8zInvalid && ((m.IsExpandedFields[11] && options.IncludeExpandedFields) || !m.IsExpandedFields[11]) {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = uint8(m.RearGearNum)
 		field.IsExpandedField = m.IsExpandedFields[11]
 		fields = append(fields, field)
 	}
-	if uint8(m.RearGear) != basetype.Uint8zInvalid {
+	if uint8(m.RearGear) != basetype.Uint8zInvalid && ((m.IsExpandedFields[12] && options.IncludeExpandedFields) || !m.IsExpandedFields[12]) {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = uint8(m.RearGear)
 		field.IsExpandedField = m.IsExpandedFields[12]
@@ -182,25 +191,25 @@ func (m *Event) ToMesg(fac Factory) proto.Message {
 		field.Value = byte(m.ActivityType)
 		fields = append(fields, field)
 	}
-	if byte(m.RadarThreatLevelMax) != basetype.EnumInvalid {
+	if byte(m.RadarThreatLevelMax) != basetype.EnumInvalid && ((m.IsExpandedFields[21] && options.IncludeExpandedFields) || !m.IsExpandedFields[21]) {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = byte(m.RadarThreatLevelMax)
 		field.IsExpandedField = m.IsExpandedFields[21]
 		fields = append(fields, field)
 	}
-	if m.RadarThreatCount != basetype.Uint8Invalid {
+	if m.RadarThreatCount != basetype.Uint8Invalid && ((m.IsExpandedFields[22] && options.IncludeExpandedFields) || !m.IsExpandedFields[22]) {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = m.RadarThreatCount
 		field.IsExpandedField = m.IsExpandedFields[22]
 		fields = append(fields, field)
 	}
-	if m.RadarThreatAvgApproachSpeed != basetype.Uint8Invalid {
+	if m.RadarThreatAvgApproachSpeed != basetype.Uint8Invalid && ((m.IsExpandedFields[23] && options.IncludeExpandedFields) || !m.IsExpandedFields[23]) {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = m.RadarThreatAvgApproachSpeed
 		field.IsExpandedField = m.IsExpandedFields[23]
 		fields = append(fields, field)
 	}
-	if m.RadarThreatMaxApproachSpeed != basetype.Uint8Invalid {
+	if m.RadarThreatMaxApproachSpeed != basetype.Uint8Invalid && ((m.IsExpandedFields[24] && options.IncludeExpandedFields) || !m.IsExpandedFields[24]) {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = m.RadarThreatMaxApproachSpeed
 		field.IsExpandedField = m.IsExpandedFields[24]

--- a/profile/mesgdef/exd_data_concept_configuration_gen.go
+++ b/profile/mesgdef/exd_data_concept_configuration_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -73,8 +74,16 @@ func NewExdDataConceptConfiguration(mesg *proto.Message) *ExdDataConceptConfigur
 	}
 }
 
-// ToMesg converts ExdDataConceptConfiguration into proto.Message.
-func (m *ExdDataConceptConfiguration) ToMesg(fac Factory) proto.Message {
+// ToMesg converts ExdDataConceptConfiguration into proto.Message. If options is nil, default options will be used.
+func (m *ExdDataConceptConfiguration) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -91,13 +100,13 @@ func (m *ExdDataConceptConfiguration) ToMesg(fac Factory) proto.Message {
 		field.Value = m.ConceptField
 		fields = append(fields, field)
 	}
-	if m.FieldId != basetype.Uint8Invalid {
+	if m.FieldId != basetype.Uint8Invalid && ((m.IsExpandedFields[2] && options.IncludeExpandedFields) || !m.IsExpandedFields[2]) {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.FieldId
 		field.IsExpandedField = m.IsExpandedFields[2]
 		fields = append(fields, field)
 	}
-	if m.ConceptIndex != basetype.Uint8Invalid {
+	if m.ConceptIndex != basetype.Uint8Invalid && ((m.IsExpandedFields[3] && options.IncludeExpandedFields) || !m.IsExpandedFields[3]) {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ConceptIndex
 		field.IsExpandedField = m.IsExpandedFields[3]

--- a/profile/mesgdef/exd_data_field_configuration_gen.go
+++ b/profile/mesgdef/exd_data_field_configuration_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -63,8 +64,16 @@ func NewExdDataFieldConfiguration(mesg *proto.Message) *ExdDataFieldConfiguratio
 	}
 }
 
-// ToMesg converts ExdDataFieldConfiguration into proto.Message.
-func (m *ExdDataFieldConfiguration) ToMesg(fac Factory) proto.Message {
+// ToMesg converts ExdDataFieldConfiguration into proto.Message. If options is nil, default options will be used.
+func (m *ExdDataFieldConfiguration) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -86,13 +95,13 @@ func (m *ExdDataFieldConfiguration) ToMesg(fac Factory) proto.Message {
 		field.Value = m.ConceptField
 		fields = append(fields, field)
 	}
-	if m.FieldId != basetype.Uint8Invalid {
+	if m.FieldId != basetype.Uint8Invalid && ((m.IsExpandedFields[2] && options.IncludeExpandedFields) || !m.IsExpandedFields[2]) {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.FieldId
 		field.IsExpandedField = m.IsExpandedFields[2]
 		fields = append(fields, field)
 	}
-	if m.ConceptCount != basetype.Uint8Invalid {
+	if m.ConceptCount != basetype.Uint8Invalid && ((m.IsExpandedFields[3] && options.IncludeExpandedFields) || !m.IsExpandedFields[3]) {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.ConceptCount
 		field.IsExpandedField = m.IsExpandedFields[3]

--- a/profile/mesgdef/exd_screen_configuration_gen.go
+++ b/profile/mesgdef/exd_screen_configuration_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -51,8 +52,16 @@ func NewExdScreenConfiguration(mesg *proto.Message) *ExdScreenConfiguration {
 	}
 }
 
-// ToMesg converts ExdScreenConfiguration into proto.Message.
-func (m *ExdScreenConfiguration) ToMesg(fac Factory) proto.Message {
+// ToMesg converts ExdScreenConfiguration into proto.Message. If options is nil, default options will be used.
+func (m *ExdScreenConfiguration) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/exercise_title_gen.go
+++ b/profile/mesgdef/exercise_title_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -51,8 +52,16 @@ func NewExerciseTitle(mesg *proto.Message) *ExerciseTitle {
 	}
 }
 
-// ToMesg converts ExerciseTitle into proto.Message.
-func (m *ExerciseTitle) ToMesg(fac Factory) proto.Message {
+// ToMesg converts ExerciseTitle into proto.Message. If options is nil, default options will be used.
+func (m *ExerciseTitle) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/field_capabilities_gen.go
+++ b/profile/mesgdef/field_capabilities_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -53,8 +54,16 @@ func NewFieldCapabilities(mesg *proto.Message) *FieldCapabilities {
 	}
 }
 
-// ToMesg converts FieldCapabilities into proto.Message.
-func (m *FieldCapabilities) ToMesg(fac Factory) proto.Message {
+// ToMesg converts FieldCapabilities into proto.Message. If options is nil, default options will be used.
+func (m *FieldCapabilities) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/field_description_gen.go
+++ b/profile/mesgdef/field_description_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -63,8 +64,16 @@ func NewFieldDescription(mesg *proto.Message) *FieldDescription {
 	}
 }
 
-// ToMesg converts FieldDescription into proto.Message.
-func (m *FieldDescription) ToMesg(fac Factory) proto.Message {
+// ToMesg converts FieldDescription into proto.Message. If options is nil, default options will be used.
+func (m *FieldDescription) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/file_capabilities_gen.go
+++ b/profile/mesgdef/file_capabilities_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -55,8 +56,16 @@ func NewFileCapabilities(mesg *proto.Message) *FileCapabilities {
 	}
 }
 
-// ToMesg converts FileCapabilities into proto.Message.
-func (m *FileCapabilities) ToMesg(fac Factory) proto.Message {
+// ToMesg converts FileCapabilities into proto.Message. If options is nil, default options will be used.
+func (m *FileCapabilities) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/file_creator_gen.go
+++ b/profile/mesgdef/file_creator_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -47,8 +48,16 @@ func NewFileCreator(mesg *proto.Message) *FileCreator {
 	}
 }
 
-// ToMesg converts FileCreator into proto.Message.
-func (m *FileCreator) ToMesg(fac Factory) proto.Message {
+// ToMesg converts FileCreator into proto.Message. If options is nil, default options will be used.
+func (m *FileCreator) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/file_id_gen.go
+++ b/profile/mesgdef/file_id_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -51,8 +52,16 @@ func NewFileId(mesg *proto.Message) *FileId {
 	}
 }
 
-// ToMesg converts FileId into proto.Message.
-func (m *FileId) ToMesg(fac Factory) proto.Message {
+// ToMesg converts FileId into proto.Message. If options is nil, default options will be used.
+func (m *FileId) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/goal_gen.go
+++ b/profile/mesgdef/goal_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -71,8 +72,16 @@ func NewGoal(mesg *proto.Message) *Goal {
 	}
 }
 
-// ToMesg converts Goal into proto.Message.
-func (m *Goal) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Goal into proto.Message. If options is nil, default options will be used.
+func (m *Goal) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/gps_metadata_gen.go
+++ b/profile/mesgdef/gps_metadata_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -64,8 +65,16 @@ func NewGpsMetadata(mesg *proto.Message) *GpsMetadata {
 	}
 }
 
-// ToMesg converts GpsMetadata into proto.Message.
-func (m *GpsMetadata) ToMesg(fac Factory) proto.Message {
+// ToMesg converts GpsMetadata into proto.Message. If options is nil, default options will be used.
+func (m *GpsMetadata) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/gyroscope_data_gen.go
+++ b/profile/mesgdef/gyroscope_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -63,8 +64,16 @@ func NewGyroscopeData(mesg *proto.Message) *GyroscopeData {
 	}
 }
 
-// ToMesg converts GyroscopeData into proto.Message.
-func (m *GyroscopeData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts GyroscopeData into proto.Message. If options is nil, default options will be used.
+func (m *GyroscopeData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hr_gen.go
+++ b/profile/mesgdef/hr_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -66,8 +67,16 @@ func NewHr(mesg *proto.Message) *Hr {
 	}
 }
 
-// ToMesg converts Hr into proto.Message.
-func (m *Hr) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Hr into proto.Message. If options is nil, default options will be used.
+func (m *Hr) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -84,7 +93,7 @@ func (m *Hr) ToMesg(fac Factory) proto.Message {
 		field.Value = m.FilteredBpm
 		fields = append(fields, field)
 	}
-	if m.EventTimestamp != nil {
+	if m.EventTimestamp != nil && ((m.IsExpandedFields[9] && options.IncludeExpandedFields) || !m.IsExpandedFields[9]) {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = m.EventTimestamp
 		field.IsExpandedField = m.IsExpandedFields[9]
@@ -95,7 +104,7 @@ func (m *Hr) ToMesg(fac Factory) proto.Message {
 		field.Value = m.EventTimestamp12
 		fields = append(fields, field)
 	}
-	if m.FractionalTimestamp != basetype.Uint16Invalid {
+	if m.FractionalTimestamp != basetype.Uint16Invalid && ((m.IsExpandedFields[0] && options.IncludeExpandedFields) || !m.IsExpandedFields[0]) {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = m.FractionalTimestamp
 		field.IsExpandedField = m.IsExpandedFields[0]

--- a/profile/mesgdef/hr_zone_gen.go
+++ b/profile/mesgdef/hr_zone_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -49,8 +50,16 @@ func NewHrZone(mesg *proto.Message) *HrZone {
 	}
 }
 
-// ToMesg converts HrZone into proto.Message.
-func (m *HrZone) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HrZone into proto.Message. If options is nil, default options will be used.
+func (m *HrZone) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hrm_profile_gen.go
+++ b/profile/mesgdef/hrm_profile_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -53,8 +54,16 @@ func NewHrmProfile(mesg *proto.Message) *HrmProfile {
 	}
 }
 
-// ToMesg converts HrmProfile into proto.Message.
-func (m *HrmProfile) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HrmProfile into proto.Message. If options is nil, default options will be used.
+func (m *HrmProfile) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hrv_gen.go
+++ b/profile/mesgdef/hrv_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/typedef"
@@ -45,8 +46,16 @@ func NewHrv(mesg *proto.Message) *Hrv {
 	}
 }
 
-// ToMesg converts Hrv into proto.Message.
-func (m *Hrv) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Hrv into proto.Message. If options is nil, default options will be used.
+func (m *Hrv) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hrv_status_summary_gen.go
+++ b/profile/mesgdef/hrv_status_summary_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -62,8 +63,16 @@ func NewHrvStatusSummary(mesg *proto.Message) *HrvStatusSummary {
 	}
 }
 
-// ToMesg converts HrvStatusSummary into proto.Message.
-func (m *HrvStatusSummary) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HrvStatusSummary into proto.Message. If options is nil, default options will be used.
+func (m *HrvStatusSummary) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hrv_value_gen.go
+++ b/profile/mesgdef/hrv_value_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -50,8 +51,16 @@ func NewHrvValue(mesg *proto.Message) *HrvValue {
 	}
 }
 
-// ToMesg converts HrvValue into proto.Message.
-func (m *HrvValue) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HrvValue into proto.Message. If options is nil, default options will be used.
+func (m *HrvValue) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hsa_accelerometer_data_gen.go
+++ b/profile/mesgdef/hsa_accelerometer_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -60,8 +61,16 @@ func NewHsaAccelerometerData(mesg *proto.Message) *HsaAccelerometerData {
 	}
 }
 
-// ToMesg converts HsaAccelerometerData into proto.Message.
-func (m *HsaAccelerometerData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HsaAccelerometerData into proto.Message. If options is nil, default options will be used.
+func (m *HsaAccelerometerData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hsa_body_battery_data_gen.go
+++ b/profile/mesgdef/hsa_body_battery_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -55,8 +56,16 @@ func NewHsaBodyBatteryData(mesg *proto.Message) *HsaBodyBatteryData {
 	}
 }
 
-// ToMesg converts HsaBodyBatteryData into proto.Message.
-func (m *HsaBodyBatteryData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HsaBodyBatteryData into proto.Message. If options is nil, default options will be used.
+func (m *HsaBodyBatteryData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hsa_configuration_data_gen.go
+++ b/profile/mesgdef/hsa_configuration_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -51,8 +52,16 @@ func NewHsaConfigurationData(mesg *proto.Message) *HsaConfigurationData {
 	}
 }
 
-// ToMesg converts HsaConfigurationData into proto.Message.
-func (m *HsaConfigurationData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HsaConfigurationData into proto.Message. If options is nil, default options will be used.
+func (m *HsaConfigurationData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hsa_event_gen.go
+++ b/profile/mesgdef/hsa_event_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -49,8 +50,16 @@ func NewHsaEvent(mesg *proto.Message) *HsaEvent {
 	}
 }
 
-// ToMesg converts HsaEvent into proto.Message.
-func (m *HsaEvent) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HsaEvent into proto.Message. If options is nil, default options will be used.
+func (m *HsaEvent) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hsa_gyroscope_data_gen.go
+++ b/profile/mesgdef/hsa_gyroscope_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -60,8 +61,16 @@ func NewHsaGyroscopeData(mesg *proto.Message) *HsaGyroscopeData {
 	}
 }
 
-// ToMesg converts HsaGyroscopeData into proto.Message.
-func (m *HsaGyroscopeData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HsaGyroscopeData into proto.Message. If options is nil, default options will be used.
+func (m *HsaGyroscopeData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hsa_heart_rate_data_gen.go
+++ b/profile/mesgdef/hsa_heart_rate_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -53,8 +54,16 @@ func NewHsaHeartRateData(mesg *proto.Message) *HsaHeartRateData {
 	}
 }
 
-// ToMesg converts HsaHeartRateData into proto.Message.
-func (m *HsaHeartRateData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HsaHeartRateData into proto.Message. If options is nil, default options will be used.
+func (m *HsaHeartRateData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hsa_respiration_data_gen.go
+++ b/profile/mesgdef/hsa_respiration_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -52,8 +53,16 @@ func NewHsaRespirationData(mesg *proto.Message) *HsaRespirationData {
 	}
 }
 
-// ToMesg converts HsaRespirationData into proto.Message.
-func (m *HsaRespirationData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HsaRespirationData into proto.Message. If options is nil, default options will be used.
+func (m *HsaRespirationData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hsa_spo2_data_gen.go
+++ b/profile/mesgdef/hsa_spo2_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -53,8 +54,16 @@ func NewHsaSpo2Data(mesg *proto.Message) *HsaSpo2Data {
 	}
 }
 
-// ToMesg converts HsaSpo2Data into proto.Message.
-func (m *HsaSpo2Data) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HsaSpo2Data into proto.Message. If options is nil, default options will be used.
+func (m *HsaSpo2Data) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hsa_step_data_gen.go
+++ b/profile/mesgdef/hsa_step_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -51,8 +52,16 @@ func NewHsaStepData(mesg *proto.Message) *HsaStepData {
 	}
 }
 
-// ToMesg converts HsaStepData into proto.Message.
-func (m *HsaStepData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HsaStepData into proto.Message. If options is nil, default options will be used.
+func (m *HsaStepData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hsa_stress_data_gen.go
+++ b/profile/mesgdef/hsa_stress_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -51,8 +52,16 @@ func NewHsaStressData(mesg *proto.Message) *HsaStressData {
 	}
 }
 
-// ToMesg converts HsaStressData into proto.Message.
-func (m *HsaStressData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HsaStressData into proto.Message. If options is nil, default options will be used.
+func (m *HsaStressData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/hsa_wrist_temperature_data_gen.go
+++ b/profile/mesgdef/hsa_wrist_temperature_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -52,8 +53,16 @@ func NewHsaWristTemperatureData(mesg *proto.Message) *HsaWristTemperatureData {
 	}
 }
 
-// ToMesg converts HsaWristTemperatureData into proto.Message.
-func (m *HsaWristTemperatureData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts HsaWristTemperatureData into proto.Message. If options is nil, default options will be used.
+func (m *HsaWristTemperatureData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/jump_gen.go
+++ b/profile/mesgdef/jump_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -74,8 +75,16 @@ func NewJump(mesg *proto.Message) *Jump {
 	}
 }
 
-// ToMesg converts Jump into proto.Message.
-func (m *Jump) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Jump into proto.Message. If options is nil, default options will be used.
+func (m *Jump) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -117,7 +126,7 @@ func (m *Jump) ToMesg(fac Factory) proto.Message {
 		field.Value = m.PositionLong
 		fields = append(fields, field)
 	}
-	if m.EnhancedSpeed != basetype.Uint32Invalid {
+	if m.EnhancedSpeed != basetype.Uint32Invalid && ((m.IsExpandedFields[8] && options.IncludeExpandedFields) || !m.IsExpandedFields[8]) {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = m.EnhancedSpeed
 		field.IsExpandedField = m.IsExpandedFields[8]

--- a/profile/mesgdef/lap_gen.go
+++ b/profile/mesgdef/lap_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -300,8 +301,16 @@ func NewLap(mesg *proto.Message) *Lap {
 	}
 }
 
-// ToMesg converts Lap into proto.Message.
-func (m *Lap) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Lap into proto.Message. If options is nil, default options will be used.
+func (m *Lap) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -473,31 +482,31 @@ func (m *Lap) ToMesg(fac Factory) proto.Message {
 		field.Value = m.TimeStanding
 		fields = append(fields, field)
 	}
-	if m.EnhancedAvgSpeed != basetype.Uint32Invalid {
+	if m.EnhancedAvgSpeed != basetype.Uint32Invalid && ((m.IsExpandedFields[110] && options.IncludeExpandedFields) || !m.IsExpandedFields[110]) {
 		field := fac.CreateField(mesg.Num, 110)
 		field.Value = m.EnhancedAvgSpeed
 		field.IsExpandedField = m.IsExpandedFields[110]
 		fields = append(fields, field)
 	}
-	if m.EnhancedMaxSpeed != basetype.Uint32Invalid {
+	if m.EnhancedMaxSpeed != basetype.Uint32Invalid && ((m.IsExpandedFields[111] && options.IncludeExpandedFields) || !m.IsExpandedFields[111]) {
 		field := fac.CreateField(mesg.Num, 111)
 		field.Value = m.EnhancedMaxSpeed
 		field.IsExpandedField = m.IsExpandedFields[111]
 		fields = append(fields, field)
 	}
-	if m.EnhancedAvgAltitude != basetype.Uint32Invalid {
+	if m.EnhancedAvgAltitude != basetype.Uint32Invalid && ((m.IsExpandedFields[112] && options.IncludeExpandedFields) || !m.IsExpandedFields[112]) {
 		field := fac.CreateField(mesg.Num, 112)
 		field.Value = m.EnhancedAvgAltitude
 		field.IsExpandedField = m.IsExpandedFields[112]
 		fields = append(fields, field)
 	}
-	if m.EnhancedMinAltitude != basetype.Uint32Invalid {
+	if m.EnhancedMinAltitude != basetype.Uint32Invalid && ((m.IsExpandedFields[113] && options.IncludeExpandedFields) || !m.IsExpandedFields[113]) {
 		field := fac.CreateField(mesg.Num, 113)
 		field.Value = m.EnhancedMinAltitude
 		field.IsExpandedField = m.IsExpandedFields[113]
 		fields = append(fields, field)
 	}
-	if m.EnhancedMaxAltitude != basetype.Uint32Invalid {
+	if m.EnhancedMaxAltitude != basetype.Uint32Invalid && ((m.IsExpandedFields[114] && options.IncludeExpandedFields) || !m.IsExpandedFields[114]) {
 		field := fac.CreateField(mesg.Num, 114)
 		field.Value = m.EnhancedMaxAltitude
 		field.IsExpandedField = m.IsExpandedFields[114]
@@ -738,13 +747,13 @@ func (m *Lap) ToMesg(fac Factory) proto.Message {
 		field.Value = m.AvgVam
 		fields = append(fields, field)
 	}
-	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid {
+	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid && ((m.IsExpandedFields[136] && options.IncludeExpandedFields) || !m.IsExpandedFields[136]) {
 		field := fac.CreateField(mesg.Num, 136)
 		field.Value = m.EnhancedAvgRespirationRate
 		field.IsExpandedField = m.IsExpandedFields[136]
 		fields = append(fields, field)
 	}
-	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid {
+	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid && ((m.IsExpandedFields[137] && options.IncludeExpandedFields) || !m.IsExpandedFields[137]) {
 		field := fac.CreateField(mesg.Num, 137)
 		field.Value = m.EnhancedMaxRespirationRate
 		field.IsExpandedField = m.IsExpandedFields[137]

--- a/profile/mesgdef/length_gen.go
+++ b/profile/mesgdef/length_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -98,8 +99,16 @@ func NewLength(mesg *proto.Message) *Length {
 	}
 }
 
-// ToMesg converts Length into proto.Message.
-func (m *Length) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Length into proto.Message. If options is nil, default options will be used.
+func (m *Length) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -166,13 +175,13 @@ func (m *Length) ToMesg(fac Factory) proto.Message {
 		field.Value = m.OpponentScore
 		fields = append(fields, field)
 	}
-	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid {
+	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid && ((m.IsExpandedFields[22] && options.IncludeExpandedFields) || !m.IsExpandedFields[22]) {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = m.EnhancedAvgRespirationRate
 		field.IsExpandedField = m.IsExpandedFields[22]
 		fields = append(fields, field)
 	}
-	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid {
+	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid && ((m.IsExpandedFields[23] && options.IncludeExpandedFields) || !m.IsExpandedFields[23]) {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = m.EnhancedMaxRespirationRate
 		field.IsExpandedField = m.IsExpandedFields[23]

--- a/profile/mesgdef/magnetometer_data_gen.go
+++ b/profile/mesgdef/magnetometer_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -63,8 +64,16 @@ func NewMagnetometerData(mesg *proto.Message) *MagnetometerData {
 	}
 }
 
-// ToMesg converts MagnetometerData into proto.Message.
-func (m *MagnetometerData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts MagnetometerData into proto.Message. If options is nil, default options will be used.
+func (m *MagnetometerData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/max_met_data_gen.go
+++ b/profile/mesgdef/max_met_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -62,8 +63,16 @@ func NewMaxMetData(mesg *proto.Message) *MaxMetData {
 	}
 }
 
-// ToMesg converts MaxMetData into proto.Message.
-func (m *MaxMetData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts MaxMetData into proto.Message. If options is nil, default options will be used.
+func (m *MaxMetData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/memo_glob_gen.go
+++ b/profile/mesgdef/memo_glob_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -55,8 +56,16 @@ func NewMemoGlob(mesg *proto.Message) *MemoGlob {
 	}
 }
 
-// ToMesg converts MemoGlob into proto.Message.
-func (m *MemoGlob) ToMesg(fac Factory) proto.Message {
+// ToMesg converts MemoGlob into proto.Message. If options is nil, default options will be used.
+func (m *MemoGlob) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/mesg_capabilities_gen.go
+++ b/profile/mesgdef/mesg_capabilities_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -53,8 +54,16 @@ func NewMesgCapabilities(mesg *proto.Message) *MesgCapabilities {
 	}
 }
 
-// ToMesg converts MesgCapabilities into proto.Message.
-func (m *MesgCapabilities) ToMesg(fac Factory) proto.Message {
+// ToMesg converts MesgCapabilities into proto.Message. If options is nil, default options will be used.
+func (m *MesgCapabilities) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/mesgdef.go
+++ b/profile/mesgdef/mesgdef.go
@@ -3,6 +3,7 @@ package mesgdef
 import (
 	"sync"
 
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
@@ -17,4 +18,18 @@ var fieldsPool = sync.Pool{
 		fields := [256]proto.Field{}
 		return &fields
 	},
+}
+
+type Options struct {
+	Factory               Factory // If not specified, factory.StandardFactory() will be used.
+	IncludeExpandedFields bool
+}
+
+var defaultOptions = DefaultOptions()
+
+func DefaultOptions() *Options {
+	return &Options{
+		Factory:               factory.StandardFactory(),
+		IncludeExpandedFields: false,
+	}
 }

--- a/profile/mesgdef/mesgdef_test.go
+++ b/profile/mesgdef/mesgdef_test.go
@@ -1,0 +1,31 @@
+package mesgdef
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/proto"
+)
+
+func TestFieldPool(t *testing.T) {
+	fields, ok := fieldsPool.Get().(*[256]proto.Field)
+	defer fieldsPool.Put(fields)
+	if !ok {
+		t.Fatalf("expected ok, got not ok")
+	}
+}
+
+func TestDefaultOptions(t *testing.T) {
+	options := DefaultOptions()
+	if diff := cmp.Diff(options, &Options{
+		Factory:               factory.StandardFactory(),
+		IncludeExpandedFields: false,
+	}, cmp.Transformer("Factory", func(fac Factory) uintptr {
+		return uintptr(reflect.ValueOf(fac).UnsafePointer())
+	}),
+	); diff != "" {
+		t.Fatal(diff)
+	}
+}

--- a/profile/mesgdef/met_zone_gen.go
+++ b/profile/mesgdef/met_zone_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -52,8 +53,16 @@ func NewMetZone(mesg *proto.Message) *MetZone {
 	}
 }
 
-// ToMesg converts MetZone into proto.Message.
-func (m *MetZone) ToMesg(fac Factory) proto.Message {
+// ToMesg converts MetZone into proto.Message. If options is nil, default options will be used.
+func (m *MetZone) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/monitoring_gen.go
+++ b/profile/mesgdef/monitoring_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -112,8 +113,16 @@ func NewMonitoring(mesg *proto.Message) *Monitoring {
 	}
 }
 
-// ToMesg converts Monitoring into proto.Message.
-func (m *Monitoring) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Monitoring into proto.Message. If options is nil, default options will be used.
+func (m *Monitoring) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -230,7 +239,7 @@ func (m *Monitoring) ToMesg(fac Factory) proto.Message {
 		field.Value = uint8(m.DeviceIndex)
 		fields = append(fields, field)
 	}
-	if byte(m.ActivityType) != basetype.EnumInvalid {
+	if byte(m.ActivityType) != basetype.EnumInvalid && ((m.IsExpandedFields[5] && options.IncludeExpandedFields) || !m.IsExpandedFields[5]) {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = byte(m.ActivityType)
 		field.IsExpandedField = m.IsExpandedFields[5]
@@ -261,7 +270,7 @@ func (m *Monitoring) ToMesg(fac Factory) proto.Message {
 		field.Value = m.HeartRate
 		fields = append(fields, field)
 	}
-	if m.Intensity != basetype.Uint8Invalid {
+	if m.Intensity != basetype.Uint8Invalid && ((m.IsExpandedFields[28] && options.IncludeExpandedFields) || !m.IsExpandedFields[28]) {
 		field := fac.CreateField(mesg.Num, 28)
 		field.Value = m.Intensity
 		field.IsExpandedField = m.IsExpandedFields[28]

--- a/profile/mesgdef/monitoring_hr_data_gen.go
+++ b/profile/mesgdef/monitoring_hr_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -51,8 +52,16 @@ func NewMonitoringHrData(mesg *proto.Message) *MonitoringHrData {
 	}
 }
 
-// ToMesg converts MonitoringHrData into proto.Message.
-func (m *MonitoringHrData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts MonitoringHrData into proto.Message. If options is nil, default options will be used.
+func (m *MonitoringHrData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/monitoring_info_gen.go
+++ b/profile/mesgdef/monitoring_info_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -58,8 +59,16 @@ func NewMonitoringInfo(mesg *proto.Message) *MonitoringInfo {
 	}
 }
 
-// ToMesg converts MonitoringInfo into proto.Message.
-func (m *MonitoringInfo) ToMesg(fac Factory) proto.Message {
+// ToMesg converts MonitoringInfo into proto.Message. If options is nil, default options will be used.
+func (m *MonitoringInfo) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/nmea_sentence_gen.go
+++ b/profile/mesgdef/nmea_sentence_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -51,8 +52,16 @@ func NewNmeaSentence(mesg *proto.Message) *NmeaSentence {
 	}
 }
 
-// ToMesg converts NmeaSentence into proto.Message.
-func (m *NmeaSentence) ToMesg(fac Factory) proto.Message {
+// ToMesg converts NmeaSentence into proto.Message. If options is nil, default options will be used.
+func (m *NmeaSentence) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/obdii_data_gen.go
+++ b/profile/mesgdef/obdii_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -63,8 +64,16 @@ func NewObdiiData(mesg *proto.Message) *ObdiiData {
 	}
 }
 
-// ToMesg converts ObdiiData into proto.Message.
-func (m *ObdiiData) ToMesg(fac Factory) proto.Message {
+// ToMesg converts ObdiiData into proto.Message. If options is nil, default options will be used.
+func (m *ObdiiData) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/ohr_settings_gen.go
+++ b/profile/mesgdef/ohr_settings_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -49,8 +50,16 @@ func NewOhrSettings(mesg *proto.Message) *OhrSettings {
 	}
 }
 
-// ToMesg converts OhrSettings into proto.Message.
-func (m *OhrSettings) ToMesg(fac Factory) proto.Message {
+// ToMesg converts OhrSettings into proto.Message. If options is nil, default options will be used.
+func (m *OhrSettings) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/one_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/one_d_sensor_calibration_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -57,8 +58,16 @@ func NewOneDSensorCalibration(mesg *proto.Message) *OneDSensorCalibration {
 	}
 }
 
-// ToMesg converts OneDSensorCalibration into proto.Message.
-func (m *OneDSensorCalibration) ToMesg(fac Factory) proto.Message {
+// ToMesg converts OneDSensorCalibration into proto.Message. If options is nil, default options will be used.
+func (m *OneDSensorCalibration) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/power_zone_gen.go
+++ b/profile/mesgdef/power_zone_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -49,8 +50,16 @@ func NewPowerZone(mesg *proto.Message) *PowerZone {
 	}
 }
 
-// ToMesg converts PowerZone into proto.Message.
-func (m *PowerZone) ToMesg(fac Factory) proto.Message {
+// ToMesg converts PowerZone into proto.Message. If options is nil, default options will be used.
+func (m *PowerZone) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/raw_bbi_gen.go
+++ b/profile/mesgdef/raw_bbi_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -65,8 +66,16 @@ func NewRawBbi(mesg *proto.Message) *RawBbi {
 	}
 }
 
-// ToMesg converts RawBbi into proto.Message.
-func (m *RawBbi) ToMesg(fac Factory) proto.Message {
+// ToMesg converts RawBbi into proto.Message. If options is nil, default options will be used.
+func (m *RawBbi) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -83,19 +92,19 @@ func (m *RawBbi) ToMesg(fac Factory) proto.Message {
 		field.Value = m.Data
 		fields = append(fields, field)
 	}
-	if m.Time != nil {
+	if m.Time != nil && ((m.IsExpandedFields[2] && options.IncludeExpandedFields) || !m.IsExpandedFields[2]) {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = m.Time
 		field.IsExpandedField = m.IsExpandedFields[2]
 		fields = append(fields, field)
 	}
-	if m.Quality != nil {
+	if m.Quality != nil && ((m.IsExpandedFields[3] && options.IncludeExpandedFields) || !m.IsExpandedFields[3]) {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = m.Quality
 		field.IsExpandedField = m.IsExpandedFields[3]
 		fields = append(fields, field)
 	}
-	if m.Gap != nil {
+	if m.Gap != nil && ((m.IsExpandedFields[4] && options.IncludeExpandedFields) || !m.IsExpandedFields[4]) {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = m.Gap
 		field.IsExpandedField = m.IsExpandedFields[4]

--- a/profile/mesgdef/record_gen.go
+++ b/profile/mesgdef/record_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -222,8 +223,16 @@ func NewRecord(mesg *proto.Message) *Record {
 	}
 }
 
-// ToMesg converts Record into proto.Message.
-func (m *Record) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Record into proto.Message. If options is nil, default options will be used.
+func (m *Record) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -275,7 +284,7 @@ func (m *Record) ToMesg(fac Factory) proto.Message {
 		field.Value = m.PositionLong
 		fields = append(fields, field)
 	}
-	if m.Distance != basetype.Uint32Invalid {
+	if m.Distance != basetype.Uint32Invalid && ((m.IsExpandedFields[5] && options.IncludeExpandedFields) || !m.IsExpandedFields[5]) {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = m.Distance
 		field.IsExpandedField = m.IsExpandedFields[5]
@@ -286,25 +295,25 @@ func (m *Record) ToMesg(fac Factory) proto.Message {
 		field.Value = m.TimeFromCourse
 		fields = append(fields, field)
 	}
-	if m.TotalCycles != basetype.Uint32Invalid {
+	if m.TotalCycles != basetype.Uint32Invalid && ((m.IsExpandedFields[19] && options.IncludeExpandedFields) || !m.IsExpandedFields[19]) {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = m.TotalCycles
 		field.IsExpandedField = m.IsExpandedFields[19]
 		fields = append(fields, field)
 	}
-	if m.AccumulatedPower != basetype.Uint32Invalid {
+	if m.AccumulatedPower != basetype.Uint32Invalid && ((m.IsExpandedFields[29] && options.IncludeExpandedFields) || !m.IsExpandedFields[29]) {
 		field := fac.CreateField(mesg.Num, 29)
 		field.Value = m.AccumulatedPower
 		field.IsExpandedField = m.IsExpandedFields[29]
 		fields = append(fields, field)
 	}
-	if m.EnhancedSpeed != basetype.Uint32Invalid {
+	if m.EnhancedSpeed != basetype.Uint32Invalid && ((m.IsExpandedFields[73] && options.IncludeExpandedFields) || !m.IsExpandedFields[73]) {
 		field := fac.CreateField(mesg.Num, 73)
 		field.Value = m.EnhancedSpeed
 		field.IsExpandedField = m.IsExpandedFields[73]
 		fields = append(fields, field)
 	}
-	if m.EnhancedAltitude != basetype.Uint32Invalid {
+	if m.EnhancedAltitude != basetype.Uint32Invalid && ((m.IsExpandedFields[78] && options.IncludeExpandedFields) || !m.IsExpandedFields[78]) {
 		field := fac.CreateField(mesg.Num, 78)
 		field.Value = m.EnhancedAltitude
 		field.IsExpandedField = m.IsExpandedFields[78]
@@ -365,7 +374,7 @@ func (m *Record) ToMesg(fac Factory) proto.Message {
 		field.Value = m.Altitude
 		fields = append(fields, field)
 	}
-	if m.Speed != basetype.Uint16Invalid {
+	if m.Speed != basetype.Uint16Invalid && ((m.IsExpandedFields[6] && options.IncludeExpandedFields) || !m.IsExpandedFields[6]) {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.Speed
 		field.IsExpandedField = m.IsExpandedFields[6]
@@ -481,7 +490,7 @@ func (m *Record) ToMesg(fac Factory) proto.Message {
 		field.Value = m.N2Load
 		fields = append(fields, field)
 	}
-	if m.EnhancedRespirationRate != basetype.Uint16Invalid {
+	if m.EnhancedRespirationRate != basetype.Uint16Invalid && ((m.IsExpandedFields[108] && options.IncludeExpandedFields) || !m.IsExpandedFields[108]) {
 		field := fac.CreateField(mesg.Num, 108)
 		field.Value = m.EnhancedRespirationRate
 		field.IsExpandedField = m.IsExpandedFields[108]

--- a/profile/mesgdef/record_gen_test.go
+++ b/profile/mesgdef/record_gen_test.go
@@ -22,6 +22,6 @@ func BenchmarkRecordToMesg(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = record.ToMesg(factory.StandardFactory())
+		_ = record.ToMesg(nil)
 	}
 }

--- a/profile/mesgdef/respiration_rate_gen.go
+++ b/profile/mesgdef/respiration_rate_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -50,8 +51,16 @@ func NewRespirationRate(mesg *proto.Message) *RespirationRate {
 	}
 }
 
-// ToMesg converts RespirationRate into proto.Message.
-func (m *RespirationRate) ToMesg(fac Factory) proto.Message {
+// ToMesg converts RespirationRate into proto.Message. If options is nil, default options will be used.
+func (m *RespirationRate) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/schedule_gen.go
+++ b/profile/mesgdef/schedule_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -59,8 +60,16 @@ func NewSchedule(mesg *proto.Message) *Schedule {
 	}
 }
 
-// ToMesg converts Schedule into proto.Message.
-func (m *Schedule) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Schedule into proto.Message. If options is nil, default options will be used.
+func (m *Schedule) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/sdm_profile_gen.go
+++ b/profile/mesgdef/sdm_profile_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -60,8 +61,16 @@ func NewSdmProfile(mesg *proto.Message) *SdmProfile {
 	}
 }
 
-// ToMesg converts SdmProfile into proto.Message.
-func (m *SdmProfile) ToMesg(fac Factory) proto.Message {
+// ToMesg converts SdmProfile into proto.Message. If options is nil, default options will be used.
+func (m *SdmProfile) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/segment_file_gen.go
+++ b/profile/mesgdef/segment_file_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -61,8 +62,16 @@ func NewSegmentFile(mesg *proto.Message) *SegmentFile {
 	}
 }
 
-// ToMesg converts SegmentFile into proto.Message.
-func (m *SegmentFile) ToMesg(fac Factory) proto.Message {
+// ToMesg converts SegmentFile into proto.Message. If options is nil, default options will be used.
+func (m *SegmentFile) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/segment_id_gen.go
+++ b/profile/mesgdef/segment_id_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -61,8 +62,16 @@ func NewSegmentId(mesg *proto.Message) *SegmentId {
 	}
 }
 
-// ToMesg converts SegmentId into proto.Message.
-func (m *SegmentId) ToMesg(fac Factory) proto.Message {
+// ToMesg converts SegmentId into proto.Message. If options is nil, default options will be used.
+func (m *SegmentId) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/segment_lap_gen.go
+++ b/profile/mesgdef/segment_lap_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -244,8 +245,16 @@ func NewSegmentLap(mesg *proto.Message) *SegmentLap {
 	}
 }
 
-// ToMesg converts SegmentLap into proto.Message.
-func (m *SegmentLap) ToMesg(fac Factory) proto.Message {
+// ToMesg converts SegmentLap into proto.Message. If options is nil, default options will be used.
+func (m *SegmentLap) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -432,19 +441,19 @@ func (m *SegmentLap) ToMesg(fac Factory) proto.Message {
 		field.Value = m.AvgFlow
 		fields = append(fields, field)
 	}
-	if m.EnhancedAvgAltitude != basetype.Uint32Invalid {
+	if m.EnhancedAvgAltitude != basetype.Uint32Invalid && ((m.IsExpandedFields[91] && options.IncludeExpandedFields) || !m.IsExpandedFields[91]) {
 		field := fac.CreateField(mesg.Num, 91)
 		field.Value = m.EnhancedAvgAltitude
 		field.IsExpandedField = m.IsExpandedFields[91]
 		fields = append(fields, field)
 	}
-	if m.EnhancedMaxAltitude != basetype.Uint32Invalid {
+	if m.EnhancedMaxAltitude != basetype.Uint32Invalid && ((m.IsExpandedFields[92] && options.IncludeExpandedFields) || !m.IsExpandedFields[92]) {
 		field := fac.CreateField(mesg.Num, 92)
 		field.Value = m.EnhancedMaxAltitude
 		field.IsExpandedField = m.IsExpandedFields[92]
 		fields = append(fields, field)
 	}
-	if m.EnhancedMinAltitude != basetype.Uint32Invalid {
+	if m.EnhancedMinAltitude != basetype.Uint32Invalid && ((m.IsExpandedFields[93] && options.IncludeExpandedFields) || !m.IsExpandedFields[93]) {
 		field := fac.CreateField(mesg.Num, 93)
 		field.Value = m.EnhancedMinAltitude
 		field.IsExpandedField = m.IsExpandedFields[93]

--- a/profile/mesgdef/segment_leaderboard_entry_gen.go
+++ b/profile/mesgdef/segment_leaderboard_entry_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -58,8 +59,16 @@ func NewSegmentLeaderboardEntry(mesg *proto.Message) *SegmentLeaderboardEntry {
 	}
 }
 
-// ToMesg converts SegmentLeaderboardEntry into proto.Message.
-func (m *SegmentLeaderboardEntry) ToMesg(fac Factory) proto.Message {
+// ToMesg converts SegmentLeaderboardEntry into proto.Message. If options is nil, default options will be used.
+func (m *SegmentLeaderboardEntry) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/segment_point_gen.go
+++ b/profile/mesgdef/segment_point_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -66,8 +67,16 @@ func NewSegmentPoint(mesg *proto.Message) *SegmentPoint {
 	}
 }
 
-// ToMesg converts SegmentPoint into proto.Message.
-func (m *SegmentPoint) ToMesg(fac Factory) proto.Message {
+// ToMesg converts SegmentPoint into proto.Message. If options is nil, default options will be used.
+func (m *SegmentPoint) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -94,7 +103,7 @@ func (m *SegmentPoint) ToMesg(fac Factory) proto.Message {
 		field.Value = m.Distance
 		fields = append(fields, field)
 	}
-	if m.EnhancedAltitude != basetype.Uint32Invalid {
+	if m.EnhancedAltitude != basetype.Uint32Invalid && ((m.IsExpandedFields[6] && options.IncludeExpandedFields) || !m.IsExpandedFields[6]) {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = m.EnhancedAltitude
 		field.IsExpandedField = m.IsExpandedFields[6]

--- a/profile/mesgdef/session_gen.go
+++ b/profile/mesgdef/session_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -362,8 +363,16 @@ func NewSession(mesg *proto.Message) *Session {
 	}
 }
 
-// ToMesg converts Session into proto.Message.
-func (m *Session) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Session into proto.Message. If options is nil, default options will be used.
+func (m *Session) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 
@@ -575,31 +584,31 @@ func (m *Session) ToMesg(fac Factory) proto.Message {
 		field.Value = m.TimeStanding
 		fields = append(fields, field)
 	}
-	if m.EnhancedAvgSpeed != basetype.Uint32Invalid {
+	if m.EnhancedAvgSpeed != basetype.Uint32Invalid && ((m.IsExpandedFields[124] && options.IncludeExpandedFields) || !m.IsExpandedFields[124]) {
 		field := fac.CreateField(mesg.Num, 124)
 		field.Value = m.EnhancedAvgSpeed
 		field.IsExpandedField = m.IsExpandedFields[124]
 		fields = append(fields, field)
 	}
-	if m.EnhancedMaxSpeed != basetype.Uint32Invalid {
+	if m.EnhancedMaxSpeed != basetype.Uint32Invalid && ((m.IsExpandedFields[125] && options.IncludeExpandedFields) || !m.IsExpandedFields[125]) {
 		field := fac.CreateField(mesg.Num, 125)
 		field.Value = m.EnhancedMaxSpeed
 		field.IsExpandedField = m.IsExpandedFields[125]
 		fields = append(fields, field)
 	}
-	if m.EnhancedAvgAltitude != basetype.Uint32Invalid {
+	if m.EnhancedAvgAltitude != basetype.Uint32Invalid && ((m.IsExpandedFields[126] && options.IncludeExpandedFields) || !m.IsExpandedFields[126]) {
 		field := fac.CreateField(mesg.Num, 126)
 		field.Value = m.EnhancedAvgAltitude
 		field.IsExpandedField = m.IsExpandedFields[126]
 		fields = append(fields, field)
 	}
-	if m.EnhancedMinAltitude != basetype.Uint32Invalid {
+	if m.EnhancedMinAltitude != basetype.Uint32Invalid && ((m.IsExpandedFields[127] && options.IncludeExpandedFields) || !m.IsExpandedFields[127]) {
 		field := fac.CreateField(mesg.Num, 127)
 		field.Value = m.EnhancedMinAltitude
 		field.IsExpandedField = m.IsExpandedFields[127]
 		fields = append(fields, field)
 	}
-	if m.EnhancedMaxAltitude != basetype.Uint32Invalid {
+	if m.EnhancedMaxAltitude != basetype.Uint32Invalid && ((m.IsExpandedFields[128] && options.IncludeExpandedFields) || !m.IsExpandedFields[128]) {
 		field := fac.CreateField(mesg.Num, 128)
 		field.Value = m.EnhancedMaxAltitude
 		field.IsExpandedField = m.IsExpandedFields[128]
@@ -900,19 +909,19 @@ func (m *Session) ToMesg(fac Factory) proto.Message {
 		field.Value = m.O2Toxicity
 		fields = append(fields, field)
 	}
-	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid {
+	if m.EnhancedAvgRespirationRate != basetype.Uint16Invalid && ((m.IsExpandedFields[169] && options.IncludeExpandedFields) || !m.IsExpandedFields[169]) {
 		field := fac.CreateField(mesg.Num, 169)
 		field.Value = m.EnhancedAvgRespirationRate
 		field.IsExpandedField = m.IsExpandedFields[169]
 		fields = append(fields, field)
 	}
-	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid {
+	if m.EnhancedMaxRespirationRate != basetype.Uint16Invalid && ((m.IsExpandedFields[170] && options.IncludeExpandedFields) || !m.IsExpandedFields[170]) {
 		field := fac.CreateField(mesg.Num, 170)
 		field.Value = m.EnhancedMaxRespirationRate
 		field.IsExpandedField = m.IsExpandedFields[170]
 		fields = append(fields, field)
 	}
-	if m.EnhancedMinRespirationRate != basetype.Uint16Invalid {
+	if m.EnhancedMinRespirationRate != basetype.Uint16Invalid && ((m.IsExpandedFields[180] && options.IncludeExpandedFields) || !m.IsExpandedFields[180]) {
 		field := fac.CreateField(mesg.Num, 180)
 		field.Value = m.EnhancedMinRespirationRate
 		field.IsExpandedField = m.IsExpandedFields[180]

--- a/profile/mesgdef/set_gen.go
+++ b/profile/mesgdef/set_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -68,8 +69,16 @@ func NewSet(mesg *proto.Message) *Set {
 	}
 }
 
-// ToMesg converts Set into proto.Message.
-func (m *Set) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Set into proto.Message. If options is nil, default options will be used.
+func (m *Set) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/slave_device_gen.go
+++ b/profile/mesgdef/slave_device_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -47,8 +48,16 @@ func NewSlaveDevice(mesg *proto.Message) *SlaveDevice {
 	}
 }
 
-// ToMesg converts SlaveDevice into proto.Message.
-func (m *SlaveDevice) ToMesg(fac Factory) proto.Message {
+// ToMesg converts SlaveDevice into proto.Message. If options is nil, default options will be used.
+func (m *SlaveDevice) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/sleep_assessment_gen.go
+++ b/profile/mesgdef/sleep_assessment_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -72,8 +73,16 @@ func NewSleepAssessment(mesg *proto.Message) *SleepAssessment {
 	}
 }
 
-// ToMesg converts SleepAssessment into proto.Message.
-func (m *SleepAssessment) ToMesg(fac Factory) proto.Message {
+// ToMesg converts SleepAssessment into proto.Message. If options is nil, default options will be used.
+func (m *SleepAssessment) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/sleep_level_gen.go
+++ b/profile/mesgdef/sleep_level_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -49,8 +50,16 @@ func NewSleepLevel(mesg *proto.Message) *SleepLevel {
 	}
 }
 
-// ToMesg converts SleepLevel into proto.Message.
-func (m *SleepLevel) ToMesg(fac Factory) proto.Message {
+// ToMesg converts SleepLevel into proto.Message. If options is nil, default options will be used.
+func (m *SleepLevel) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/software_gen.go
+++ b/profile/mesgdef/software_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -50,8 +51,16 @@ func NewSoftware(mesg *proto.Message) *Software {
 	}
 }
 
-// ToMesg converts Software into proto.Message.
-func (m *Software) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Software into proto.Message. If options is nil, default options will be used.
+func (m *Software) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/speed_zone_gen.go
+++ b/profile/mesgdef/speed_zone_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -50,8 +51,16 @@ func NewSpeedZone(mesg *proto.Message) *SpeedZone {
 	}
 }
 
-// ToMesg converts SpeedZone into proto.Message.
-func (m *SpeedZone) ToMesg(fac Factory) proto.Message {
+// ToMesg converts SpeedZone into proto.Message. If options is nil, default options will be used.
+func (m *SpeedZone) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/split_gen.go
+++ b/profile/mesgdef/split_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -84,8 +85,16 @@ func NewSplit(mesg *proto.Message) *Split {
 	}
 }
 
-// ToMesg converts Split into proto.Message.
-func (m *Split) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Split into proto.Message. If options is nil, default options will be used.
+func (m *Split) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/split_summary_gen.go
+++ b/profile/mesgdef/split_summary_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -72,8 +73,16 @@ func NewSplitSummary(mesg *proto.Message) *SplitSummary {
 	}
 }
 
-// ToMesg converts SplitSummary into proto.Message.
-func (m *SplitSummary) ToMesg(fac Factory) proto.Message {
+// ToMesg converts SplitSummary into proto.Message. If options is nil, default options will be used.
+func (m *SplitSummary) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/spo2_data_gen.go
+++ b/profile/mesgdef/spo2_data_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -53,8 +54,16 @@ func NewSpo2Data(mesg *proto.Message) *Spo2Data {
 	}
 }
 
-// ToMesg converts Spo2Data into proto.Message.
-func (m *Spo2Data) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Spo2Data into proto.Message. If options is nil, default options will be used.
+func (m *Spo2Data) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/sport_gen.go
+++ b/profile/mesgdef/sport_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -49,8 +50,16 @@ func NewSport(mesg *proto.Message) *Sport {
 	}
 }
 
-// ToMesg converts Sport into proto.Message.
-func (m *Sport) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Sport into proto.Message. If options is nil, default options will be used.
+func (m *Sport) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/stress_level_gen.go
+++ b/profile/mesgdef/stress_level_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -49,8 +50,16 @@ func NewStressLevel(mesg *proto.Message) *StressLevel {
 	}
 }
 
-// ToMesg converts StressLevel into proto.Message.
-func (m *StressLevel) ToMesg(fac Factory) proto.Message {
+// ToMesg converts StressLevel into proto.Message. If options is nil, default options will be used.
+func (m *StressLevel) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/tank_summary_gen.go
+++ b/profile/mesgdef/tank_summary_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -56,8 +57,16 @@ func NewTankSummary(mesg *proto.Message) *TankSummary {
 	}
 }
 
-// ToMesg converts TankSummary into proto.Message.
-func (m *TankSummary) ToMesg(fac Factory) proto.Message {
+// ToMesg converts TankSummary into proto.Message. If options is nil, default options will be used.
+func (m *TankSummary) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/tank_update_gen.go
+++ b/profile/mesgdef/tank_update_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -52,8 +53,16 @@ func NewTankUpdate(mesg *proto.Message) *TankUpdate {
 	}
 }
 
-// ToMesg converts TankUpdate into proto.Message.
-func (m *TankUpdate) ToMesg(fac Factory) proto.Message {
+// ToMesg converts TankUpdate into proto.Message. If options is nil, default options will be used.
+func (m *TankUpdate) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/three_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/three_d_sensor_calibration_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -60,8 +61,16 @@ func NewThreeDSensorCalibration(mesg *proto.Message) *ThreeDSensorCalibration {
 	}
 }
 
-// ToMesg converts ThreeDSensorCalibration into proto.Message.
-func (m *ThreeDSensorCalibration) ToMesg(fac Factory) proto.Message {
+// ToMesg converts ThreeDSensorCalibration into proto.Message. If options is nil, default options will be used.
+func (m *ThreeDSensorCalibration) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/time_in_zone_gen.go
+++ b/profile/mesgdef/time_in_zone_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -80,8 +81,16 @@ func NewTimeInZone(mesg *proto.Message) *TimeInZone {
 	}
 }
 
-// ToMesg converts TimeInZone into proto.Message.
-func (m *TimeInZone) ToMesg(fac Factory) proto.Message {
+// ToMesg converts TimeInZone into proto.Message. If options is nil, default options will be used.
+func (m *TimeInZone) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/timestamp_correlation_gen.go
+++ b/profile/mesgdef/timestamp_correlation_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -60,8 +61,16 @@ func NewTimestampCorrelation(mesg *proto.Message) *TimestampCorrelation {
 	}
 }
 
-// ToMesg converts TimestampCorrelation into proto.Message.
-func (m *TimestampCorrelation) ToMesg(fac Factory) proto.Message {
+// ToMesg converts TimestampCorrelation into proto.Message. If options is nil, default options will be used.
+func (m *TimestampCorrelation) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/totals_gen.go
+++ b/profile/mesgdef/totals_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -65,8 +66,16 @@ func NewTotals(mesg *proto.Message) *Totals {
 	}
 }
 
-// ToMesg converts Totals into proto.Message.
-func (m *Totals) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Totals into proto.Message. If options is nil, default options will be used.
+func (m *Totals) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/training_file_gen.go
+++ b/profile/mesgdef/training_file_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -57,8 +58,16 @@ func NewTrainingFile(mesg *proto.Message) *TrainingFile {
 	}
 }
 
-// ToMesg converts TrainingFile into proto.Message.
-func (m *TrainingFile) ToMesg(fac Factory) proto.Message {
+// ToMesg converts TrainingFile into proto.Message. If options is nil, default options will be used.
+func (m *TrainingFile) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/user_profile_gen.go
+++ b/profile/mesgdef/user_profile_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -102,8 +103,16 @@ func NewUserProfile(mesg *proto.Message) *UserProfile {
 	}
 }
 
-// ToMesg converts UserProfile into proto.Message.
-func (m *UserProfile) ToMesg(fac Factory) proto.Message {
+// ToMesg converts UserProfile into proto.Message. If options is nil, default options will be used.
+func (m *UserProfile) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/video_clip_gen.go
+++ b/profile/mesgdef/video_clip_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -59,8 +60,16 @@ func NewVideoClip(mesg *proto.Message) *VideoClip {
 	}
 }
 
-// ToMesg converts VideoClip into proto.Message.
-func (m *VideoClip) ToMesg(fac Factory) proto.Message {
+// ToMesg converts VideoClip into proto.Message. If options is nil, default options will be used.
+func (m *VideoClip) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/video_description_gen.go
+++ b/profile/mesgdef/video_description_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -49,8 +50,16 @@ func NewVideoDescription(mesg *proto.Message) *VideoDescription {
 	}
 }
 
-// ToMesg converts VideoDescription into proto.Message.
-func (m *VideoDescription) ToMesg(fac Factory) proto.Message {
+// ToMesg converts VideoDescription into proto.Message. If options is nil, default options will be used.
+func (m *VideoDescription) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/video_frame_gen.go
+++ b/profile/mesgdef/video_frame_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -51,8 +52,16 @@ func NewVideoFrame(mesg *proto.Message) *VideoFrame {
 	}
 }
 
-// ToMesg converts VideoFrame into proto.Message.
-func (m *VideoFrame) ToMesg(fac Factory) proto.Message {
+// ToMesg converts VideoFrame into proto.Message. If options is nil, default options will be used.
+func (m *VideoFrame) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/video_gen.go
+++ b/profile/mesgdef/video_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -49,8 +50,16 @@ func NewVideo(mesg *proto.Message) *Video {
 	}
 }
 
-// ToMesg converts Video into proto.Message.
-func (m *Video) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Video into proto.Message. If options is nil, default options will be used.
+func (m *Video) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/video_title_gen.go
+++ b/profile/mesgdef/video_title_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -49,8 +50,16 @@ func NewVideoTitle(mesg *proto.Message) *VideoTitle {
 	}
 }
 
-// ToMesg converts VideoTitle into proto.Message.
-func (m *VideoTitle) ToMesg(fac Factory) proto.Message {
+// ToMesg converts VideoTitle into proto.Message. If options is nil, default options will be used.
+func (m *VideoTitle) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/watchface_settings_gen.go
+++ b/profile/mesgdef/watchface_settings_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -49,8 +50,16 @@ func NewWatchfaceSettings(mesg *proto.Message) *WatchfaceSettings {
 	}
 }
 
-// ToMesg converts WatchfaceSettings into proto.Message.
-func (m *WatchfaceSettings) ToMesg(fac Factory) proto.Message {
+// ToMesg converts WatchfaceSettings into proto.Message. If options is nil, default options will be used.
+func (m *WatchfaceSettings) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/weather_alert_gen.go
+++ b/profile/mesgdef/weather_alert_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -57,8 +58,16 @@ func NewWeatherAlert(mesg *proto.Message) *WeatherAlert {
 	}
 }
 
-// ToMesg converts WeatherAlert into proto.Message.
-func (m *WeatherAlert) ToMesg(fac Factory) proto.Message {
+// ToMesg converts WeatherAlert into proto.Message. If options is nil, default options will be used.
+func (m *WeatherAlert) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/weather_conditions_gen.go
+++ b/profile/mesgdef/weather_conditions_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -78,8 +79,16 @@ func NewWeatherConditions(mesg *proto.Message) *WeatherConditions {
 	}
 }
 
-// ToMesg converts WeatherConditions into proto.Message.
-func (m *WeatherConditions) ToMesg(fac Factory) proto.Message {
+// ToMesg converts WeatherConditions into proto.Message. If options is nil, default options will be used.
+func (m *WeatherConditions) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/weight_scale_gen.go
+++ b/profile/mesgdef/weight_scale_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
@@ -74,8 +75,16 @@ func NewWeightScale(mesg *proto.Message) *WeightScale {
 	}
 }
 
-// ToMesg converts WeightScale into proto.Message.
-func (m *WeightScale) ToMesg(fac Factory) proto.Message {
+// ToMesg converts WeightScale into proto.Message. If options is nil, default options will be used.
+func (m *WeightScale) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/workout_gen.go
+++ b/profile/mesgdef/workout_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -60,8 +61,16 @@ func NewWorkout(mesg *proto.Message) *Workout {
 	}
 }
 
-// ToMesg converts Workout into proto.Message.
-func (m *Workout) ToMesg(fac Factory) proto.Message {
+// ToMesg converts Workout into proto.Message. If options is nil, default options will be used.
+func (m *Workout) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/workout_session_gen.go
+++ b/profile/mesgdef/workout_session_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -58,8 +59,16 @@ func NewWorkoutSession(mesg *proto.Message) *WorkoutSession {
 	}
 }
 
-// ToMesg converts WorkoutSession into proto.Message.
-func (m *WorkoutSession) ToMesg(fac Factory) proto.Message {
+// ToMesg converts WorkoutSession into proto.Message. If options is nil, default options will be used.
+func (m *WorkoutSession) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/workout_step_gen.go
+++ b/profile/mesgdef/workout_step_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
@@ -82,8 +83,16 @@ func NewWorkoutStep(mesg *proto.Message) *WorkoutStep {
 	}
 }
 
-// ToMesg converts WorkoutStep into proto.Message.
-func (m *WorkoutStep) ToMesg(fac Factory) proto.Message {
+// ToMesg converts WorkoutStep into proto.Message. If options is nil, default options will be used.
+func (m *WorkoutStep) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 

--- a/profile/mesgdef/zones_target_gen.go
+++ b/profile/mesgdef/zones_target_gen.go
@@ -7,6 +7,7 @@
 package mesgdef
 
 import (
+	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/typeconv"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -53,8 +54,16 @@ func NewZonesTarget(mesg *proto.Message) *ZonesTarget {
 	}
 }
 
-// ToMesg converts ZonesTarget into proto.Message.
-func (m *ZonesTarget) ToMesg(fac Factory) proto.Message {
+// ToMesg converts ZonesTarget into proto.Message. If options is nil, default options will be used.
+func (m *ZonesTarget) ToMesg(options *Options) proto.Message {
+	if options == nil {
+		options = defaultOptions
+	} else if options.Factory == nil {
+		options.Factory = factory.StandardFactory()
+	}
+
+	fac := options.Factory
+
 	fieldsArray := fieldsPool.Get().(*[256]proto.Field)
 	defer fieldsPool.Put(fieldsArray)
 


### PR DESCRIPTION
BREAKING CHANGES:
- filedef's `ToFit` and mesgdef's `ToMesg` now receive `*mesgdef.Options` as parameter instead of `factory`. This change accomodate additional options that may be passed to the method later on such as whether to include expanded field or not when converting back to proto.Fit and proto.Message as encoder will remove expanded fields anyway, this will reduce unecessary step when converting is only meant to encode. When nil is passed as options, default options will be used: use standard factory and expanded field will not be included.