### PR TITLE
cli: update fitconv

### DIFF
--- a/cmd/fitconv/README.md
+++ b/cmd/fitconv/README.md
@@ -34,6 +34,7 @@ ls
 | -deg       | FIT to CSV only | Print GPS Positions in degrees instead of semicircles. |
 | -trim      | FIT to CSV only | Trim trailing commas in every line (save storage)      |
 | -no-expand | FIT to CSV only | [Decode Option] Do not expand components               |
+| -checksum  | FIT to CSV only | [Decode Option] Do CRC checksum to ensure integrity    |
 
 ```sh
 go run main.go -deg activity.fit activity2.fit


### PR DESCRIPTION
- `fitconv` now will always produce csv files regardless decode return with error or not, so we could retrieved the data.
- By default, `fitconv` will not check crc checksum since most cases we use `fitconv` for debugging. However, `-checksum` option is now provided if user want to perform the checksum.