### PR TITLE
feat(mesgdef): add dynamic field accessor

### DIFF
--- a/internal/cmd/fitgen/profile/mesgdef/data.go
+++ b/internal/cmd/fitgen/profile/mesgdef/data.go
@@ -9,6 +9,7 @@ type Data struct {
 	Imports           []string
 	Name              string
 	Fields            []Field
+	DynamicFields     []DynamicField
 	MaxFieldNum       byte
 	MaxFieldExpandNum byte
 }
@@ -32,4 +33,26 @@ type Field struct {
 	Offset          float64
 	Array           bool
 	CanExpand       bool
+}
+
+type DynamicField struct {
+	Name        string
+	SwitchCases []SwitchCase
+	Default     ReturnValue
+}
+
+type SwitchCase struct {
+	Name       string
+	CondsValue []CondValue
+}
+
+type CondValue struct {
+	Conds       string
+	ReturnValue ReturnValue
+}
+
+type ReturnValue struct {
+	Name  string
+	Units string
+	Value string
 }

--- a/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
+++ b/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
@@ -114,6 +114,30 @@ func (m *{{ .Name }}) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+{{ range .DynamicFields -}}
+// Get{{ .Name }} returns Dynamic Field interpretation of {{ .Name }}. Otherwise, returns the original value of {{ .Name }}.
+// 
+{{ range .SwitchCases -}} 
+// Based on {{ .Name }}:
+	{{ range .CondsValue -}}
+//   - name: "{{ .ReturnValue.Name }}" {{- if .ReturnValue.Units -}}, units: "{{ .ReturnValue.Units }}" {{ end }}, value: {{ .ReturnValue.Value }}
+	{{ end -}}
+{{ end -}}
+// Otherwise:
+//   - name: "{{ .Default.Name }}" {{- if .Default.Units -}}, units: "{{ .Default.Units }}" {{ end }}, value: {{ .Default.Value }}
+func (m *{{ $.Name }}) Get{{ .Name }}() (name string, value any) {
+{{ range .SwitchCases -}}
+	switch {{ .Name -}} {
+	{{- range .CondsValue }}
+	case {{ .Conds }}:
+		return "{{ .ReturnValue.Name }}", {{ .ReturnValue.Value -}}
+	{{ end}}
+	}
+{{ end -}}
+	return "{{ .Default.Name }}", {{ .Default.Value }}
+}
+{{ end }}
+
 {{ range .Fields -}}
 {{ if eq .Type "time.Time" }}
 // {{ .Name }}Uint32 returns {{ .Name }} in uint32 (seconds since FIT's epoch) instead of time.Time.

--- a/profile/mesgdef/device_info_gen.go
+++ b/profile/mesgdef/device_info_gen.go
@@ -205,6 +205,48 @@ func (m *DeviceInfo) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetDeviceType returns Dynamic Field interpretation of DeviceType. Otherwise, returns the original value of DeviceType.
+//
+// Based on m.SourceType:
+//   - name: "ble_device_type", value: typedef.BleDeviceType(m.DeviceType)
+//   - name: "antplus_device_type", value: typedef.AntplusDeviceType(m.DeviceType)
+//   - name: "ant_device_type", value: uint8(m.DeviceType)
+//   - name: "local_device_type", value: typedef.LocalDeviceType(m.DeviceType)
+//
+// Otherwise:
+//   - name: "device_type", value: m.DeviceType
+func (m *DeviceInfo) GetDeviceType() (name string, value any) {
+	switch m.SourceType {
+	case typedef.SourceTypeBluetoothLowEnergy:
+		return "ble_device_type", typedef.BleDeviceType(m.DeviceType)
+	case typedef.SourceTypeAntplus:
+		return "antplus_device_type", typedef.AntplusDeviceType(m.DeviceType)
+	case typedef.SourceTypeAnt:
+		return "ant_device_type", uint8(m.DeviceType)
+	case typedef.SourceTypeLocal:
+		return "local_device_type", typedef.LocalDeviceType(m.DeviceType)
+	}
+	return "device_type", m.DeviceType
+}
+
+// GetProduct returns Dynamic Field interpretation of Product. Otherwise, returns the original value of Product.
+//
+// Based on m.Manufacturer:
+//   - name: "favero_product", value: typedef.FaveroProduct(m.Product)
+//   - name: "garmin_product", value: typedef.GarminProduct(m.Product)
+//
+// Otherwise:
+//   - name: "product", value: m.Product
+func (m *DeviceInfo) GetProduct() (name string, value any) {
+	switch m.Manufacturer {
+	case typedef.ManufacturerFaveroElectronics:
+		return "favero_product", typedef.FaveroProduct(m.Product)
+	case typedef.ManufacturerGarmin, typedef.ManufacturerDynastream, typedef.ManufacturerDynastreamOem, typedef.ManufacturerTacx:
+		return "garmin_product", typedef.GarminProduct(m.Product)
+	}
+	return "product", m.Product
+}
+
 // TimestampUint32 returns Timestamp in uint32 (seconds since FIT's epoch) instead of time.Time.
 func (m *DeviceInfo) TimestampUint32() uint32 { return datetime.ToUint32(m.Timestamp) }
 

