### PR TITLE
fix: potential incorrect string to integer conversion

### DIFF
--- a/internal/cmd/fitgen/parser/parser.go
+++ b/internal/cmd/fitgen/parser/parser.go
@@ -140,7 +140,7 @@ func (p *Parser) ParseMessages() ([]Message, error) {
 		}
 
 		// only field has fieldNum, sub-field doesn't.
-		fieldNum, err := strconv.Atoi(row.Cell("B"))
+		fieldNum, err := strconv.ParseUint(row.Cell("B"), 0, 8)
 		if err != nil {
 			return nil, err
 		}
@@ -213,7 +213,7 @@ func splitBytesOrNil(s string) ([]byte, error) {
 	strVals := strings.Split(s, ",")
 	bs := make([]byte, 0, len(strVals))
 	for _, s := range strVals {
-		b, err := strconv.Atoi(s)
+		b, err := strconv.ParseUint(s, 0, 8)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Resolve https://github.com/muktihari/fit/security/code-scanning/26

This does not change the current generated files, so no release needed. This change ensure future profile update to be correct, any typo related to this integer conversion in `Profile.xlsx` from official release (or `Product Profile` specified by user) will be spotted right away instead of silent error, even thought the chance is pretty low.