### PR TITLE
fix: decoder integer divide by zero on invalid basetype

### DIFF
--- a/profile/basetype/basetype.go
+++ b/profile/basetype/basetype.go
@@ -160,7 +160,7 @@ func (t BaseType) String() string {
 	return "invalid"
 }
 
-// Size returns how many bytes the value need in binary form.
+// Size returns how many bytes the value need in binary form. If BaseType is invalid, 255 will be returned.
 func (t BaseType) Size() byte {
 	switch t {
 	case Enum, Byte, Sint8, Uint8, Uint8z:
@@ -178,7 +178,7 @@ func (t BaseType) Size() byte {
 	case Sint64, Uint64, Uint64z:
 		return 8
 	}
-	return 0
+	return 255
 }
 
 // GoType returns go equivalent type in string.

--- a/profile/basetype/basetype_test.go
+++ b/profile/basetype/basetype_test.go
@@ -109,7 +109,7 @@ func TestSize(t *testing.T) {
 		{baseType: basetype.Uint64, size: 8},
 		{baseType: basetype.Uint64z, size: 8},
 		{baseType: basetype.Float64, size: 8},
-		{baseType: 255, size: 0},
+		{baseType: 255, size: 255},
 	}
 	for _, tc := range tt {
 		t.Run(tc.baseType.String(), func(t *testing.T) {


### PR DESCRIPTION
When receiving bad encoded FIT file such as this bytes stream `[]byte("\x0e\x10^\x06\x17\b\x00\x00.FIT\xe3\xbb@0000\x060000000000000000000")`, It has fieldDef with invalid BaseType causing our decoder to panic when doing this operation `fieldDef.Size%fieldDef.BaseType.Size()` since Size will return 0. To avoid this, let's make invalid size to be 255 just like all invalid values is the max size of the types. Any value modulo by 255 is always the value itself and any value divided by 255 will always zero.