### PR TITLE
fix: update readbuffer minReadBufferSize

### DIFF
--- a/decoder/bits.go
+++ b/decoder/bits.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	bit    = 8
-	maxBit = 32
-	size   = maxBit / bit
+	bit     = 8
+	maxBit  = 32
+	bitSize = maxBit / bit
 )
 
 // bitsFromValue convert value into 32-bits unsigned integer.
@@ -42,7 +42,7 @@ func bitsFromValue(value proto.Value) (bits uint32, ok bool) {
 		return uint32(value.Float64()), true
 	case proto.TypeSliceUint8:
 		val := value.SliceUint8()
-		if len(val) > size {
+		if len(val) > bitSize {
 			return 0, false
 		}
 		for i := range val {

--- a/decoder/readbuffer.go
+++ b/decoder/readbuffer.go
@@ -10,14 +10,14 @@ import (
 )
 
 const (
-	minReadBufferSize     = 16
-	maxReadBufferSize     = math.MaxUint32
-	defaultReadBufferSize = 4096
-
 	// reservedbuf is the maximum bytes that will be requested by the Decoder in one read.
 	// The value is obtained from the maximum n field definition in a mesg is 255 and
 	// we need 3 byte per field. So 255 * 3 = 765.
 	reservedbuf = 765
+
+	minReadBufferSize     = reservedbuf // should not less than this
+	maxReadBufferSize     = math.MaxUint32
+	defaultReadBufferSize = 4096
 )
 
 // readBuffer is a custom buffered reader. See newReadBuffer() for details.
@@ -81,7 +81,7 @@ func (b *readBuffer) ReadN(n int) ([]byte, error) {
 // Reset resets buf reader.
 func (b *readBuffer) Reset(rd io.Reader, size int) {
 	oldsize := cap(b.buf) - reservedbuf
-	if size != oldsize {
+	if size > oldsize {
 		b.buf = make([]byte, reservedbuf+size)
 	}
 	b.buf = b.buf[:reservedbuf+size]


### PR DESCRIPTION
- readBuffer's minReadBufferSize should at least 765 since max value of decoder read from reader is 765, otherwise, readBuffer will always return ErrShortBuffer when n read is > 16 (previous minReadBufferSize).
- on reset readBuffer, only when size > oldsize we will allocate new slice, otherwise reuse existing by reslice.
- chore: rename `size` constant to `bitSize` in bits.go to reduce the constant being shadowed or potential misuse. 