### PR TITLE
fix: decoder now handle bad encoded fit file when size < basetype.Size

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -362,84 +362,94 @@ func main() {
 
 ### Available Decode Options
 
-1. **WithFactory**: allow us to use custom Factory, for example if we are working with multiple manufacturer specific messages at the same time.
+1.  **WithFactory**: allow us to use custom Factory, for example if we are working with multiple manufacturer specific messages at the same time.
 
-   Example
+    Example
 
-   ```go
-   fac := factory.New()
-   fac.RegisterMesg(proto.Message{
-       Num:  65281,
-       Fields: []proto.Field{
-           {
-               FieldBase: &proto.FieldBase{
-                   Num:    253,
-                   Name:   "Timestamp",
-                   Type:   profile.Uint32,
-                   Size:   4,
-                   Scale:  1,
-                   Offset: 0,
-                   Units:  "s",
-               },
-           },
-       },
-   })
+    ```go
+    fac := factory.New()
+    fac.RegisterMesg(proto.Message{
+        Num:  65281,
+        Fields: []proto.Field{
+            {
+                FieldBase: &proto.FieldBase{
+                    Num:    253,
+                    Name:   "Timestamp",
+                    Type:   profile.Uint32,
+                    Size:   4,
+                    Scale:  1,
+                    Offset: 0,
+                    Units:  "s",
+                },
+            },
+        },
+    })
 
-   dec := decoder.New(f, decoder.WithFactory(fac))
-   ```
+    dec := decoder.New(f, decoder.WithFactory(fac))
+    ```
 
-1. **WithMesgListener**: adds message listener to the listener pool so that we can receive the messages as soon as it is decoded.
+1.  **WithMesgListener**: adds message listener to the listener pool so that we can receive the messages as soon as it is decoded.
 
-   Example:
+    Example:
 
-   ```go
-   al := filedef.NewListener()
-   dec := decoder.New(f,
-       decoder.WithMesgListener(al),
-   )
-   ```
+    ```go
+    al := filedef.NewListener()
+    dec := decoder.New(f,
+        decoder.WithMesgListener(al),
+    )
+    ```
 
-1. **WithMesgDefListener**: adds message definition listener to the listener pool so that we can receive the message definitions as soon as it is decoded.
+1.  **WithMesgDefListener**: adds message definition listener to the listener pool so that we can receive the message definitions as soon as it is decoded.
 
-   Example:
+    Example:
 
-   ```go
-   conv := fitcsv.NewConverter(bw)
-   defer conv.Wait()
+    ```go
+    conv := fitcsv.NewConverter(bw)
+    defer conv.Wait()
 
-   dec := decoder.New(f,
-       decoder.WithMesgDefListener(conv),
-       decoder.WithMesgListener(conv),
-   )
-   ```
+    dec := decoder.New(f,
+        decoder.WithMesgDefListener(conv),
+        decoder.WithMesgListener(conv),
+    )
+    ```
 
-1. **WithBroadcastOnly**: directs the decoder to only broadcast the messages without retaining them.
+1.  **WithBroadcastOnly**: directs the decoder to only broadcast the messages without retaining them.
 
-   Example:
+    Example:
 
-   ```go
-   al := filedef.NewListener()
-   dec := decoder.New(f,
-       decoder.WithMesgListener(al),
-       decoder.WithBroadcastOnly(),
-   )
-   ```
+    ```go
+    al := filedef.NewListener()
+    dec := decoder.New(f,
+        decoder.WithMesgListener(al),
+        decoder.WithBroadcastOnly(),
+    )
+    ```
 
-1. **WithIgnoreChecksum**: directs the decoder to ignore the checksum, which is useful when we want to retrieve the data without considering its integrity.
+1.  **WithIgnoreChecksum**: directs the decoder to ignore the checksum, which is useful when we want to retrieve the data without considering its integrity.
 
-   Example:
+    Example:
 
-   ```go
-   dec := decoder.New(f, decoder.WithIgnoreChecksum())
-   ```
+    ```go
+    dec := decoder.New(f, decoder.WithIgnoreChecksum())
+    ```
 
-1. **WithNoComponentExpansion**: directs the Decoder to not expand the components.
+1.  **WithNoComponentExpansion**: directs the Decoder to not expand the components.
 
-   Example:
+    Example:
 
-   ```go
-   dec := decoder.New(f, decoder.WithNoComponentExpansion())
-   ```
+    ```go
+    dec := decoder.New(f, decoder.WithNoComponentExpansion())
+    ```
+
+1.  **WithLogWriter**: specifies where the log messages will be written to. By default, the Decoder writes log message to io.Discard.
+    The Decoder will only write log messages when it encountered a bad encoded FIT file such as:
+
+    - Field Definition's Size is less than its basetype's size. e.g. Size 1 byte but having basetype uint32 (4 bytes).
+    - Encounter a Developer Field without prior Field Description Message.
+
+    ```go
+    dec := decoder.New(f, decoder.WithLogWriter(os.Stdout))
+    ```
 
 ### RawDecoder (Low-Level Abstraction)
 


### PR DESCRIPTION
There is a case where a FIT file from a well-known brand contains fieldDef's Size mismatch with fieldDef's Basetype.Size(): Size is 1 byte but the type is uint32 which should have been 4 bytes. This cause panic in our current implementation since the binary unmarshaler will try to unmarshal 4 bytes but we got only 1 byte in []byte slice, index out of bound. 

Actually, we do not want to support bad encoded FIT file as there might be too many cases to handle and adding complexity to our code. However, this bug causes panic in our FIT SDK so we need to take a measurement and gracefully handle such cases. 

Returning an error is one of the options, but then we can't get the FIT file contents at all, so let's make a simple workaround to handle that so we could retrieve the contents as much as we can and just write a log message when the Decoder found such cases so user known that the data they are receiving might be changed due to the value type casting.