### PR TITLE
fix: proto value marshal empty string slice

### DIFF
--- a/proto/value_marshal.go
+++ b/proto/value_marshal.go
@@ -11,13 +11,12 @@ import (
 	"math"
 )
 
-var (
-	ErrTypeNotSupported = errors.New("type is not supported")
-)
+var ErrTypeNotSupported = errors.New("type is not supported")
 
 // MarshalAppend appends the FIT format encoding of Value to b. Returning the result.
 // If arch is 0, marshal in Little-Endian, otherwise marshal in Big-Endian.
 func (v Value) MarshalAppend(b []byte, arch byte) ([]byte, error) {
+	// NOTE: The size of the resulting bytes should align with lenof.
 	switch v.Type() {
 	case TypeBool:
 		if v.Bool() {
@@ -211,6 +210,9 @@ func (v Value) MarshalAppend(b []byte, arch byte) ([]byte, error) {
 			if vals[i][len(vals[i])-1] != '\x00' {
 				b = append(b, '\x00')
 			}
+		}
+		if len(vals) == 0 {
+			b = append(b, '\x00')
 		}
 		return b, nil
 	default:

--- a/proto/value_marshal_test.go
+++ b/proto/value_marshal_test.go
@@ -54,6 +54,7 @@ func TestValueMarshalAppend(t *testing.T) {
 		{b: kit.Ptr([]byte{}), value: SliceInt32([]int32{-8979123})},
 		{b: kit.Ptr([]byte{}), value: SliceUint32([]uint32{9929})},
 		{b: kit.Ptr([]byte{}), value: SliceString([]string{"supported"})},
+		{b: kit.Ptr([]byte{}), value: SliceString([]string{})},
 		{b: kit.Ptr([]byte{}), value: SliceString([]string{""})},
 		{b: kit.Ptr([]byte{}), value: SliceString([]string{"\x00"})},
 		{b: kit.Ptr([]byte{}), value: SliceString([]string{"\x00", "\x00"})},
@@ -128,6 +129,9 @@ func marshalValueWithReflectionForTest(w io.Writer, value Value, arch byte) erro
 			if err := marshalValueWithReflectionForTest(w, val, arch); err != nil {
 				return err
 			}
+		}
+		if rv.Len() == 0 && rv.Type() == reflect.TypeOf([]string{}) {
+			w.Write([]byte{0})
 		}
 		return nil
 	}


### PR DESCRIPTION
When string slice value is empty, `lenof` will return 1 for 0x00 (null-terminated string), however value marshal did not add the 0x00 value. And if message validator with perverse invalid value is enabled, it will lead to a corrupted FIT file.