--- a/profile/mesgdef/dive_settings_gen.go
+++ b/profile/mesgdef/dive_settings_gen.go
@@ -317,6 +317,24 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetHeartRateSource returns Dynamic Field interpretation of HeartRateSource. Otherwise, returns the original value of HeartRateSource.
+//
+// Based on m.HeartRateSourceType:
+//   - name: "heart_rate_antplus_device_type", value: typedef.AntplusDeviceType(m.HeartRateSource)
+//   - name: "heart_rate_local_device_type", value: typedef.LocalDeviceType(m.HeartRateSource)
+//
+// Otherwise:
+//   - name: "heart_rate_source", value: m.HeartRateSource
+func (m *DiveSettings) GetHeartRateSource() (name string, value any) {
+	switch m.HeartRateSourceType {
+	case typedef.SourceTypeAntplus:
+		return "heart_rate_antplus_device_type", typedef.AntplusDeviceType(m.HeartRateSource)
+	case typedef.SourceTypeLocal:
+		return "heart_rate_local_device_type", typedef.LocalDeviceType(m.HeartRateSource)
+	}
+	return "heart_rate_source", m.HeartRateSource
+}
+
 // TimestampUint32 returns Timestamp in uint32 (seconds since FIT's epoch) instead of time.Time.
 func (m *DiveSettings) TimestampUint32() uint32 { return datetime.ToUint32(m.Timestamp) }
 

--- a/profile/mesgdef/event_gen.go
+++ b/profile/mesgdef/event_gen.go
@@ -224,6 +224,102 @@ func (m *Event) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetData returns Dynamic Field interpretation of Data. Otherwise, returns the original value of Data.
+//
+// Based on m.Event:
+//   - name: "timer_trigger", value: typedef.TimerTrigger(m.Data)
+//   - name: "distance_duration_alert", units: "m" , value: (float64(m.Data) * 100) - 0
+//   - name: "rider_position", value: typedef.RiderPositionType(m.Data)
+//   - name: "battery_level", units: "V" , value: (float64(m.Data) * 1000) - 0
+//   - name: "time_duration_alert", units: "s" , value: (float64(m.Data) * 1000) - 0
+//   - name: "gear_change_data", value: uint32(m.Data)
+//   - name: "auto_activity_detect_duration", units: "min" , value: uint16(m.Data)
+//   - name: "virtual_partner_speed", units: "m/s" , value: (float64(m.Data) * 1000) - 0
+//   - name: "hr_low_alert", units: "bpm" , value: uint8(m.Data)
+//   - name: "power_low_alert", units: "watts" , value: uint16(m.Data)
+//   - name: "dive_alert", value: typedef.DiveAlert(m.Data)
+//   - name: "radar_threat_alert", value: uint32(m.Data)
+//   - name: "course_point_index", value: typedef.MessageIndex(m.Data)
+//   - name: "hr_high_alert", units: "bpm" , value: uint8(m.Data)
+//   - name: "speed_high_alert", units: "m/s" , value: (float64(m.Data) * 1000) - 0
+//   - name: "speed_low_alert", units: "m/s" , value: (float64(m.Data) * 1000) - 0
+//   - name: "cad_high_alert", units: "rpm" , value: uint16(m.Data)
+//   - name: "cad_low_alert", units: "rpm" , value: uint16(m.Data)
+//   - name: "power_high_alert", units: "watts" , value: uint16(m.Data)
+//   - name: "calorie_duration_alert", units: "calories" , value: uint32(m.Data)
+//   - name: "fitness_equipment_state", value: typedef.FitnessEquipmentState(m.Data)
+//   - name: "sport_point", value: uint32(m.Data)
+//   - name: "comm_timeout", value: typedef.CommTimeoutType(m.Data)
+//
+// Otherwise:
+//   - name: "data", value: m.Data
+func (m *Event) GetData() (name string, value any) {
+	switch m.Event {
+	case typedef.EventTimer:
+		return "timer_trigger", typedef.TimerTrigger(m.Data)
+	case typedef.EventDistanceDurationAlert:
+		return "distance_duration_alert", (float64(m.Data) * 100) - 0
+	case typedef.EventRiderPositionChange:
+		return "rider_position", typedef.RiderPositionType(m.Data)
+	case typedef.EventBattery:
+		return "battery_level", (float64(m.Data) * 1000) - 0
+	case typedef.EventTimeDurationAlert:
+		return "time_duration_alert", (float64(m.Data) * 1000) - 0
+	case typedef.EventFrontGearChange, typedef.EventRearGearChange:
+		return "gear_change_data", uint32(m.Data)
+	case typedef.EventAutoActivityDetect:
+		return "auto_activity_detect_duration", uint16(m.Data)
+	case typedef.EventVirtualPartnerPace:
+		return "virtual_partner_speed", (float64(m.Data) * 1000) - 0
+	case typedef.EventHrLowAlert:
+		return "hr_low_alert", uint8(m.Data)
+	case typedef.EventPowerLowAlert:
+		return "power_low_alert", uint16(m.Data)
+	case typedef.EventDiveAlert:
+		return "dive_alert", typedef.DiveAlert(m.Data)
+	case typedef.EventRadarThreatAlert:
+		return "radar_threat_alert", uint32(m.Data)
+	case typedef.EventCoursePoint:
+		return "course_point_index", typedef.MessageIndex(m.Data)
+	case typedef.EventHrHighAlert:
+		return "hr_high_alert", uint8(m.Data)
+	case typedef.EventSpeedHighAlert:
+		return "speed_high_alert", (float64(m.Data) * 1000) - 0
+	case typedef.EventSpeedLowAlert:
+		return "speed_low_alert", (float64(m.Data) * 1000) - 0
+	case typedef.EventCadHighAlert:
+		return "cad_high_alert", uint16(m.Data)
+	case typedef.EventCadLowAlert:
+		return "cad_low_alert", uint16(m.Data)
+	case typedef.EventPowerHighAlert:
+		return "power_high_alert", uint16(m.Data)
+	case typedef.EventCalorieDurationAlert:
+		return "calorie_duration_alert", uint32(m.Data)
+	case typedef.EventFitnessEquipment:
+		return "fitness_equipment_state", typedef.FitnessEquipmentState(m.Data)
+	case typedef.EventSportPoint:
+		return "sport_point", uint32(m.Data)
+	case typedef.EventCommTimeout:
+		return "comm_timeout", typedef.CommTimeoutType(m.Data)
+	}
+	return "data", m.Data
+}
+
+// GetStartTimestamp returns Dynamic Field interpretation of StartTimestamp. Otherwise, returns the original value of StartTimestamp.
+//
+// Based on m.Event:
+//   - name: "auto_activity_detect_start_timestamp", units: "s" , value: time.Time(m.StartTimestamp)
+//
+// Otherwise:
+//   - name: "start_timestamp", units: "s" , value: m.StartTimestamp
+func (m *Event) GetStartTimestamp() (name string, value any) {
+	switch m.Event {
+	case typedef.EventAutoActivityDetect:
+		return "auto_activity_detect_start_timestamp", time.Time(m.StartTimestamp)
+	}
+	return "start_timestamp", m.StartTimestamp
+}
+
 // TimestampUint32 returns Timestamp in uint32 (seconds since FIT's epoch) instead of time.Time.
 func (m *Event) TimestampUint32() uint32 { return datetime.ToUint32(m.Timestamp) }
 

