### PR TITLE
chore: fix internal cli: csvdiff, testgen

### DIFF
--- a/internal/cmd/csvdiff/main.go
+++ b/internal/cmd/csvdiff/main.go
@@ -79,10 +79,22 @@ func splitByField(s string) []string {
 	buf.WriteString(s)
 
 	reader := csv.NewReader(buf)
+	reader.FieldsPerRecord = -1
 	cols, _ := reader.Read()
 
-	ss := make([]string, 0, len(cols)/3)
-	for i := 0; i < len(cols); i += 3 {
+	if len(cols) < 2 {
+		return nil
+	}
+
+	ss := make([]string, 0, ((len(cols)-2)/3)+2)
+
+	strbuf.Reset()
+	strbuf.WriteString(cols[0]) // Data/Definition
+	strbuf.WriteByte(',')
+	strbuf.WriteString(cols[1]) // LocalNum
+	ss = append(ss, strbuf.String())
+
+	for i := 2; i < len(cols)-2; i += 3 {
 		strbuf.Reset()
 		strbuf.WriteString(cols[i])
 		strbuf.WriteByte(',')
@@ -90,7 +102,7 @@ func splitByField(s string) []string {
 		strbuf.WriteByte(',')
 		strbuf.WriteString(cols[i+2])
 		strbuf.WriteByte(',')
-		ss = append(ss, strbuf.String()) // no need to copy, strings is immutable.
+		ss = append(ss, strbuf.String())
 	}
 	return ss
 }

--- a/internal/cmd/testgen/big_activity.go
+++ b/internal/cmd/testgen/big_activity.go
@@ -20,9 +20,7 @@ import (
 	"github.com/muktihari/fit/proto"
 )
 
-const (
-	RecordSize = 200_000
-)
+const RecordSize = 100_000
 
 func createBigActivityFile(ctx context.Context) error {
 	f, err := os.OpenFile(filepath.Join(testdata, "big_activity.fit"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
@@ -31,7 +29,7 @@ func createBigActivityFile(ctx context.Context) error {
 	}
 	defer f.Close()
 
-	now := time.Now()
+	now := datetime.ToTime(uint32(1062766519))
 	fit := new(proto.FIT)
 	fit.Messages = make([]proto.Message, 0, RecordSize)
 	fit.Messages = append(fit.Messages,
@@ -75,7 +73,8 @@ func createBigActivityFile(ctx context.Context) error {
 		}),
 	)
 
-	for i := 0; i < RecordSize-len(fit.Messages); i++ {
+	n := RecordSize - len(fit.Messages)
+	for i := 0; i < n; i++ {
 		now = now.Add(time.Second) // only time is moving forward
 		fit.Messages = append(fit.Messages, factory.CreateMesg(mesgnum.Record).WithFieldValues(map[byte]any{
 			fieldnum.RecordTimestamp:    datetime.ToUint32(now),
@@ -94,7 +93,7 @@ func createBigActivityFile(ctx context.Context) error {
 	defer bw.Flush()
 
 	enc := encoder.New(bw)
-	if err := enc.EncodeWithContext(context.Background(), fit); err != nil {
+	if err := enc.EncodeWithContext(ctx, fit); err != nil {
 		return err
 	}
 

--- a/internal/cmd/testgen/main.go
+++ b/internal/cmd/testgen/main.go
@@ -20,20 +20,22 @@ import (
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"github.com/pkg/profile"
 )
 
 var (
 	_, filename, _, _ = runtime.Caller(0)
 	cd                = filepath.Dir(filename)
-	testdata          = filepath.Join(cd, "..", "..", "testdata")
+	testdata          = filepath.Join(cd, "..", "..", "..", "testdata")
 
 	flag int         = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
 	perm os.FileMode = 0o777
 )
 
 func main() {
-	defer profile.Start(profile.CPUProfile, profile.ProfilePath(".")).Stop()
+	// NOTE: Encoder will always use current profile.Version, if we re-run this program, new generated files
+	// 		 might have different FileHeader.ProfileVersion.
+
+	// defer profile.Start(profile.CPUProfile, profile.ProfilePath(".")).Stop()
 
 	ctx := context.Background()
 
@@ -59,18 +61,19 @@ func createValidFitOnlyContainFileId(ctx context.Context) error {
 
 	type Uint16 uint16
 
+	now := datetime.ToTime(uint32(1062766519))
 	fit := new(proto.FIT).WithMessages(
 		factory.CreateMesgOnly(typedef.MesgNumFileId).WithFields(
 			factory.CreateField(mesgnum.FileId, fieldnum.FileIdType).WithValue(typedef.FileActivity),
 			factory.CreateField(mesgnum.FileId, fieldnum.FileIdProductName).WithValue("something ss"),
 			factory.CreateField(mesgnum.FileId, fieldnum.FileIdManufacturer).WithValue(typedef.ManufacturerBryton),
-			factory.CreateField(mesgnum.FileId, fieldnum.FileIdTimeCreated).WithValue(datetime.ToUint32(time.Now())),
+			factory.CreateField(mesgnum.FileId, fieldnum.FileIdTimeCreated).WithValue(datetime.ToUint32(now)),
 		),
 		factory.CreateMesgOnly(typedef.MesgNumActivity).WithFields(
-			factory.CreateField(typedef.MesgNumActivity, fieldnum.ActivityTimestamp).WithValue(datetime.ToUint32(time.Now())),
+			factory.CreateField(typedef.MesgNumActivity, fieldnum.ActivityTimestamp).WithValue(datetime.ToUint32(now)),
 		),
 		factory.CreateMesg(typedef.MesgNumRecord).WithFieldValues(map[byte]any{
-			fieldnum.RecordTimestamp: datetime.ToUint32(time.Now()),
+			fieldnum.RecordTimestamp: datetime.ToUint32(now),
 			fieldnum.RecordHeartRate: uint8(112),
 			fieldnum.RecordCadence:   uint8(80),
 			// fieldnum.RecordAltitude:  float64(150), // input scaled value


### PR DESCRIPTION
No need to release, no functionality change, only update internal CLIs for debugging:
- csvdiff: fix `splitByField`'s bad loop on iterating splitted values
- testgen: fix `len(fit.Messages)` size mismatch, no need to regenerate test files, small diff only.
