### PR TITLE
perf!: reduce crc16 pointer dereference

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -190,7 +190,7 @@ func New(r io.Reader, opts ...Option) *Decoder {
 		options:                 options,
 		factory:                 options.factory,
 		accumulator:             NewAccumulator(),
-		crc16:                   crc16.New(crc16.MakeFitTable()),
+		crc16:                   crc16.New(nil),
 		localMessageDefinitions: [proto.LocalMesgNumMask + 1]*proto.MessageDefinition{},
 		mesgListeners:           options.mesgListeners,
 		mesgDefListeners:        options.mesgDefListeners,

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -385,7 +385,7 @@ func TestCheckIntegrity(t *testing.T) {
 					DataType:        proto.DataTypeFIT,
 				}
 				b, _ := h.MarshalBinary()
-				crc := crc16.New(crc16.MakeFitTable())
+				crc := crc16.New(nil)
 				crc.Write(b[:12])
 				binary.LittleEndian.PutUint16(b[12:14], crc.Sum16())
 				return bytes.NewReader(b)
@@ -539,7 +539,7 @@ func createFitForTest() (proto.FIT, []byte) {
 	bytesbuffer.Write(b)
 
 	// Marshal and calculate data size and crc checksum
-	crc16checker := crc16.New(crc16.MakeFitTable())
+	crc16checker := crc16.New(nil)
 	for i := range fit.Messages {
 		mesg := fit.Messages[i]
 		mesgDef := proto.CreateMessageDefinition(&mesg)

--- a/decoder/raw_test.go
+++ b/decoder/raw_test.go
@@ -36,7 +36,7 @@ var fnDecodeRawErr = func(flag RawFlag, b []byte) error {
 
 func TestRawDecoderDecode(t *testing.T) {
 	_, buf := createFitForTest()
-	hash16 := crc16.New(crc16.MakeFitTable())
+	hash16 := crc16.New(nil)
 
 	tt := []struct {
 		name string

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -479,7 +479,7 @@ func main() {
     defer f.Close()
 
     dec := decoder.NewRaw()
-    hash16 := crc16.New(crc16.MakeFitTable())
+    hash16 := crc16.New(nil)
 
     _, err = dec.Decode(bufio.NewReader(f), func(flag decoder.RawFlag, b []byte) error {
         switch flag {

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -191,7 +191,7 @@ func New(w io.Writer, opts ...Option) *Encoder {
 		lruCapacity = options.multipleLocalMessageType + 1
 	}
 
-	crc16 := crc16.New(crc16.MakeFitTable())
+	crc16 := crc16.New(nil)
 	e := &Encoder{
 		w:                 w,
 		options:           options,

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -477,7 +477,7 @@ func TestEncodeHeader(t *testing.T) {
 
 				binary.LittleEndian.PutUint16(b[2:4], profile.Version)
 
-				crc := crc16.New(crc16.MakeFitTable())
+				crc := crc16.New(nil)
 				crc.Write(b[:12])
 				binary.LittleEndian.PutUint16(b[12:14], crc.Sum16())
 

--- a/kit/hash/crc16/crc16_test.go
+++ b/kit/hash/crc16/crc16_test.go
@@ -5,42 +5,55 @@
 package crc16_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/muktihari/fit/kit/hash/crc16"
 )
 
 func TestCRC16(t *testing.T) {
-	b := []byte{14, 32, 84, 8, 214, 204, 9, 0, 46, 70, 73, 84} // example from some fit header.
-	crc := uint16(12856)                                       // should match this checksum.
-
-	c16 := crc16.New(nil)
-
-	if c16.BlockSize() != 1 {
-		t.Fatalf("blocksize mismatch")
+	tt := []struct {
+		name  string
+		table *crc16.Table
+	}{
+		{name: "nil table", table: nil},
+		{name: "crc16.MakeFITTable()", table: crc16.MakeFITTable()},
 	}
 
-	if c16.Size() != 2 {
-		t.Fatalf("size mismatch")
-	}
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
+			b := []byte{14, 32, 84, 8, 214, 204, 9, 0, 46, 70, 73, 84} // example from some fit header.
+			crc := uint16(12856)                                       // should match this checksum.
 
-	_, _ = c16.Write(b)
-	if c16.Sum16() != crc {
-		t.Fatalf("expected: %v, got: %v", crc, c16.Sum16())
-	}
+			c16 := crc16.New(tc.table)
 
-	sum := c16.Sum([]byte{10})
-	expect := []byte{10, 50, 56}
-	for i := range sum {
-		if sum[i] != expect[i] {
-			t.Fatalf("expected: %v, got: %v", expect[i], sum[i])
-		}
-	}
+			if c16.BlockSize() != 1 {
+				t.Fatalf("blocksize mismatch")
+			}
 
-	c16.Reset()
+			if c16.Size() != 2 {
+				t.Fatalf("size mismatch")
+			}
 
-	if c16.Sum16() != 0 {
-		t.Fatalf("expected 0 after reset, got: %v", c16.Sum16())
+			_, _ = c16.Write(b)
+			if c16.Sum16() != crc {
+				t.Fatalf("expected: %v, got: %v", crc, c16.Sum16())
+			}
+
+			sum := c16.Sum([]byte{10})
+			expect := []byte{10, 50, 56}
+			for i := range sum {
+				if sum[i] != expect[i] {
+					t.Fatalf("expected: %v, got: %v", expect[i], sum[i])
+				}
+			}
+
+			c16.Reset()
+
+			if c16.Sum16() != 0 {
+				t.Fatalf("expected 0 after reset, got: %v", c16.Sum16())
+			}
+		})
 	}
 }
 

--- a/kit/hash/crc16/crc16_test.go
+++ b/kit/hash/crc16/crc16_test.go
@@ -14,7 +14,7 @@ func TestCRC16(t *testing.T) {
 	b := []byte{14, 32, 84, 8, 214, 204, 9, 0, 46, 70, 73, 84} // example from some fit header.
 	crc := uint16(12856)                                       // should match this checksum.
 
-	c16 := crc16.New(crc16.MakeFitTable())
+	c16 := crc16.New(nil)
 
 	if c16.BlockSize() != 1 {
 		t.Fatalf("blocksize mismatch")
@@ -41,5 +41,16 @@ func TestCRC16(t *testing.T) {
 
 	if c16.Sum16() != 0 {
 		t.Fatalf("expected 0 after reset, got: %v", c16.Sum16())
+	}
+}
+
+func BenchmarkWrite(b *testing.B) {
+	b.StopTimer()
+	buf := make([]byte, 4096)
+	h := crc16.New(nil)
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		h.Write(buf)
 	}
 }


### PR DESCRIPTION
BREAKING CHANGES:
- `MakeFitTable` renamed to `MakeFITTable`

Benchmark:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/kit/hash/crc16
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
        │   old.txt   │               new.txt               │
        │   sec/op    │   sec/op     vs base                │
Write-4   27.82µ ± 0%   21.55µ ± 0%  -22.53% (p=0.000 n=10)

        │  old.txt   │            new.txt             │
        │    B/op    │    B/op     vs base            │
Write-4   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

        │  old.txt   │            new.txt             │
        │ allocs/op  │ allocs/op   vs base            │
Write-4   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

```

close #180 