### PR TITLE
fix: remove profile.Version() and export Version constant instead

### DIFF
--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -373,7 +373,7 @@ func TestCheckIntegrity(t *testing.T) {
 				h := proto.FileHeader{
 					Size:            14,
 					ProtocolVersion: byte(proto.V2),
-					ProfileVersion:  profile.Version(),
+					ProfileVersion:  profile.Version,
 					DataSize:        0,
 					DataType:        proto.DataTypeFIT,
 				}

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -201,7 +201,7 @@ func New(w io.Writer, opts ...Option) *Encoder {
 		defaultFileHeader: proto.FileHeader{
 			Size:            proto.DefaultFileHeaderSize,
 			ProtocolVersion: byte(options.protocolVersion),
-			ProfileVersion:  profile.Version(),
+			ProfileVersion:  profile.Version,
 			DataSize:        0, // calculated during encoding
 			DataType:        proto.DataTypeFIT,
 			CRC:             0, // calculated during encoding

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -475,7 +475,7 @@ func TestEncodeHeader(t *testing.T) {
 					0, 0, // crc checksum will be calculated
 				}
 
-				binary.LittleEndian.PutUint16(b[2:4], profile.Version())
+				binary.LittleEndian.PutUint16(b[2:4], profile.Version)
 
 				crc := crc16.New(crc16.MakeFitTable())
 				crc.Write(b[:12])

--- a/internal/cmd/fitgen/profile/data.go
+++ b/internal/cmd/fitgen/profile/data.go
@@ -23,5 +23,7 @@ type ProfileTypeBaseType struct {
 type VersionData struct {
 	ProfileVersion string
 	Package        string
+	Major          uint16
+	Minor          uint16
 	Version        uint16
 }

--- a/internal/cmd/fitgen/profile/profile.tmpl
+++ b/internal/cmd/fitgen/profile/profile.tmpl
@@ -37,11 +37,9 @@ func (p ProfileType) BaseType() basetype.BaseType {
 
 package {{ .Package }}
 
-const version = {{ .Version }}
+// Version is the current profile version, v{{ .ProfileVersion }}, in uint16 representation. 
+//  -> "{{ .Major }}" + "{{ .Minor }}" = "{{ .Version }}" -> {{ .Version }}.
+const Version uint16 = {{ .Version }}
 
-// Version returns the current profile version, v{{ .ProfileVersion }}, in its uint16 form: (Major * 1000) + Minor = {{ .Version }}.
-func Version() uint16 { 
-	return version
-}
 
 {{ end }}

--- a/profile/profile_gen.go
+++ b/profile/profile_gen.go
@@ -215,6 +215,8 @@ const (
 	Invalid
 )
 
+func (p ProfileType) Uint16() uint16 { return uint16(p) }
+
 func (p ProfileType) String() string {
 	switch p {
 	case Enum:

--- a/profile/version_gen.go
+++ b/profile/version_gen.go
@@ -6,9 +6,7 @@
 
 package profile
 
-const version = 21133
-
-// Version returns the current profile version, v21.133, in its uint16 form: (Major * 1000) + Minor = 21133.
-func Version() uint16 {
-	return version
-}
+// Version is the current profile version, v21.133, in uint16 representation.
+//
+//	-> "21" + "133" = "21133" -> 21133.
+const Version uint16 = 21133


### PR DESCRIPTION
Remove Version() and  export the Version constant directly, so we can retrieve the version at compile time.