### PR TITLE
fix: wrong 'Size' value when creating mesgDef from mesg

### DIFF
--- a/proto/proto.go
+++ b/proto/proto.go
@@ -79,7 +79,7 @@ func CreateMessageDefinitionTo(target *MessageDefinition, mesg *Message) {
 	for i := range mesg.DeveloperFields {
 		target.DeveloperFieldDefinitions = append(target.DeveloperFieldDefinitions, DeveloperFieldDefinition{
 			Num:                mesg.DeveloperFields[i].Num,
-			Size:               mesg.DeveloperFields[i].BaseType.Size(),
+			Size:               byte(Sizeof(mesg.DeveloperFields[i].Value, mesg.DeveloperFields[i].BaseType)),
 			DeveloperDataIndex: mesg.DeveloperFields[i].DeveloperDataIndex,
 		})
 	}

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -39,14 +39,16 @@ func LocalMesgNum(header byte) byte {
 }
 
 // CreateMessageDefinition creates new MessageDefinition base on given Message.
-// It will panic if mesg is nil.
+// It will panic if mesg is nil. And mesg must be validated first, for instance
+// if field.Value's size is more than 255 bytes, overflow will occurs.
 func CreateMessageDefinition(mesg *Message) (mesgDef MessageDefinition) {
 	CreateMessageDefinitionTo(&mesgDef, mesg)
 	return
 }
 
 // CreateMessageDefinitionTo create MessageDefinition base on given Message and put it at target object to avoid allocation.
-// It will panic if either target or mesg is nil.
+// It will panic if either target or mesg is nil. And mesg must be validated first, for instance
+// if field.Value's size is more than 255 bytes, overflow will occurs.
 func CreateMessageDefinitionTo(target *MessageDefinition, mesg *Message) {
 	target.Header = MesgDefinitionMask
 	target.Reserved = mesg.Reserved

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -457,13 +457,67 @@ func TestCreateMessageDefinition(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "developer fields with string value \"FIT SDK Go\", size should be 11",
+			mesg: proto.Message{Num: mesgnum.UserProfile}.
+				WithFields(
+					factory.CreateField(mesgnum.UserProfile, fieldnum.UserProfileGlobalId).WithValue([]byte{byte(2), byte(9)})).
+				WithDeveloperFields(
+					proto.DeveloperField{
+						Num: 0, Name: "FIT SDK Go", BaseType: basetype.String, DeveloperDataIndex: 0, Value: proto.String("FIT SDK Go"),
+					},
+				),
+			mesgDef: proto.MessageDefinition{
+				Header:  proto.MesgDefinitionMask | proto.DevDataMask,
+				MesgNum: mesgnum.UserProfile,
+				FieldDefinitions: []proto.FieldDefinition{
+					{
+						Num:      fieldnum.UserProfileGlobalId,
+						Size:     2,
+						BaseType: basetype.Byte,
+					},
+				},
+				DeveloperFieldDefinitions: []proto.DeveloperFieldDefinition{
+					{
+						Num: 0, Size: 11, DeveloperDataIndex: 0,
+					},
+				},
+			},
+		},
+		{
+			name: "developer fields with value []uint16{1,2,3}, size should be 3*2 = 6",
+			mesg: proto.Message{Num: mesgnum.UserProfile}.
+				WithFields(
+					factory.CreateField(mesgnum.UserProfile, fieldnum.UserProfileGlobalId).WithValue([]byte{byte(2), byte(9)})).
+				WithDeveloperFields(
+					proto.DeveloperField{
+						Num: 0, Name: "FIT SDK Go", BaseType: basetype.Uint16, DeveloperDataIndex: 0, Value: proto.SliceUint16([]uint16{1, 2, 3}),
+					},
+				),
+			mesgDef: proto.MessageDefinition{
+				Header:  proto.MesgDefinitionMask | proto.DevDataMask,
+				MesgNum: mesgnum.UserProfile,
+				FieldDefinitions: []proto.FieldDefinition{
+					{
+						Num:      fieldnum.UserProfileGlobalId,
+						Size:     2,
+						BaseType: basetype.Byte,
+					},
+				},
+				DeveloperFieldDefinitions: []proto.DeveloperFieldDefinition{
+					{
+						Num: 0, Size: 6, DeveloperDataIndex: 0,
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
 			mesgDef := proto.CreateMessageDefinition(&tc.mesg)
 			if diff := cmp.Diff(mesgDef, tc.mesgDef); diff != "" {
-				t.Fatal(i, diff)
+				t.Fatal(diff)
 			}
 		})
 	}


### PR DESCRIPTION
The value should be calculated from DeveloperField.Value and DeveloperField.BaseType using proto.Sizeof.