### PR TITLE
fix: gracefully handle poorly encoded FIT file to prevent panic.

### DIFF
--- a/decoder/raw.go
+++ b/decoder/raw.go
@@ -224,6 +224,8 @@ func (d *RawDecoder) Decode(r io.Reader, fn func(flag RawFlag, b []byte) error) 
 		}
 
 		seq++
+
+		d.reset() // reset for next FIT sequence.
 	}
 }
 


### PR DESCRIPTION
- Previously, panic will occur on `proto.Unmarshal` if field definition's size is zero and `field.Array` is false. When `field.Array` is true, `proto.Unmarshal` will return empty slice which is an undefined behavior. A checker to check the size before unmarshal is now implemented: if size is zero, the field/developerField will be skipped. New log message is added to print the warning (only if `logWriter` is not nil).
- Now log will only print if `logWriter` is not nil, previously it was printing to `io.Discard` which will do unnecessarily formatting that consume additional CPU time.
- Fix `RawDecoder` should reset local message definitions after a sequence is completed.
- Gracefully handle poorly encoded FIT file on `decodeDeveloperFields` too just like on `decodeFields`.
- Clean up code.