--- a/profile/mesgdef/file_id_gen.go
+++ b/profile/mesgdef/file_id_gen.go
@@ -109,6 +109,24 @@ func (m *FileId) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetProduct returns Dynamic Field interpretation of Product. Otherwise, returns the original value of Product.
+//
+// Based on m.Manufacturer:
+//   - name: "favero_product", value: typedef.FaveroProduct(m.Product)
+//   - name: "garmin_product", value: typedef.GarminProduct(m.Product)
+//
+// Otherwise:
+//   - name: "product", value: m.Product
+func (m *FileId) GetProduct() (name string, value any) {
+	switch m.Manufacturer {
+	case typedef.ManufacturerFaveroElectronics:
+		return "favero_product", typedef.FaveroProduct(m.Product)
+	case typedef.ManufacturerGarmin, typedef.ManufacturerDynastream, typedef.ManufacturerDynastreamOem, typedef.ManufacturerTacx:
+		return "garmin_product", typedef.GarminProduct(m.Product)
+	}
+	return "product", m.Product
+}
+
 // TimeCreatedUint32 returns TimeCreated in uint32 (seconds since FIT's epoch) instead of time.Time.
 func (m *FileId) TimeCreatedUint32() uint32 { return datetime.ToUint32(m.TimeCreated) }
 

--- a/profile/mesgdef/lap_gen.go
+++ b/profile/mesgdef/lap_gen.go
@@ -949,6 +949,54 @@ func (m *Lap) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetTotalCycles returns Dynamic Field interpretation of TotalCycles. Otherwise, returns the original value of TotalCycles.
+//
+// Based on m.Sport:
+//   - name: "total_strides", units: "strides" , value: uint32(m.TotalCycles)
+//   - name: "total_strokes", units: "strokes" , value: uint32(m.TotalCycles)
+//
+// Otherwise:
+//   - name: "total_cycles", units: "cycles" , value: m.TotalCycles
+func (m *Lap) GetTotalCycles() (name string, value any) {
+	switch m.Sport {
+	case typedef.SportRunning, typedef.SportWalking:
+		return "total_strides", uint32(m.TotalCycles)
+	case typedef.SportCycling, typedef.SportSwimming, typedef.SportRowing, typedef.SportStandUpPaddleboarding:
+		return "total_strokes", uint32(m.TotalCycles)
+	}
+	return "total_cycles", m.TotalCycles
+}
+
+// GetAvgCadence returns Dynamic Field interpretation of AvgCadence. Otherwise, returns the original value of AvgCadence.
+//
+// Based on m.Sport:
+//   - name: "avg_running_cadence", units: "strides/min" , value: uint8(m.AvgCadence)
+//
+// Otherwise:
+//   - name: "avg_cadence", units: "rpm" , value: m.AvgCadence
+func (m *Lap) GetAvgCadence() (name string, value any) {
+	switch m.Sport {
+	case typedef.SportRunning:
+		return "avg_running_cadence", uint8(m.AvgCadence)
+	}
+	return "avg_cadence", m.AvgCadence
+}
+
+// GetMaxCadence returns Dynamic Field interpretation of MaxCadence. Otherwise, returns the original value of MaxCadence.
+//
+// Based on m.Sport:
+//   - name: "max_running_cadence", units: "strides/min" , value: uint8(m.MaxCadence)
+//
+// Otherwise:
+//   - name: "max_cadence", units: "rpm" , value: m.MaxCadence
+func (m *Lap) GetMaxCadence() (name string, value any) {
+	switch m.Sport {
+	case typedef.SportRunning:
+		return "max_running_cadence", uint8(m.MaxCadence)
+	}
+	return "max_cadence", m.MaxCadence
+}
+
 // TimestampUint32 returns Timestamp in uint32 (seconds since FIT's epoch) instead of time.Time.
 func (m *Lap) TimestampUint32() uint32 { return datetime.ToUint32(m.Timestamp) }
 

