### PR TITLE
fix(decoder): should reset crc16 when file's crc is 0

### DIFF
--- a/decoder/raw_test.go
+++ b/decoder/raw_test.go
@@ -474,7 +474,6 @@ func TestRawDecoderDecode(t *testing.T) {
 			}
 
 			result.Reset()
-			dec.reset()
 			hash16.Reset()
 		})
 	}


### PR DESCRIPTION
- When `d.fileHeader.CRC == 0x0000`, it means the FIT file might be using legacy header (12 bytes) so there is no crc integrity for the `file_header`. However, the `file_crc` that will validate the integrity of the messages should be present. We should reset the `d.crc16` before returning nil, otherwise the calculation of the messages' crc might mismatch since `d.crc16` is still containing file_header's crc calculation. (We don't need reset `d.crc16` on error)
- Clean up decoder's code