### PR TITLE
pref: implement readBuffer to eliminate extra copying

### DIFF
--- a/decoder/readbuffer.go
+++ b/decoder/readbuffer.go
@@ -1,0 +1,95 @@
+// Copyright 2024 The FIT SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package decoder
+
+import (
+	"io"
+	"math"
+)
+
+const (
+	minReadBufferSize     = 16
+	maxReadBufferSize     = math.MaxUint32
+	defaultReadBufferSize = 4096
+
+	// reservedbuf is the maximum bytes that will be requested by the Decoder in one read.
+	// The value is obtained from the maximum n field definition in a mesg is 255 and
+	// we need 3 byte per field. So 255 * 3 = 765.
+	reservedbuf = 765
+)
+
+// readBuffer is a custom buffered reader. See newReadBuffer() for details.
+type readBuffer struct {
+	r io.Reader // reader provided by the client
+
+	// buf is a bytes buffer to read from io.Reader.
+	// This has unique memory layout:
+	// [reserved section] + [resizable section]
+	// [0, 1,..., 765,    + 766, 767,..., size]
+	//
+	// reserved section is used to memmove remaining bytes when remaining < n.
+	// resizable section is the space for reading from io.Reader.
+	//
+	// This way, fragmented remaining bytes is handled and it will always try to
+	// read exactly x size bytes from io.Reader.
+	buf []byte
+
+	cur, last int // cur and last of buf positions
+}
+
+// newReadBuffer creates a new reader that will automatically handle buffering,
+// allowing us to read bytes directly from the buffer without extra copying.
+// This is unlike *bufio.Reader, which requires us to copy the bytes on every Read() method call.
+func newReadBuffer(rd io.Reader, size int) *readBuffer {
+	if size < minReadBufferSize {
+		size = minReadBufferSize
+	} else if size > maxReadBufferSize {
+		size = maxReadBufferSize
+	}
+	r := new(readBuffer)
+	r.Reset(rd, size)
+	return r
+}
+
+// ReadN reads bytes from the buffer and return exactly n bytes.
+// If the remaining bytes in the buffer is less than n bytes requested, it will automatically fill the buffer.
+// And if in the process it got less than n, an error will be returned.
+func (b *readBuffer) ReadN(n int) ([]byte, error) {
+	remaining := b.last - b.cur
+	if remaining == 0 {
+		b.cur = reservedbuf
+	} else if n > remaining {
+		b.cur = reservedbuf - remaining               // cursor is now pointing at index on 'reserved section'
+		copy(b.buf[b.cur:], b.buf[b.last-remaining:]) // memmove remaining bytes to 'reserved section'.
+	}
+
+	if n > remaining { // fill buf
+		nr, err := io.ReadAtLeast(b.r, b.buf[reservedbuf:], n-remaining)
+		if err != nil {
+			return nil, err
+		}
+		b.last = reservedbuf + nr
+	}
+
+	buf := b.buf[b.cur : b.cur+n]
+	b.cur += n
+	return buf, nil
+}
+
+// Reset resets buf reader.
+func (b *readBuffer) Reset(rd io.Reader, size int) {
+	oldsize := cap(b.buf) - reservedbuf
+	if size != oldsize {
+		b.buf = make([]byte, reservedbuf+size)
+	}
+	b.buf = b.buf[:reservedbuf+size]
+
+	b.r = rd
+	b.cur = reservedbuf
+	b.last = reservedbuf
+}
+
+// Size return the len of resizeable section of buf.
+func (b *readBuffer) Size() int { return len(b.buf) - reservedbuf }

