### PR TITLE
fix: consistency on treating invalid strings

### DIFF
--- a/profile/basetype/basetype.go
+++ b/profile/basetype/basetype.go
@@ -43,7 +43,7 @@ const (
 	Uint16Invalid  uint16 = math.MaxUint16 // 0xFFFF
 	Sint32Invalid  int32  = math.MaxInt32  // 0x7FFFFFFF
 	Uint32Invalid  uint32 = math.MaxUint32 // 0xFFFFFFFF
-	StringInvalid  string = "\x00"         // 0x00. Same as string([]byte{0x00}), 0x00 is utf-8 null-terminated string.
+	StringInvalid  string = ""             // We use empty string to represent an invalid string in Go. However, it will be converted automatically into an utf8 null-terminated string "\x00" by the Value Marshaler.
 	Float32Invalid uint32 = math.MaxUint32 // 0xFFFFFFFF. math.Float32frombits(0xFFFFFFFF) produces float64 NaN which is uncomparable. Can only check in its integer form e.g. math.Float32bits(float32value) == Float32Invalid.
 	Float64Invalid uint64 = math.MaxUint64 // 0xFFFFFFFFFFFFFFFF. math.Float64frombits(0xFFFFFFFFFFFFFFFF) produces float64 NaN which is uncomparable. Can only check in its integer form e.g. math.Float64bits(float64value) == Float64Invalid.
 	Uint8zInvalid  uint8  = 0              // 0x00

--- a/proto/value.go
+++ b/proto/value.go
@@ -517,7 +517,7 @@ func (v Value) Valid(t basetype.BaseType) bool {
 		return v.Uint64() != basetype.Uint64Invalid
 	case TypeString:
 		s := v.String()
-		return s != basetype.StringInvalid && s != ""
+		return s != basetype.StringInvalid && s != "\x00"
 	case TypeSliceInt8:
 		vals := v.SliceInt8()
 		for i := range vals {
@@ -601,7 +601,7 @@ func (v Value) Valid(t basetype.BaseType) bool {
 	case TypeSliceString:
 		vals := v.SliceString()
 		for i := range vals {
-			if vals[i] == basetype.StringInvalid || vals[i] == "" {
+			if vals[i] == basetype.StringInvalid || vals[i] == "\x00" {
 				invalidCount++
 			}
 		}


### PR DESCRIPTION
In proto.Unmarshal, the SDK will remove any UTF-8 Null-Terminated String (0x00) from the string or []string value. To make consistency on how we should treat strings, all functions or methods that returning strings should return strings without `0x00`, and all functions or methods that validate invalid strings should check for both empty string and `0x00`, invalid if the result of this is true -> `value == "" || value == "\x00"`. 

Value marshaler will check whether a string is end with `0x00`, if it does not end with `0x00` will automatically add it. If the users intentionally add multiple `0x00` it should allow it. In cases where message definitions differ only slightly, such as when creating FieldDescription messages with minor variations in the FieldName value (type: []string), it make sense to add `0x00` padding so that the length of the strings (the byte size of the FieldName value) become the same, this will reduce message definition interleave as it can be treated using the same message definition.