### PR TITLE
perf: reduce factory memory usage

### DIFF
--- a/internal/cmd/fitgen/factory/builder.go
+++ b/internal/cmd/fitgen/factory/builder.go
@@ -180,7 +180,7 @@ func (b *factoryBuilder) makeFields(message parser.Message) string {
 	}
 
 	strbuf := new(strings.Builder)
-	strbuf.WriteString("[256]proto.Field{\n")
+	strbuf.WriteString("[256]*proto.Field{\n")
 	for _, field := range message.Fields {
 		// strbuf.WriteString("{\n")
 		strbuf.WriteString(fmt.Sprintf("%d: {\n", field.Num))

--- a/internal/cmd/fitgen/factory/factory.tmpl
+++ b/internal/cmd/fitgen/factory/factory.tmpl
@@ -48,40 +48,42 @@ type Factory struct {
 // Receiving messages through here means we need to validate all of it, while RegisterMesg is already exist for that purpose.
 func New() *Factory { return &Factory{} }
 
-var ( // cache for CreateMesg func
-	once sync.Once
-	cache map[typedef.MesgNum]proto.Message
+var ( // cache for CreateMesg method
+	once	   sync.Once
+	protoMesgs [len(mesgs)]proto.Message // data is populated on CreateMesg first invocation.
 )
 
 {{ template "create_mesg_doc" -}}
 func (f *Factory) CreateMesg(num typedef.MesgNum) proto.Message {
 	once.Do(func() { // populate data fields in the cache.
-		cache = make(map[typedef.MesgNum]proto.Message)
 		for i := range mesgs {
 			rawmesg := &mesgs[i]
-			if _, ok := cache[rawmesg.Num]; ok {
-				continue
+			if rawmesg.Num != typedef.MesgNum(i) {
+				continue // skip unknown message
 			}
 			var n byte
 			for j := range rawmesg.Fields {
 				field := rawmesg.Fields[j]
-				if field.FieldBase != nil {
+				if field != nil {
 					n++
 				}
 			}
-            fields := make([]proto.Field, 0, n)
+			fields := make([]proto.Field, 0, n)
 			for j := range rawmesg.Fields {
 				field := rawmesg.Fields[j]
-				if field.FieldBase != nil {
-					fields = append(fields, field)
+				if field != nil {
+					fields = append(fields, *field)
 				}
 			}
-			cache[rawmesg.Num] = proto.Message{Num: rawmesg.Num, Fields: fields}
+			protoMesgs[rawmesg.Num] = proto.Message{
+				Num:    rawmesg.Num, 
+				Fields: fields,
+			}
 		}
 	})
 
-	mesg, ok := cache[num]
-	if !ok {
+	mesg := protoMesgs[num]
+	if mesg.Num != num {
 		mesg = f.registeredMesgs[num]
 	}
 
@@ -105,18 +107,18 @@ func (f *Factory) CreateMesgOnly(num typedef.MesgNum) proto.Message {
 func (f *Factory) CreateField(mesgNum typedef.MesgNum, num byte) proto.Field {
 	if mesgNum < typedef.MesgNum(len(mesgs)) && mesgs[mesgNum].Num == mesgNum {
 		field := mesgs[mesgNum].Fields[num]
-		if field.FieldBase != nil {
-			return field
+		if field != nil {
+			return *field
 		}
 		return createUnknownField(num)
 	}
 
-    if mesg, ok := f.registeredMesgs[mesgNum]; ok {
-        for i := range mesg.Fields {
-            if mesg.Fields[i].Num == num {
-                return mesg.Fields[i]
-            }
-        }
+	if mesg, ok := f.registeredMesgs[mesgNum]; ok {
+		for i := range mesg.Fields {
+			if mesg.Fields[i].Num == num {
+				return mesg.Fields[i]
+			}
+		}
 	}
 
 	return createUnknownField(num)
@@ -128,11 +130,11 @@ func createUnknownField(num byte) proto.Field {
 
 {{ template "register_mesg_doc" -}}
 func (f *Factory) RegisterMesg(mesg proto.Message) error {
-    if f.registeredMesgs == nil {
-        f.registeredMesgs = make(map[typedef.MesgNum]proto.Message) // only alloc when needed
-    }
+	if f.registeredMesgs == nil {
+		f.registeredMesgs = make(map[typedef.MesgNum]proto.Message) // only alloc when needed
+	}
 
-    if mesg.Num > typedef.MesgNumMfgRangeMax {
+	if mesg.Num > typedef.MesgNumMfgRangeMax {
 		return fmt.Errorf("could not register outside max range: %d", typedef.MesgNumMfgRangeMax)
 	}
 
@@ -147,7 +149,7 @@ func (f *Factory) RegisterMesg(mesg proto.Message) error {
 
 type message struct {
 	Num    typedef.MesgNum
-	Fields [256]proto.Field // Use array to ensure O(1) lookup
+	Fields [256]*proto.Field // Use array to ensure O(1) lookup, use pointer to reduce memory usage.
 }
 
 // Use array to ensure O(1) lookup


### PR DESCRIPTION
- Previously we use concret values for fields in message struct, using `unsafe.Sizeof(mesgs)`, it will produce 3362000 B (3.36 MB)
```go
type message struct {
	Num    typedef.MesgNum
	Fields [256]proto.Field
}

var mesgs = [...]message{ /* data */ }

```

- We change it to use pointer values since most of the message only has small amount of fields, it will only produce 842960 (0,84 MB)
```go
type message struct {
	Num    typedef.MesgNum
	Fields [256]*proto.Field // <---- this
}
```

There is no significant performance reduction on decoding process after factory uses pointer values
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/decoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
         │   new.txt   │           new2.txt            │
         │   sec/op    │   sec/op     vs base          │
Decode-4   108.6m ± 1%   108.8m ± 1%  ~ (p=0.529 n=10)

         │   new.txt    │              new2.txt               │
         │     B/op     │     B/op      vs base               │
Decode-4   67.39Mi ± 0%   67.39Mi ± 0%  -0.00% (p=0.050 n=10)

         │   new.txt   │            new2.txt             │
         │  allocs/op  │  allocs/op   vs base            │
Decode-4   900.0k ± 0%   900.0k ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

```

- Another change is proto messages variable used by CreateMesg is now using array to ensure O(1) lookup, it will only use 22960 (22.96 KB) on its empty state.