### PR TITLE
fix: decoder on handling invalid basetype

### DIFF
--- a/profile/basetype/basetype.go
+++ b/profile/basetype/basetype.go
@@ -6,6 +6,7 @@ package basetype
 
 import (
 	"math"
+	"strconv"
 )
 
 // BaseTypeNumMask used to get the index/order of the constants (start from 0, Enum).
@@ -157,7 +158,7 @@ func (t BaseType) String() string {
 	case Uint64z:
 		return "uint64z"
 	}
-	return "invalid"
+	return "invalid(" + strconv.Itoa(int(t)) + ")"
 }
 
 // Size returns how many bytes the value need in binary form. If BaseType is invalid, 255 will be returned.
@@ -211,7 +212,7 @@ func (t BaseType) GoType() string {
 	case Uint64, Uint64z:
 		return "uint64"
 	}
-	return "invalid"
+	return "invalid(" + strconv.Itoa(int(t)) + ")"
 }
 
 // EndianAbility return whether t have endianness.
@@ -310,4 +311,28 @@ func (t BaseType) Invalid() any {
 		return Uint64zInvalid
 	}
 	return "invalid"
+}
+
+func (t BaseType) Valid() bool {
+	switch t {
+	case Enum,
+		Sint8,
+		Uint8,
+		Sint16,
+		Uint16,
+		Sint32,
+		Uint32,
+		String,
+		Float32,
+		Float64,
+		Uint8z,
+		Uint16z,
+		Uint32z,
+		Byte,
+		Sint64,
+		Uint64,
+		Uint64z:
+		return true
+	}
+	return false
 }

--- a/profile/basetype/basetype_test.go
+++ b/profile/basetype/basetype_test.go
@@ -5,6 +5,7 @@
 package basetype_test
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -34,7 +35,7 @@ func TestFromStringAndString(t *testing.T) {
 		{s: "sint64", baseType: basetype.Sint64},
 		{s: "uint64", baseType: basetype.Uint64},
 		{s: "uint64z", baseType: basetype.Uint64z},
-		{s: "invalid", baseType: basetype.BaseType(255)},
+		{s: "invalid(255)", baseType: basetype.BaseType(255)},
 	}
 
 	t.Run("FromString", func(t *testing.T) {
@@ -143,7 +144,7 @@ func TestGoType(t *testing.T) {
 		{baseType: basetype.Uint64, goType: "uint64"},
 		{baseType: basetype.Uint64z, goType: "uint64"},
 		{baseType: basetype.Float64, goType: "float64"},
-		{baseType: 255, goType: "invalid"},
+		{baseType: 255, goType: "invalid(255)"},
 	}
 	for _, tc := range tt {
 		t.Run(tc.baseType.String(), func(t *testing.T) {
@@ -265,6 +266,41 @@ func TestInvalid(t *testing.T) {
 				if invalid != tc.invalid {
 					t.Fatalf("expected: %t, got: %t", tc.invalid, invalid)
 				}
+			}
+		})
+	}
+}
+
+func TestValid(t *testing.T) {
+	tt := []struct {
+		baseType basetype.BaseType
+		valid    bool
+	}{
+		{baseType: basetype.Enum, valid: true},
+		{baseType: basetype.Sint8, valid: true},
+		{baseType: basetype.Uint8, valid: true},
+		{baseType: basetype.Sint16, valid: true},
+		{baseType: basetype.Uint16, valid: true},
+		{baseType: basetype.Sint32, valid: true},
+		{baseType: basetype.Uint32, valid: true},
+		{baseType: basetype.String, valid: true},
+		{baseType: basetype.Float32, valid: true},
+		{baseType: basetype.Float64, valid: true},
+		{baseType: basetype.Uint8z, valid: true},
+		{baseType: basetype.Uint16z, valid: true},
+		{baseType: basetype.Uint32z, valid: true},
+		{baseType: basetype.Byte, valid: true},
+		{baseType: basetype.Sint64, valid: true},
+		{baseType: basetype.Uint64, valid: true},
+		{baseType: basetype.Uint64z, valid: true},
+		{baseType: basetype.BaseType(48), valid: false},
+		{baseType: basetype.BaseType(255), valid: false},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.baseType.String()), func(t *testing.T) {
+			if tc.baseType.Valid() != tc.valid {
+				t.Fatalf("expected: %v, got: %v", tc.valid, tc.baseType.Valid())
 			}
 		})
 	}


### PR DESCRIPTION
When encountering invalid `basetype` on decoding message definition's field definition, decoder now will return a error instead of undefined behavior. If the field is a known field, actually we could use `basetype` from the factory, however, the correctness of the data is still questionable, let's just make it fail since most cases bad encoded FIT files are corrupt anyway.

Another changes:
- basetype: add `Valid` method to check whether the basetype is valid or not.
- decoder: remove sentinel error `ErrByteSizeMismatch` since it's not used anywhere.
- decoder: add sentinel error `ErrInvalidBaseType`