### PR TITLE
fix: listener object pooling

### DIFF
--- a/cmd/fitprint/printer/printer.go
+++ b/cmd/fitprint/printer/printer.go
@@ -197,10 +197,6 @@ func (p *printer) prep(mesg proto.Message) proto.Message {
 	copy(m.Fields, mesg.Fields)
 	mesg.Fields = m.Fields
 
-	if mesg.DeveloperFields == nil {
-		return mesg
-	}
-
 	if cap(m.DeveloperFields) < len(mesg.DeveloperFields) {
 		m.DeveloperFields = make([]proto.DeveloperField, len(mesg.DeveloperFields))
 	}

--- a/cmd/fitprint/printer/printer.go
+++ b/cmd/fitprint/printer/printer.go
@@ -193,8 +193,9 @@ func (p *printer) prep(mesg proto.Message) proto.Message {
 	if cap(m.Fields) < len(mesg.Fields) {
 		m.Fields = make([]proto.Field, len(mesg.Fields))
 	}
+	m.Fields = m.Fields[:len(mesg.Fields)]
 	copy(m.Fields, mesg.Fields)
-	mesg.Fields = m.Fields[:len(mesg.Fields)]
+	mesg.Fields = m.Fields
 
 	if mesg.DeveloperFields == nil {
 		return mesg
@@ -203,8 +204,9 @@ func (p *printer) prep(mesg proto.Message) proto.Message {
 	if cap(m.DeveloperFields) < len(mesg.DeveloperFields) {
 		m.DeveloperFields = make([]proto.DeveloperField, len(mesg.DeveloperFields))
 	}
+	m.DeveloperFields = m.DeveloperFields[:len(mesg.DeveloperFields)]
 	copy(m.DeveloperFields, mesg.DeveloperFields)
-	mesg.DeveloperFields = m.DeveloperFields[:len(mesg.DeveloperFields)]
+	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
 }

--- a/profile/filedef/listener.go
+++ b/profile/filedef/listener.go
@@ -140,8 +140,9 @@ func (l *Listener) prep(mesg proto.Message) proto.Message {
 	if cap(m.Fields) < len(mesg.Fields) {
 		m.Fields = make([]proto.Field, len(mesg.Fields))
 	}
+	m.Fields = m.Fields[:len(mesg.Fields)]
 	copy(m.Fields, mesg.Fields)
-	mesg.Fields = m.Fields[:len(mesg.Fields)]
+	mesg.Fields = m.Fields
 
 	if mesg.DeveloperFields == nil {
 		return mesg
@@ -150,8 +151,9 @@ func (l *Listener) prep(mesg proto.Message) proto.Message {
 	if cap(m.DeveloperFields) < len(mesg.DeveloperFields) {
 		m.DeveloperFields = make([]proto.DeveloperField, len(mesg.DeveloperFields))
 	}
+	m.DeveloperFields = m.DeveloperFields[:len(mesg.DeveloperFields)]
 	copy(m.DeveloperFields, mesg.DeveloperFields)
-	mesg.DeveloperFields = m.DeveloperFields[:len(mesg.DeveloperFields)]
+	mesg.DeveloperFields = m.DeveloperFields
 
 	return mesg
 }

--- a/profile/filedef/listener.go
+++ b/profile/filedef/listener.go
@@ -9,6 +9,7 @@ import (
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 // Listener is Message Listener.
@@ -144,16 +145,8 @@ func (l *Listener) prep(mesg proto.Message) proto.Message {
 	copy(m.Fields, mesg.Fields)
 	mesg.Fields = m.Fields
 
-	if mesg.DeveloperFields == nil {
-		return mesg
-	}
-
-	if cap(m.DeveloperFields) < len(mesg.DeveloperFields) {
-		m.DeveloperFields = make([]proto.DeveloperField, len(mesg.DeveloperFields))
-	}
-	m.DeveloperFields = m.DeveloperFields[:len(mesg.DeveloperFields)]
-	copy(m.DeveloperFields, mesg.DeveloperFields)
-	mesg.DeveloperFields = m.DeveloperFields
+	// Must clone DeveloperFields since it is being referenced in mesgdef's structs.
+	mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 
 	return mesg
 }


### PR DESCRIPTION
- Fix wrong re-slicing that causing inconsistent data
- Filedef's Listener **_must clone_** DeveloperFields since on mesgdef's struct creation, it's being referenced only, not copied.