### PR TITLE
fix(filedef): unrelated messages should be copied before append

### DIFF
--- a/profile/filedef/activity.go
+++ b/profile/filedef/activity.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // Activity is a common file type that most wearable device or cycling computer uses to record activities.
@@ -95,6 +96,8 @@ func (f *Activity) Add(mesg proto.Message) {
 	case mesgnum.Hrv:
 		f.HRVs = append(f.HRVs, mesgdef.NewHrv(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/activity_summary.go
+++ b/profile/filedef/activity_summary.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // ActivitySummary is a compact version of the activity file and contain only activity, session and lap messages
@@ -53,6 +54,8 @@ func (f *ActivitySummary) Add(mesg proto.Message) {
 	case mesgnum.Lap:
 		f.Laps = append(f.Laps, mesgdef.NewLap(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/activity_summary_test.go
+++ b/profile/filedef/activity_summary_test.go
@@ -90,4 +90,10 @@ func TestActivitySummaryCorrectness(t *testing.T) {
 	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/activity_test.go
+++ b/profile/filedef/activity_test.go
@@ -140,7 +140,6 @@ func newActivityMessageForTest(now time.Time) []proto.Message {
 
 func TestActivityCorrectness(t *testing.T) {
 	mesgs := newActivityMessageForTest(time.Now())
-
 	activity := filedef.NewActivity(mesgs...)
 	if activity.FileId.Type != typedef.FileActivity {
 		t.Fatalf("expected: %v, got: %v", typedef.FileActivity, activity.FileId.Type)
@@ -158,5 +157,11 @@ func TestActivityCorrectness(t *testing.T) {
 
 	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
 		t.Fatal(diff)
+	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
 	}
 }

--- a/profile/filedef/blood_pressure.go
+++ b/profile/filedef/blood_pressure.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // BloodPressure files contain time-stamped discrete measurement data of blood pressure.
@@ -53,6 +54,8 @@ func (f *BloodPressure) Add(mesg proto.Message) {
 	case mesgnum.DeviceInfo:
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/blood_pressure_test.go
+++ b/profile/filedef/blood_pressure_test.go
@@ -76,4 +76,10 @@ func TestBloodPressureCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/course.go
+++ b/profile/filedef/course.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // Course is a common file type used as points of courses to assist with on- and off-road navigation,
@@ -69,6 +70,8 @@ func (f *Course) Add(mesg proto.Message) {
 	case mesgnum.CoursePoint:
 		f.CoursePoints = append(f.CoursePoints, mesgdef.NewCoursePoint(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/course_test.go
+++ b/profile/filedef/course_test.go
@@ -91,4 +91,10 @@ func TestCourseCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/device.go
+++ b/profile/filedef/device.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // Device files contain information about a device’s file structure/capabilities.
@@ -59,6 +60,8 @@ func (f *Device) Add(mesg proto.Message) {
 	case mesgnum.FieldCapabilities:
 		f.FieldCapabilities = append(f.FieldCapabilities, mesgdef.NewFieldCapabilities(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/device_test.go
+++ b/profile/filedef/device_test.go
@@ -83,4 +83,10 @@ func TestDeviceCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/goals.go
+++ b/profile/filedef/goals.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // Goals files allow a user to communicate their exercise/health goals.
@@ -47,6 +48,8 @@ func (f *Goals) Add(mesg proto.Message) {
 	case mesgnum.Goal:
 		f.Goals = append(f.Goals, mesgdef.NewGoal(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/goals_test.go
+++ b/profile/filedef/goals_test.go
@@ -67,4 +67,10 @@ func TestGoalsCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/monitoring_ab.go
+++ b/profile/filedef/monitoring_ab.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // MonitoringAB (Monitoring A and Monitoring B) files are used to store data that is logged over varying time intervals.
@@ -57,6 +58,8 @@ func (f *MonitoringAB) Add(mesg proto.Message) {
 	case mesgnum.DeviceInfo:
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/monitoring_ab_test.go
+++ b/profile/filedef/monitoring_ab_test.go
@@ -89,6 +89,12 @@ func TestMonitoringABCorrectness(t *testing.T) {
 		t.Fatal(diff)
 	}
 
+	// Edit unrelated message, should not change the resulting messages.
+	mesgsA[len(mesgsA)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgsA, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
+
 	mesgsB := newMonitoringBMessageForTest(time.Now())
 	ftype := mesgsB[0].FieldByNum(fieldnum.FileIdType)
 	ftype.Value = proto.Uint8(uint8(typedef.FileMonitoringB))
@@ -112,5 +118,11 @@ func TestMonitoringABCorrectness(t *testing.T) {
 		}
 		fmt.Println("")
 		t.Fatal(diff)
+	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgsB[len(mesgsB)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgsB, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
 	}
 }

--- a/profile/filedef/monitoring_daily.go
+++ b/profile/filedef/monitoring_daily.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // MonitoringDaily files follow the same format as monitoring files, however data is logged at 24 hour time intervals.
@@ -53,6 +54,8 @@ func (f *MonitoringDaily) Add(mesg proto.Message) {
 	case mesgnum.DeviceInfo:
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/monitoring_daily_test.go
+++ b/profile/filedef/monitoring_daily_test.go
@@ -73,4 +73,10 @@ func TestDailyMonitoringCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/schedules.go
+++ b/profile/filedef/schedules.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // Schedules files are used to schedule a user’s workouts and may contain multiple schedule messages each representing the start time of a workout.
@@ -47,6 +48,8 @@ func (f *Schedules) Add(mesg proto.Message) {
 	case mesgnum.Schedule:
 		f.Schedules = append(f.Schedules, mesgdef.NewSchedule(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/schedules_test.go
+++ b/profile/filedef/schedules_test.go
@@ -67,4 +67,10 @@ func TestSchedulesCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/segment.go
+++ b/profile/filedef/segment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // Segment files contain data defining a route and timing information to gauge progress against previous performances or other users
@@ -56,6 +57,8 @@ func (f *Segment) Add(mesg proto.Message) {
 	case mesgnum.SegmentPoint:
 		f.SegmentPoints = append(f.SegmentPoints, mesgdef.NewSegmentPoint(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/segment_list.go
+++ b/profile/filedef/segment_list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // SegmentList files maintain a list of available segments on the device.
@@ -50,6 +51,8 @@ func (f *SegmentList) Add(mesg proto.Message) {
 	case mesgnum.SegmentFile:
 		f.SegmentFiles = append(f.SegmentFiles, mesgdef.NewSegmentFile(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/segment_list_test.go
+++ b/profile/filedef/segment_list_test.go
@@ -70,4 +70,10 @@ func TestSegmentListCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/segment_test.go
+++ b/profile/filedef/segment_test.go
@@ -76,4 +76,10 @@ func TestSegmentCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/settings.go
+++ b/profile/filedef/settings.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // Settings files contain user and device information in the form of profiles.
@@ -59,6 +60,8 @@ func (f *Settings) Add(mesg proto.Message) {
 	case mesgnum.DeviceSettings:
 		f.DeviceSettings = append(f.DeviceSettings, mesgdef.NewDeviceSettings(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/settings_test.go
+++ b/profile/filedef/settings_test.go
@@ -79,4 +79,10 @@ func TestSettingsCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/sport.go
+++ b/profile/filedef/sport.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // Sport files contain information about the user’s desired target zones.
@@ -65,6 +66,8 @@ func (f *Sport) Add(mesg proto.Message) {
 	case mesgnum.CadenceZone:
 		f.CadenceZones = append(f.CadenceZones, mesgdef.NewCadenceZone(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/sport_test.go
+++ b/profile/filedef/sport_test.go
@@ -85,4 +85,10 @@ func TestSportCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/totals.go
+++ b/profile/filedef/totals.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // Totals files are used to summarize a user’s activities and may contain multiple totals messages each representing
@@ -48,6 +49,8 @@ func (f *Totals) Add(mesg proto.Message) {
 	case mesgnum.Totals:
 		f.Totals = append(f.Totals, mesgdef.NewTotals(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/totals_test.go
+++ b/profile/filedef/totals_test.go
@@ -67,4 +67,10 @@ func TestTotalsCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/weight.go
+++ b/profile/filedef/weight.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // Weight contains time-stamped discrete measurement data of weight.
@@ -53,6 +54,8 @@ func (f *Weight) Add(mesg proto.Message) {
 	case mesgnum.DeviceInfo:
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/weight_test.go
+++ b/profile/filedef/weight_test.go
@@ -73,4 +73,10 @@ func TestWeightCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }

--- a/profile/filedef/workout.go
+++ b/profile/filedef/workout.go
@@ -8,6 +8,7 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // Workout is a file contains instructions for performing a structured activity.
@@ -54,6 +55,8 @@ func (f *Workout) Add(mesg proto.Message) {
 	case mesgnum.WorkoutStep:
 		f.WorkoutSteps = append(f.WorkoutSteps, mesgdef.NewWorkoutStep(&mesg))
 	default:
+		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/workout_test.go
+++ b/profile/filedef/workout_test.go
@@ -73,4 +73,10 @@ func TestWorkoutCorrectness(t *testing.T) {
 		fmt.Println("")
 		t.Fatal(diff)
 	}
+
+	// Edit unrelated message, should not change the resulting messages.
+	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+		t.Fatalf("the modification reflect on the resulting messages")
+	}
 }


### PR DESCRIPTION
Prior to #190, `mesg` passed through listener's `OnMesg` is no longer copied and only guaranteed only before OnMesg returns, since we keep the mesg in original form and filedef's listener do not copy the mesg, we need to copy the fields and developerFields before append the mesg in `UnrelatedMessages` struct field (slice's underlying array is passed by reference not passed by value)