### PR TITLE
refactor!: change decoder's listener behavior

### DIFF
--- a/cmd/fitconv/main.go
+++ b/cmd/fitconv/main.go
@@ -157,6 +157,7 @@ func fitToCsv(path string, noExpandComponents bool, opts ...fitcsv.Option) error
 		decoder.WithMesgDefListener(conv),
 		decoder.WithMesgListener(conv),
 		decoder.WithBroadcastOnly(),
+		decoder.WithBroadcastMesgCopy(),
 	}
 	if noExpandComponents {
 		options = append(options, decoder.WithNoComponentExpansion())

--- a/decoder/listener.go
+++ b/decoder/listener.go
@@ -8,7 +8,10 @@ import "github.com/muktihari/fit/proto"
 
 // MesgListener is an interface for listening to message decoded events.
 type MesgListener interface {
-	// OnMesg receives message from Decoder.
+	// OnMesg receives message from Decoder. The lifecycle of the mesg object is only guaranteed before
+	// OnMesg returns. Any listener that wants to process the mesg concurrently should copy the mesg,
+	// otherwise, the value of the mesg might be changed by the time it is being processed. Except,
+	// the Decoder is directed to copy the mesg before passing the mesg to listener using Option.
 	OnMesg(mesg proto.Message)
 }
 

--- a/profile/filedef/activity_test.go
+++ b/profile/filedef/activity_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
+	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/filedef"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
@@ -63,6 +64,11 @@ func newActivityMessageForTest(now time.Time) []proto.Message {
 		),
 		factory.CreateMesgOnly(mesgnum.FieldDescription).WithFields(
 			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionDeveloperDataIndex).WithValue(uint8(0)),
+			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionFieldDefinitionNumber).WithValue(uint8(0)),
+			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionFieldName).WithValue([]string{"Heart Rate"}),
+			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionNativeMesgNum).WithValue(uint16(mesgnum.Record)),
+			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionNativeFieldNum).WithValue(uint8(fieldnum.RecordHeartRate)),
+			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionFitBaseTypeId).WithValue(uint8(basetype.Uint8)),
 		),
 		factory.CreateMesgOnly(mesgnum.DeviceInfo).WithFields(
 			factory.CreateField(mesgnum.DeviceInfo, fieldnum.DeviceInfoManufacturer).WithValue(uint16(typedef.ManufacturerGarmin)),

--- a/profile/filedef/monitoring_ab_test.go
+++ b/profile/filedef/monitoring_ab_test.go
@@ -59,7 +59,7 @@ func newMonitoringAMessageForTest(now time.Time) []proto.Message {
 }
 
 func newMonitoringBMessageForTest(now time.Time) []proto.Message {
-	mesgsB := slices.Clone(newMonitoringAMessageForTest(time.Now()))
+	mesgsB := slices.Clone(newMonitoringAMessageForTest(now))
 	ftype := mesgsB[0].FieldByNum(fieldnum.FileIdType)
 	ftype.Value = proto.Uint8(uint8(typedef.FileMonitoringB))
 	return mesgsB


### PR DESCRIPTION
Background: #182 

BREAKING CHANGES:
- By default, Decoder no longer copy the message before send it to listeners for efficiency, the lifecycle of the mesg is only guaranteed before `OnMesg` method returns so any listener that process the message concurrently should copy the mesg before return. For legacy behavior (<= v0.14.0), use `decoder.WithBroadcastMesgCopy()`

What's Changed:
- `filedef's Listener` now copy the mesg before processing it concurrently to accommodate the behavior change. It copies the mesg using pool of reusable messages to reduce alloc.

Benchmark:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/decoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                    │   old.txt    │               new.txt                │
                    │    sec/op    │    sec/op     vs base                │
DecodeWithFiledef-4   105.53m ± 5%   90.92m ± 10%  -13.85% (p=0.002 n=10)

                    │   old.txt    │               new.txt                │
                    │     B/op     │     B/op      vs base                │
DecodeWithFiledef-4   92.47Mi ± 0%   49.77Mi ± 0%  -46.17% (p=0.000 n=10)

                    │   old.txt   │               new.txt               │
                    │  allocs/op  │  allocs/op   vs base                │
DecodeWithFiledef-4   200.0k ± 0%   100.1k ± 0%  -49.95% (p=0.000 n=10)
```

close #182 