--- a/profile/mesgdef/mesg_capabilities_gen.go
+++ b/profile/mesgdef/mesg_capabilities_gen.go
@@ -103,6 +103,27 @@ func (m *MesgCapabilities) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetCount returns Dynamic Field interpretation of Count. Otherwise, returns the original value of Count.
+//
+// Based on m.CountType:
+//   - name: "num_per_file", value: uint16(m.Count)
+//   - name: "max_per_file", value: uint16(m.Count)
+//   - name: "max_per_file_type", value: uint16(m.Count)
+//
+// Otherwise:
+//   - name: "count", value: m.Count
+func (m *MesgCapabilities) GetCount() (name string, value any) {
+	switch m.CountType {
+	case typedef.MesgCountNumPerFile:
+		return "num_per_file", uint16(m.Count)
+	case typedef.MesgCountMaxPerFile:
+		return "max_per_file", uint16(m.Count)
+	case typedef.MesgCountMaxPerFileType:
+		return "max_per_file_type", uint16(m.Count)
+	}
+	return "count", m.Count
+}
+
 // SetMessageIndex sets MesgCapabilities value.
 func (m *MesgCapabilities) SetMessageIndex(v typedef.MessageIndex) *MesgCapabilities {
 	m.MessageIndex = v

--- a/profile/mesgdef/monitoring_gen.go
+++ b/profile/mesgdef/monitoring_gen.go
@@ -285,6 +285,24 @@ func (m *Monitoring) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetCycles returns Dynamic Field interpretation of Cycles. Otherwise, returns the original value of Cycles.
+//
+// Based on m.ActivityType:
+//   - name: "strokes", units: "strokes" , value: (float64(m.Cycles) * 2) - 0
+//   - name: "steps", units: "steps" , value: uint32(m.Cycles)
+//
+// Otherwise:
+//   - name: "cycles", units: "cycles" , value: m.Cycles
+func (m *Monitoring) GetCycles() (name string, value any) {
+	switch m.ActivityType {
+	case typedef.ActivityTypeCycling, typedef.ActivityTypeSwimming:
+		return "strokes", (float64(m.Cycles) * 2) - 0
+	case typedef.ActivityTypeWalking, typedef.ActivityTypeRunning:
+		return "steps", uint32(m.Cycles)
+	}
+	return "cycles", m.Cycles
+}
+
 // TimestampUint32 returns Timestamp in uint32 (seconds since FIT's epoch) instead of time.Time.
 func (m *Monitoring) TimestampUint32() uint32 { return datetime.ToUint32(m.Timestamp) }
 

--- a/profile/mesgdef/one_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/one_d_sensor_calibration_gen.go
@@ -112,6 +112,21 @@ func (m *OneDSensorCalibration) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetCalibrationFactor returns Dynamic Field interpretation of CalibrationFactor. Otherwise, returns the original value of CalibrationFactor.
+//
+// Based on m.SensorType:
+//   - name: "baro_cal_factor", units: "Pa" , value: uint32(m.CalibrationFactor)
+//
+// Otherwise:
+//   - name: "calibration_factor", value: m.CalibrationFactor
+func (m *OneDSensorCalibration) GetCalibrationFactor() (name string, value any) {
+	switch m.SensorType {
+	case typedef.SensorTypeBarometer:
+		return "baro_cal_factor", uint32(m.CalibrationFactor)
+	}
+	return "calibration_factor", m.CalibrationFactor
+}
+
 // TimestampUint32 returns Timestamp in uint32 (seconds since FIT's epoch) instead of time.Time.
 func (m *OneDSensorCalibration) TimestampUint32() uint32 { return datetime.ToUint32(m.Timestamp) }
 

--- a/profile/mesgdef/schedule_gen.go
+++ b/profile/mesgdef/schedule_gen.go
@@ -119,6 +119,24 @@ func (m *Schedule) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetProduct returns Dynamic Field interpretation of Product. Otherwise, returns the original value of Product.
+//
+// Based on m.Manufacturer:
+//   - name: "favero_product", value: typedef.FaveroProduct(m.Product)
+//   - name: "garmin_product", value: typedef.GarminProduct(m.Product)
+//
+// Otherwise:
+//   - name: "product", value: m.Product
+func (m *Schedule) GetProduct() (name string, value any) {
+	switch m.Manufacturer {
+	case typedef.ManufacturerFaveroElectronics:
+		return "favero_product", typedef.FaveroProduct(m.Product)
+	case typedef.ManufacturerGarmin, typedef.ManufacturerDynastream, typedef.ManufacturerDynastreamOem, typedef.ManufacturerTacx:
+		return "garmin_product", typedef.GarminProduct(m.Product)
+	}
+	return "product", m.Product
+}
+
 // TimeCreatedUint32 returns TimeCreated in uint32 (seconds since FIT's epoch) instead of time.Time.
 func (m *Schedule) TimeCreatedUint32() uint32 { return datetime.ToUint32(m.TimeCreated) }
 

--- a/profile/mesgdef/segment_lap_gen.go
+++ b/profile/mesgdef/segment_lap_gen.go
@@ -749,6 +749,21 @@ func (m *SegmentLap) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetTotalCycles returns Dynamic Field interpretation of TotalCycles. Otherwise, returns the original value of TotalCycles.
+//
+// Based on m.Sport:
+//   - name: "total_strokes", units: "strokes" , value: uint32(m.TotalCycles)
+//
+// Otherwise:
+//   - name: "total_cycles", units: "cycles" , value: m.TotalCycles
+func (m *SegmentLap) GetTotalCycles() (name string, value any) {
+	switch m.Sport {
+	case typedef.SportCycling:
+		return "total_strokes", uint32(m.TotalCycles)
+	}
+	return "total_cycles", m.TotalCycles
+}
+
 // TimestampUint32 returns Timestamp in uint32 (seconds since FIT's epoch) instead of time.Time.
 func (m *SegmentLap) TimestampUint32() uint32 { return datetime.ToUint32(m.Timestamp) }
 

--- a/profile/mesgdef/session_gen.go
+++ b/profile/mesgdef/session_gen.go
@@ -1167,6 +1167,54 @@ func (m *Session) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetTotalCycles returns Dynamic Field interpretation of TotalCycles. Otherwise, returns the original value of TotalCycles.
+//
+// Based on m.Sport:
+//   - name: "total_strides", units: "strides" , value: uint32(m.TotalCycles)
+//   - name: "total_strokes", units: "strokes" , value: uint32(m.TotalCycles)
+//
+// Otherwise:
+//   - name: "total_cycles", units: "cycles" , value: m.TotalCycles
+func (m *Session) GetTotalCycles() (name string, value any) {
+	switch m.Sport {
+	case typedef.SportRunning, typedef.SportWalking:
+		return "total_strides", uint32(m.TotalCycles)
+	case typedef.SportCycling, typedef.SportSwimming, typedef.SportRowing, typedef.SportStandUpPaddleboarding:
+		return "total_strokes", uint32(m.TotalCycles)
+	}
+	return "total_cycles", m.TotalCycles
+}
+
+// GetAvgCadence returns Dynamic Field interpretation of AvgCadence. Otherwise, returns the original value of AvgCadence.
+//
+// Based on m.Sport:
+//   - name: "avg_running_cadence", units: "strides/min" , value: uint8(m.AvgCadence)
+//
+// Otherwise:
+//   - name: "avg_cadence", units: "rpm" , value: m.AvgCadence
+func (m *Session) GetAvgCadence() (name string, value any) {
+	switch m.Sport {
+	case typedef.SportRunning:
+		return "avg_running_cadence", uint8(m.AvgCadence)
+	}
+	return "avg_cadence", m.AvgCadence
+}
+
+// GetMaxCadence returns Dynamic Field interpretation of MaxCadence. Otherwise, returns the original value of MaxCadence.
+//
+// Based on m.Sport:
+//   - name: "max_running_cadence", units: "strides/min" , value: uint8(m.MaxCadence)
+//
+// Otherwise:
+//   - name: "max_cadence", units: "rpm" , value: m.MaxCadence
+func (m *Session) GetMaxCadence() (name string, value any) {
+	switch m.Sport {
+	case typedef.SportRunning:
+		return "max_running_cadence", uint8(m.MaxCadence)
+	}
+	return "max_cadence", m.MaxCadence
+}
+
 // TimestampUint32 returns Timestamp in uint32 (seconds since FIT's epoch) instead of time.Time.
 func (m *Session) TimestampUint32() uint32 { return datetime.ToUint32(m.Timestamp) }
 

--- a/profile/mesgdef/slave_device_gen.go
+++ b/profile/mesgdef/slave_device_gen.go
@@ -82,6 +82,24 @@ func (m *SlaveDevice) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetProduct returns Dynamic Field interpretation of Product. Otherwise, returns the original value of Product.
+//
+// Based on m.Manufacturer:
+//   - name: "favero_product", value: typedef.FaveroProduct(m.Product)
+//   - name: "garmin_product", value: typedef.GarminProduct(m.Product)
+//
+// Otherwise:
+//   - name: "product", value: m.Product
+func (m *SlaveDevice) GetProduct() (name string, value any) {
+	switch m.Manufacturer {
+	case typedef.ManufacturerFaveroElectronics:
+		return "favero_product", typedef.FaveroProduct(m.Product)
+	case typedef.ManufacturerGarmin, typedef.ManufacturerDynastream, typedef.ManufacturerDynastreamOem, typedef.ManufacturerTacx:
+		return "garmin_product", typedef.GarminProduct(m.Product)
+	}
+	return "product", m.Product
+}
+
 // SetManufacturer sets SlaveDevice value.
 func (m *SlaveDevice) SetManufacturer(v typedef.Manufacturer) *SlaveDevice {
 	m.Manufacturer = v

--- a/profile/mesgdef/three_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/three_d_sensor_calibration_gen.go
@@ -120,6 +120,24 @@ func (m *ThreeDSensorCalibration) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetCalibrationFactor returns Dynamic Field interpretation of CalibrationFactor. Otherwise, returns the original value of CalibrationFactor.
+//
+// Based on m.SensorType:
+//   - name: "accel_cal_factor", units: "g" , value: uint32(m.CalibrationFactor)
+//   - name: "gyro_cal_factor", units: "deg/s" , value: uint32(m.CalibrationFactor)
+//
+// Otherwise:
+//   - name: "calibration_factor", value: m.CalibrationFactor
+func (m *ThreeDSensorCalibration) GetCalibrationFactor() (name string, value any) {
+	switch m.SensorType {
+	case typedef.SensorTypeAccelerometer:
+		return "accel_cal_factor", uint32(m.CalibrationFactor)
+	case typedef.SensorTypeGyroscope:
+		return "gyro_cal_factor", uint32(m.CalibrationFactor)
+	}
+	return "calibration_factor", m.CalibrationFactor
+}
+
 // TimestampUint32 returns Timestamp in uint32 (seconds since FIT's epoch) instead of time.Time.
 func (m *ThreeDSensorCalibration) TimestampUint32() uint32 { return datetime.ToUint32(m.Timestamp) }
 

--- a/profile/mesgdef/training_file_gen.go
+++ b/profile/mesgdef/training_file_gen.go
@@ -112,6 +112,24 @@ func (m *TrainingFile) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetProduct returns Dynamic Field interpretation of Product. Otherwise, returns the original value of Product.
+//
+// Based on m.Manufacturer:
+//   - name: "favero_product", value: typedef.FaveroProduct(m.Product)
+//   - name: "garmin_product", value: typedef.GarminProduct(m.Product)
+//
+// Otherwise:
+//   - name: "product", value: m.Product
+func (m *TrainingFile) GetProduct() (name string, value any) {
+	switch m.Manufacturer {
+	case typedef.ManufacturerFaveroElectronics:
+		return "favero_product", typedef.FaveroProduct(m.Product)
+	case typedef.ManufacturerGarmin, typedef.ManufacturerDynastream, typedef.ManufacturerDynastreamOem, typedef.ManufacturerTacx:
+		return "garmin_product", typedef.GarminProduct(m.Product)
+	}
+	return "product", m.Product
+}
+
 // TimestampUint32 returns Timestamp in uint32 (seconds since FIT's epoch) instead of time.Time.
 func (m *TrainingFile) TimestampUint32() uint32 { return datetime.ToUint32(m.Timestamp) }
 

--- a/profile/mesgdef/watchface_settings_gen.go
+++ b/profile/mesgdef/watchface_settings_gen.go
@@ -89,6 +89,24 @@ func (m *WatchfaceSettings) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetLayout returns Dynamic Field interpretation of Layout. Otherwise, returns the original value of Layout.
+//
+// Based on m.Mode:
+//   - name: "digital_layout", value: typedef.DigitalWatchfaceLayout(m.Layout)
+//   - name: "analog_layout", value: typedef.AnalogWatchfaceLayout(m.Layout)
+//
+// Otherwise:
+//   - name: "layout", value: m.Layout
+func (m *WatchfaceSettings) GetLayout() (name string, value any) {
+	switch m.Mode {
+	case typedef.WatchfaceModeDigital:
+		return "digital_layout", typedef.DigitalWatchfaceLayout(m.Layout)
+	case typedef.WatchfaceModeAnalog:
+		return "analog_layout", typedef.AnalogWatchfaceLayout(m.Layout)
+	}
+	return "layout", m.Layout
+}
+
 // SetMessageIndex sets WatchfaceSettings value.
 func (m *WatchfaceSettings) SetMessageIndex(v typedef.MessageIndex) *WatchfaceSettings {
 	m.MessageIndex = v

--- a/profile/mesgdef/workout_step_gen.go
+++ b/profile/mesgdef/workout_step_gen.go
@@ -203,6 +203,211 @@ func (m *WorkoutStep) ToMesg(options *Options) proto.Message {
 	return mesg
 }
 
+// GetDurationValue returns Dynamic Field interpretation of DurationValue. Otherwise, returns the original value of DurationValue.
+//
+// Based on m.DurationType:
+//   - name: "duration_reps", value: uint32(m.DurationValue)
+//   - name: "duration_time", units: "s" , value: (float64(m.DurationValue) * 1000) - 0
+//   - name: "duration_distance", units: "m" , value: (float64(m.DurationValue) * 100) - 0
+//   - name: "duration_hr", units: "% or bpm" , value: typedef.WorkoutHr(m.DurationValue)
+//   - name: "duration_calories", units: "calories" , value: uint32(m.DurationValue)
+//   - name: "duration_step", value: uint32(m.DurationValue)
+//   - name: "duration_power", units: "% or watts" , value: typedef.WorkoutPower(m.DurationValue)
+//
+// Otherwise:
+//   - name: "duration_value", value: m.DurationValue
+func (m *WorkoutStep) GetDurationValue() (name string, value any) {
+	switch m.DurationType {
+	case typedef.WktStepDurationReps:
+		return "duration_reps", uint32(m.DurationValue)
+	case typedef.WktStepDurationTime, typedef.WktStepDurationRepetitionTime:
+		return "duration_time", (float64(m.DurationValue) * 1000) - 0
+	case typedef.WktStepDurationDistance:
+		return "duration_distance", (float64(m.DurationValue) * 100) - 0
+	case typedef.WktStepDurationHrLessThan, typedef.WktStepDurationHrGreaterThan:
+		return "duration_hr", typedef.WorkoutHr(m.DurationValue)
+	case typedef.WktStepDurationCalories:
+		return "duration_calories", uint32(m.DurationValue)
+	case typedef.WktStepDurationRepeatUntilStepsCmplt, typedef.WktStepDurationRepeatUntilTime, typedef.WktStepDurationRepeatUntilDistance, typedef.WktStepDurationRepeatUntilCalories, typedef.WktStepDurationRepeatUntilHrLessThan, typedef.WktStepDurationRepeatUntilHrGreaterThan, typedef.WktStepDurationRepeatUntilPowerLessThan, typedef.WktStepDurationRepeatUntilPowerGreaterThan:
+		return "duration_step", uint32(m.DurationValue)
+	case typedef.WktStepDurationPowerLessThan, typedef.WktStepDurationPowerGreaterThan:
+		return "duration_power", typedef.WorkoutPower(m.DurationValue)
+	}
+	return "duration_value", m.DurationValue
+}
+
+// GetTargetValue returns Dynamic Field interpretation of TargetValue. Otherwise, returns the original value of TargetValue.
+//
+// Based on m.DurationType:
+//   - name: "repeat_hr", units: "% or bpm" , value: typedef.WorkoutHr(m.TargetValue)
+//   - name: "repeat_power", units: "% or watts" , value: typedef.WorkoutPower(m.TargetValue)
+//   - name: "repeat_steps", value: uint32(m.TargetValue)
+//   - name: "repeat_time", units: "s" , value: (float64(m.TargetValue) * 1000) - 0
+//   - name: "repeat_distance", units: "m" , value: (float64(m.TargetValue) * 100) - 0
+//   - name: "repeat_calories", units: "calories" , value: uint32(m.TargetValue)
+//
+// Based on m.TargetType:
+//   - name: "target_cadence_zone", value: uint32(m.TargetValue)
+//   - name: "target_power_zone", value: uint32(m.TargetValue)
+//   - name: "target_stroke_type", value: typedef.SwimStroke(m.TargetValue)
+//   - name: "target_speed_zone", value: uint32(m.TargetValue)
+//   - name: "target_hr_zone", value: uint32(m.TargetValue)
+//
+// Otherwise:
+//   - name: "target_value", value: m.TargetValue
+func (m *WorkoutStep) GetTargetValue() (name string, value any) {
+	switch m.DurationType {
+	case typedef.WktStepDurationRepeatUntilHrLessThan, typedef.WktStepDurationRepeatUntilHrGreaterThan:
+		return "repeat_hr", typedef.WorkoutHr(m.TargetValue)
+	case typedef.WktStepDurationRepeatUntilPowerLessThan, typedef.WktStepDurationRepeatUntilPowerGreaterThan:
+		return "repeat_power", typedef.WorkoutPower(m.TargetValue)
+	case typedef.WktStepDurationRepeatUntilStepsCmplt:
+		return "repeat_steps", uint32(m.TargetValue)
+	case typedef.WktStepDurationRepeatUntilTime:
+		return "repeat_time", (float64(m.TargetValue) * 1000) - 0
+	case typedef.WktStepDurationRepeatUntilDistance:
+		return "repeat_distance", (float64(m.TargetValue) * 100) - 0
+	case typedef.WktStepDurationRepeatUntilCalories:
+		return "repeat_calories", uint32(m.TargetValue)
+	}
+	switch m.TargetType {
+	case typedef.WktStepTargetCadence:
+		return "target_cadence_zone", uint32(m.TargetValue)
+	case typedef.WktStepTargetPower:
+		return "target_power_zone", uint32(m.TargetValue)
+	case typedef.WktStepTargetSwimStroke:
+		return "target_stroke_type", typedef.SwimStroke(m.TargetValue)
+	case typedef.WktStepTargetSpeed:
+		return "target_speed_zone", uint32(m.TargetValue)
+	case typedef.WktStepTargetHeartRate:
+		return "target_hr_zone", uint32(m.TargetValue)
+	}
+	return "target_value", m.TargetValue
+}
+
+// GetCustomTargetValueLow returns Dynamic Field interpretation of CustomTargetValueLow. Otherwise, returns the original value of CustomTargetValueLow.
+//
+// Based on m.TargetType:
+//   - name: "custom_target_speed_low", units: "m/s" , value: (float64(m.CustomTargetValueLow) * 1000) - 0
+//   - name: "custom_target_heart_rate_low", units: "% or bpm" , value: typedef.WorkoutHr(m.CustomTargetValueLow)
+//   - name: "custom_target_cadence_low", units: "rpm" , value: uint32(m.CustomTargetValueLow)
+//   - name: "custom_target_power_low", units: "% or watts" , value: typedef.WorkoutPower(m.CustomTargetValueLow)
+//
+// Otherwise:
+//   - name: "custom_target_value_low", value: m.CustomTargetValueLow
+func (m *WorkoutStep) GetCustomTargetValueLow() (name string, value any) {
+	switch m.TargetType {
+	case typedef.WktStepTargetSpeed:
+		return "custom_target_speed_low", (float64(m.CustomTargetValueLow) * 1000) - 0
+	case typedef.WktStepTargetHeartRate:
+		return "custom_target_heart_rate_low", typedef.WorkoutHr(m.CustomTargetValueLow)
+	case typedef.WktStepTargetCadence:
+		return "custom_target_cadence_low", uint32(m.CustomTargetValueLow)
+	case typedef.WktStepTargetPower:
+		return "custom_target_power_low", typedef.WorkoutPower(m.CustomTargetValueLow)
+	}
+	return "custom_target_value_low", m.CustomTargetValueLow
+}
+
+// GetCustomTargetValueHigh returns Dynamic Field interpretation of CustomTargetValueHigh. Otherwise, returns the original value of CustomTargetValueHigh.
+//
+// Based on m.TargetType:
+//   - name: "custom_target_speed_high", units: "m/s" , value: (float64(m.CustomTargetValueHigh) * 1000) - 0
+//   - name: "custom_target_heart_rate_high", units: "% or bpm" , value: typedef.WorkoutHr(m.CustomTargetValueHigh)
+//   - name: "custom_target_cadence_high", units: "rpm" , value: uint32(m.CustomTargetValueHigh)
+//   - name: "custom_target_power_high", units: "% or watts" , value: typedef.WorkoutPower(m.CustomTargetValueHigh)
+//
+// Otherwise:
+//   - name: "custom_target_value_high", value: m.CustomTargetValueHigh
+func (m *WorkoutStep) GetCustomTargetValueHigh() (name string, value any) {
+	switch m.TargetType {
+	case typedef.WktStepTargetSpeed:
+		return "custom_target_speed_high", (float64(m.CustomTargetValueHigh) * 1000) - 0
+	case typedef.WktStepTargetHeartRate:
+		return "custom_target_heart_rate_high", typedef.WorkoutHr(m.CustomTargetValueHigh)
+	case typedef.WktStepTargetCadence:
+		return "custom_target_cadence_high", uint32(m.CustomTargetValueHigh)
+	case typedef.WktStepTargetPower:
+		return "custom_target_power_high", typedef.WorkoutPower(m.CustomTargetValueHigh)
+	}
+	return "custom_target_value_high", m.CustomTargetValueHigh
+}
+
+// GetSecondaryTargetValue returns Dynamic Field interpretation of SecondaryTargetValue. Otherwise, returns the original value of SecondaryTargetValue.
+//
+// Based on m.SecondaryTargetType:
+//   - name: "secondary_target_speed_zone", value: uint32(m.SecondaryTargetValue)
+//   - name: "secondary_target_hr_zone", value: uint32(m.SecondaryTargetValue)
+//   - name: "secondary_target_cadence_zone", value: uint32(m.SecondaryTargetValue)
+//   - name: "secondary_target_power_zone", value: uint32(m.SecondaryTargetValue)
+//   - name: "secondary_target_stroke_type", value: typedef.SwimStroke(m.SecondaryTargetValue)
+//
+// Otherwise:
+//   - name: "secondary_target_value", value: m.SecondaryTargetValue
+func (m *WorkoutStep) GetSecondaryTargetValue() (name string, value any) {
+	switch m.SecondaryTargetType {
+	case typedef.WktStepTargetSpeed:
+		return "secondary_target_speed_zone", uint32(m.SecondaryTargetValue)
+	case typedef.WktStepTargetHeartRate:
+		return "secondary_target_hr_zone", uint32(m.SecondaryTargetValue)
+	case typedef.WktStepTargetCadence:
+		return "secondary_target_cadence_zone", uint32(m.SecondaryTargetValue)
+	case typedef.WktStepTargetPower:
+		return "secondary_target_power_zone", uint32(m.SecondaryTargetValue)
+	case typedef.WktStepTargetSwimStroke:
+		return "secondary_target_stroke_type", typedef.SwimStroke(m.SecondaryTargetValue)
+	}
+	return "secondary_target_value", m.SecondaryTargetValue
+}
+
+// GetSecondaryCustomTargetValueLow returns Dynamic Field interpretation of SecondaryCustomTargetValueLow. Otherwise, returns the original value of SecondaryCustomTargetValueLow.
+//
+// Based on m.SecondaryTargetType:
+//   - name: "secondary_custom_target_cadence_low", units: "rpm" , value: uint32(m.SecondaryCustomTargetValueLow)
+//   - name: "secondary_custom_target_power_low", units: "% or watts" , value: typedef.WorkoutPower(m.SecondaryCustomTargetValueLow)
+//   - name: "secondary_custom_target_speed_low", units: "m/s" , value: (float64(m.SecondaryCustomTargetValueLow) * 1000) - 0
+//   - name: "secondary_custom_target_heart_rate_low", units: "% or bpm" , value: typedef.WorkoutHr(m.SecondaryCustomTargetValueLow)
+//
+// Otherwise:
+//   - name: "secondary_custom_target_value_low", value: m.SecondaryCustomTargetValueLow
+func (m *WorkoutStep) GetSecondaryCustomTargetValueLow() (name string, value any) {
+	switch m.SecondaryTargetType {
+	case typedef.WktStepTargetCadence:
+		return "secondary_custom_target_cadence_low", uint32(m.SecondaryCustomTargetValueLow)
+	case typedef.WktStepTargetPower:
+		return "secondary_custom_target_power_low", typedef.WorkoutPower(m.SecondaryCustomTargetValueLow)
+	case typedef.WktStepTargetSpeed:
+		return "secondary_custom_target_speed_low", (float64(m.SecondaryCustomTargetValueLow) * 1000) - 0
+	case typedef.WktStepTargetHeartRate:
+		return "secondary_custom_target_heart_rate_low", typedef.WorkoutHr(m.SecondaryCustomTargetValueLow)
+	}
+	return "secondary_custom_target_value_low", m.SecondaryCustomTargetValueLow
+}
+
+// GetSecondaryCustomTargetValueHigh returns Dynamic Field interpretation of SecondaryCustomTargetValueHigh. Otherwise, returns the original value of SecondaryCustomTargetValueHigh.
+//
+// Based on m.SecondaryTargetType:
+//   - name: "secondary_custom_target_heart_rate_high", units: "% or bpm" , value: typedef.WorkoutHr(m.SecondaryCustomTargetValueHigh)
+//   - name: "secondary_custom_target_cadence_high", units: "rpm" , value: uint32(m.SecondaryCustomTargetValueHigh)
+//   - name: "secondary_custom_target_power_high", units: "% or watts" , value: typedef.WorkoutPower(m.SecondaryCustomTargetValueHigh)
+//   - name: "secondary_custom_target_speed_high", units: "m/s" , value: (float64(m.SecondaryCustomTargetValueHigh) * 1000) - 0
+//
+// Otherwise:
+//   - name: "secondary_custom_target_value_high", value: m.SecondaryCustomTargetValueHigh
+func (m *WorkoutStep) GetSecondaryCustomTargetValueHigh() (name string, value any) {
+	switch m.SecondaryTargetType {
+	case typedef.WktStepTargetHeartRate:
+		return "secondary_custom_target_heart_rate_high", typedef.WorkoutHr(m.SecondaryCustomTargetValueHigh)
+	case typedef.WktStepTargetCadence:
+		return "secondary_custom_target_cadence_high", uint32(m.SecondaryCustomTargetValueHigh)
+	case typedef.WktStepTargetPower:
+		return "secondary_custom_target_power_high", typedef.WorkoutPower(m.SecondaryCustomTargetValueHigh)
+	case typedef.WktStepTargetSpeed:
+		return "secondary_custom_target_speed_high", (float64(m.SecondaryCustomTargetValueHigh) * 1000) - 0
+	}
+	return "secondary_custom_target_value_high", m.SecondaryCustomTargetValueHigh
+}
+
 // ExerciseWeightScaled return ExerciseWeight in its scaled value [Scale: 100; Units: kg].
 //
 // If ExerciseWeight value is invalid, float64 invalid value will be returned.


### PR DESCRIPTION
Example: Product accessor on FileId
```go
// GetProduct returns Dynamic Field interpretation of Product. Otherwise, returns the original value of Product.
//
// Based on m.Manufacturer:
//   - name: "favero_product", value: typedef.FaveroProduct(m.Product)
//   - name: "garmin_product", value: typedef.GarminProduct(m.Product)
//
// Otherwise:
//   - name: "product", value: m.Product
func (m *FileId) GetProduct() (name string, value any) {
	switch m.Manufacturer {
	case typedef.ManufacturerFaveroElectronics:
		return "favero_product", typedef.FaveroProduct(m.Product)
	case typedef.ManufacturerGarmin, typedef.ManufacturerDynastream, typedef.ManufacturerDynastreamOem, typedef.ManufacturerTacx:
		return "garmin_product", typedef.GarminProduct(m.Product)
	}
	return "product", m.Product
}
```