### PR TITLE
fix: factory's CreateMesg missing bound check

### DIFF
--- a/internal/cmd/fitgen/factory/factory.tmpl
+++ b/internal/cmd/fitgen/factory/factory.tmpl
@@ -84,10 +84,10 @@ func (f *Factory) CreateMesg(num typedef.MesgNum) proto.Message {
 		}
 	})
 
-    var mesg proto.Message
-    if num < typedef.MesgNum(len(protoMesgs)) {
-        mesg = protoMesgs[num]
-    }
+	var mesg proto.Message
+	if num < typedef.MesgNum(len(protoMesgs)) {
+		mesg = protoMesgs[num]
+	}
 	if mesg.Num != num {
 		mesg = f.registeredMesgs[num]
 	}

--- a/internal/cmd/fitgen/factory/factory.tmpl
+++ b/internal/cmd/fitgen/factory/factory.tmpl
@@ -51,12 +51,13 @@ func New() *Factory { return &Factory{} }
 
 var ( // cache for CreateMesg method
 	once	   sync.Once
-	protoMesgs [len(mesgs)]proto.Message // data is populated on CreateMesg first invocation.
+	protoMesgs []proto.Message // data is populated on CreateMesg first invocation.
 )
 
 {{ template "create_mesg_doc" -}}
 func (f *Factory) CreateMesg(num typedef.MesgNum) proto.Message {
-	once.Do(func() { // populate data fields in the cache.
+	once.Do(func() { // populate data for the firt invocation.
+        protoMesgs = make([]proto.Message, len(mesgs))
 		for i := range mesgs {
 			rawmesg := &mesgs[i]
 			if rawmesg.Num != typedef.MesgNum(i) {
@@ -83,11 +84,13 @@ func (f *Factory) CreateMesg(num typedef.MesgNum) proto.Message {
 		}
 	})
 
-	mesg := protoMesgs[num]
+    var mesg proto.Message
+    if num < typedef.MesgNum(len(protoMesgs)) {
+        mesg = protoMesgs[num]
+    }
 	if mesg.Num != num {
 		mesg = f.registeredMesgs[num]
 	}
-
 	mesg.Num = num // In case of unknown field
 
 	if len(mesg.Fields) != 0 {
@@ -152,7 +155,7 @@ func (f *Factory) RegisterMesg(mesg proto.Message) error {
 
 type message struct {
 	Num    typedef.MesgNum
-	Fields [256]proto.Field // Use array to ensure O(1) lookup, use pointer to reduce memory usage.
+	Fields [256]proto.Field // Use array to ensure O(1) lookup
 }
 
 // Use array to ensure O(1) lookup


### PR DESCRIPTION
- Fix factory's CreateMesg missing bound check before accessing array which may cause panic index out of range.
- Change protoMesgs array to slice so we don't use memory when it's not populated.