### PR TITLE
fix: potential bug on scale offset logic

### DIFF
--- a/encoder/validator.go
+++ b/encoder/validator.go
@@ -113,7 +113,7 @@ func (v *messageValidator) Validate(mesg *proto.Message) error {
 		}
 
 		// Restore any scaled float64 value back into its corresponding integer representation.
-		if field.Scale != 1 && field.Offset != 0 {
+		if field.Scale != 1 || field.Offset != 0 {
 			field.Value = scaleoffset.DiscardValue(
 				field.Value,
 				field.BaseType,
@@ -215,7 +215,7 @@ func (v *messageValidator) handleNativeValue(developerField *proto.DeveloperFiel
 	}
 
 	// Restore any scaled float64 value back into its corresponding integer representation.
-	if field.Scale != 1 && field.Offset != 0 {
+	if field.Scale != 1 || field.Offset != 0 {
 		developerField.Value = scaleoffset.DiscardValue(
 			developerField.Value,
 			field.BaseType,

--- a/encoder/validator_test.go
+++ b/encoder/validator_test.go
@@ -418,6 +418,27 @@ func TestMessageValidatorValidate(t *testing.T) {
 			},
 			errs: []error{nil, nil, ErrValueTypeMismatch},
 		},
+		{
+			// in Profile.xlsx (v21.133) there is no field with scale 1 and offset other than 0, but just in case in future update.
+			name: "message having field with scale: 1, offset: 20",
+			mesgs: []proto.Message{
+				{
+					Fields: []proto.Field{
+						{
+							FieldBase: &proto.FieldBase{
+								Num:      254,
+								Name:     "Unknown",
+								Scale:    1,
+								Offset:   20,
+								Type:     profile.Uint16,
+								BaseType: basetype.Uint16,
+							},
+							Value: proto.Float64(200),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range tt {

--- a/internal/cmd/fitgen/profile/mesgdef/builder.go
+++ b/internal/cmd/fitgen/profile/mesgdef/builder.go
@@ -170,7 +170,7 @@ func (b *mesgdefBuilder) Build() ([]builder.Data, error) {
 				}
 			}
 
-			if !(f.Scale == 1 && f.Offset == 0) {
+			if f.Scale != 1 || f.Offset != 0 {
 				imports["github.com/muktihari/fit/kit/scaleoffset"] = struct{}{}
 			}
 
@@ -189,7 +189,7 @@ func (b *mesgdefBuilder) Build() ([]builder.Data, error) {
 				imports["github.com/muktihari/fit/kit/datetime"] = struct{}{}
 			}
 
-			if !(f.Scale == 1 && f.Offset == 0) && f.Array != true {
+			if (f.Scale != 1 || f.Offset != 0) && !f.Array {
 				imports["math"] = struct{}{}
 			}
 


### PR DESCRIPTION
Currently, in Profile.xlsx (v21.133) there is no field with scale == 1 and offset other than 0, but in case it happen, this following code in `encoder/validator.go` is problematic, if scale is 1 and offset is 20 then it become `false && true` -> `false`
```go
if field.Scale != 1 && field.Offset != 0 { }
```

- Verify and fix similar logic across files.