### PR TITLE
chore(deps): bump github/codeql-action from 3.25.1 to 3.25.2

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -68,6 +68,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@c7f9125735019aa87cfc361530512d50ea439c71 # v3.25.1
+        uses: github/codeql-action/upload-sarif@8f596b4ae3cb3c588a5c46780b86dd53fef16c52 # v3.25.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
This reverts commit 12ad7c479fbfbac354e2cf06312070483f52d23c.

The problem has been resolved. Ref: https://github.com/github/codeql-action/issues/2257