--- a/decoder/readbuffer_test.go
+++ b/decoder/readbuffer_test.go
@@ -1,0 +1,155 @@
+// Copyright 2024 The FIT SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package decoder
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewReadBuffer(t *testing.T) {
+	tt := []struct {
+		name   string
+		size   int
+		lenBuf int
+	}{
+		{name: "default", size: defaultReadBufferSize, lenBuf: reservedbuf + defaultReadBufferSize},
+		{name: "less than minReadBufferSize", size: 8, lenBuf: reservedbuf + minReadBufferSize},
+		{name: "8192", size: 8192, lenBuf: reservedbuf + 8192},
+		{name: "more than maxReadBufferSize", size: math.MaxInt, lenBuf: reservedbuf + maxReadBufferSize},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
+			b := newReadBuffer(nil, tc.size)
+			if b.cur != reservedbuf {
+				t.Fatalf("expected cur: %d, got: %d", reservedbuf, b.cur)
+			}
+			if b.last != reservedbuf {
+				t.Fatalf("expected last: %d, got: %d", reservedbuf, b.last)
+			}
+			if len(b.buf) != tc.lenBuf {
+				t.Fatalf("expected len(buf): %d, got: %d", tc.lenBuf, len(b.buf))
+			}
+		})
+	}
+}
+
+func TestReadBufferReadN(t *testing.T) {
+	tt := []struct {
+		name   string
+		r      io.Reader
+		cur    int
+		last   int
+		testFn func(buf *readBuffer) error
+	}{
+		{
+			name: "reader has exactly 4096 bytes",
+			r: func() io.Reader {
+				buf := make([]byte, 4096)
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					n = copy(b, buf[cur:])
+					cur += n
+					return
+				})
+			}(),
+			testFn: func(buf *readBuffer) error {
+				_, err := buf.ReadN(96)
+				if err != nil {
+					return err
+				}
+				_, err = buf.ReadN(4000)
+				if err != nil {
+					return err
+				}
+				_, err = buf.ReadN(1)
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			},
+		},
+		{
+			name: "reader has 14_096 bytes",
+			r: func() io.Reader {
+				buf := make([]byte, 14_096)
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					if cur == len(buf) {
+						return 0, io.EOF
+					}
+					n = copy(b, buf[cur:])
+					cur += n
+					return
+				})
+			}(),
+			testFn: func(buf *readBuffer) error {
+				_, err := buf.ReadN(96)
+				if err != nil {
+					return err
+				}
+				_, err = buf.ReadN(4000)
+				if err != nil {
+					return err
+				}
+				for i := 0; i < 10_000; i++ {
+					_, err = buf.ReadN(1)
+					if err != nil {
+						return fmt.Errorf("[%d]: %w", i, err)
+					}
+				}
+				_, err = buf.ReadN(1)
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			},
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
+			b := newReadBuffer(tc.r, 4096)
+			if err := tc.testFn(b); err != nil {
+				t.Fatalf("expected nil, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestReadBufferResetAndSize(t *testing.T) {
+	r := io.Reader(fnReaderOK)
+	b := newReadBuffer(nil, 4096)
+
+	b.Reset(r, 4096*2)
+	if b.Size() != 4096*2 {
+		t.Fatalf("expected: %d, got: %d", 4096*2, b.Size())
+	}
+	if diff := cmp.Diff(r, b.r, cmp.Transformer("r", func(r io.Reader) uintptr {
+		return reflect.ValueOf(r).Pointer()
+	})); diff != "" {
+		t.Fatal(diff)
+	}
+
+	// Revert back
+	b.Reset(nil, 4096)
+	if diff := cmp.Diff(nil, b.r, cmp.Transformer("r", func(r io.Reader) uintptr {
+		return reflect.ValueOf(r).Pointer()
+	})); diff != "" {
+		t.Fatal(diff)
+	}
+	if b.Size() != 4096 {
+		t.Fatalf("expected: %d, got: %d", 4096, b.Size())
+	}
+}


### PR DESCRIPTION
Benchmark:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/decoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
         │   old.txt    │              new.txt               │
         │    sec/op    │   sec/op     vs base               │
Decode-4   105.75m ± 1%   99.00m ± 3%  -6.39% (p=0.000 n=10)

         │   old.txt    │            new.txt             │
         │     B/op     │     B/op      vs base          │
Decode-4   73.49Mi ± 0%   73.49Mi ± 0%  ~ (p=0.050 n=10)

         │   old.txt   │             new.txt             │
         │  allocs/op  │  allocs/op   vs base            │
Decode-4   100.0k ± 0%   100.0k ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

close #179 