### PR TITLE
Revert "chore(deps): bump github/codeql-action from 3.25.1 to 3.25.2 (#210)"

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -68,6 +68,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@8f596b4ae3cb3c588a5c46780b86dd53fef16c52 # v3.25.2
+        uses: github/codeql-action/upload-sarif@c7f9125735019aa87cfc361530512d50ea439c71 # v3.25.1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
This reverts commit f4be21402c3f4383bea5c546713a6cbde73063e8.

Unexpected error:
2024/04/23 09:44:35 error sending scorecard results to webapp: http response 400, status: 400 Bad Request, error: {"code":400,"message":"workflow verification failed: imposter commit: 8f596b4ae3cb3c588a5c46780b86dd53fef16c52 does not belong to github/codeql-action/upload-sarif, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}
