### PR TITLE
cli: add fitdump for dumping bytes segments

### DIFF
--- a/cmd/fitdump/README.md
+++ b/cmd/fitdump/README.md
@@ -1,0 +1,21 @@
+# Fitdump
+
+Fitdump dumps the FIT file(s) into segmented bytes.
+
+```txt
+SEGMENT      |LOCAL NUM|  HEADER    BYTES
+file_header                         [14 32 133 82 230 44 4 0 46 70 73 84 12 58]
+message_definition  | 0|  01000000  [64 0 1 0 0 7 3 4 140 4 4 134 7 4 134 1 2 132 2 2 132 5 2 132 0 1 0]
+message_data        | 0|  00000000  [0 203 230 191 170 63 85 233 108 255 255 255 255 0 1 15 152 255 255 4]
+message_definition  | 1|  01000001  [65 0 1 0 49 5 2 20 7 0 2 132 1 1 2 3 1 0 4 1 0]
+message_data        | 1|  00000001  [1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 6 166 255 255 255]
+...
+```
+
+## Usage
+
+```sh
+go run main.go triathlon_summary_last.fit
+
+# dumped: "triathlon_summary_last.fit" -> "triathlon_summary_last.txt"
+```

--- a/cmd/fitdump/main.go
+++ b/cmd/fitdump/main.go
@@ -1,0 +1,79 @@
+// Copyright 2024 The FIT SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/muktihari/fit/decoder"
+	"github.com/muktihari/fit/proto"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "missing arguments\n")
+		os.Exit(2)
+	}
+	for i, arg := range os.Args[1:] {
+		if err := textdump(arg); err != nil {
+			fmt.Printf("could not dump args[%d] %q: %v\n", i, arg, err)
+		}
+	}
+}
+
+func textdump(path string) error {
+	ext := filepath.Ext(path)
+	if strings.ToLower(ext) != ".fit" {
+		return fmt.Errorf("expected ext: *.fit, got: %s", ext)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	base := filepath.Base(path)
+	dir := filepath.Dir(path)
+
+	name := base
+	if len(ext) < len(base) {
+		name = base[:len(base)-len(ext)]
+	}
+	name = name + ".txt"
+
+	resultPath := filepath.Join(dir, name)
+	out, err := os.OpenFile(resultPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	w := bufio.NewWriter(out)
+	defer w.Flush()
+
+	dec := decoder.NewRaw()
+
+	fmt.Fprintf(w, "%s %16s %7s %8s\n", "SEGMENT", "|LOCAL NUM|", "HEADER", "BYTES")
+	_, err = dec.Decode(bufio.NewReader(f), func(flag decoder.RawFlag, b []byte) error {
+		if flag == decoder.RawFlagMesgDef || flag == decoder.RawFlagMesgData {
+			fmt.Fprintf(w, "%-19s |%2d|  %08b  %v\n", flag, proto.LocalMesgNum(b[0]), b[0], b)
+		} else {
+			fmt.Fprintf(w, "%-19s %15s %v\n", flag, "", b)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("FIT dumped: %q -> %q\n", path, resultPath)
+
+	return nil
+}


### PR DESCRIPTION
The purpose is to represent bytes per segment for low-level debugging.