### PR TITLE
fix: decoder handle compressed timestamp for unknown field

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -659,6 +659,10 @@ func (d *Decoder) decodeMessageData(header byte) error {
 		d.lastTimeOffset = timeOffset
 
 		timestampField := d.factory.CreateField(mesgDef.MesgNum, proto.FieldNumTimestamp)
+		if timestampField.Name == factory.NameUnknown {
+			timestampField.BaseType = basetype.Uint32
+			timestampField.Type = profile.ProfileTypeFromBaseType(timestampField.BaseType)
+		}
 		timestampField.Value = proto.Uint32(d.timestamp)
 
 		mesg.Fields = append(mesg.Fields, timestampField) // add timestamp field

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -1476,6 +1476,22 @@ func TestDecodeMessageData(t *testing.T) {
 			},
 		},
 		{
+			name:   "decode message data compressed header unknown field",
+			r:      fnReaderOK,
+			header: proto.MesgCompressedHeaderMask,
+			mesgdef: &proto.MessageDefinition{
+				Header:  proto.MesgDefinitionMask,
+				MesgNum: typedef.MesgNumInvalid,
+				FieldDefinitions: []proto.FieldDefinition{
+					{
+						Num:      proto.FieldNumTimestamp,
+						Size:     4,
+						BaseType: basetype.Uint32,
+					},
+				},
+			},
+		},
+		{
 			name:    "decode message data normal header missing mesg definition",
 			r:       fnReaderOK,
 			header:  0,


### PR DESCRIPTION
When encountering compressed timestamp message but the message is unknown (it could be manufacturer specific message), the field become unknown as well, in such cases, we must assign the `BaseType` and `Type` to `uint32` so that the resulting decoded FIT can be encoded as per original instead of returning error in encoder since the `BaseType` was set to default value: `Enum`.