### PR TITLE
fix!: misspell on generated code due to Profile.xlsx's misspell issue

### DIFF
--- a/cmd/fitconv/fitcsv/lookup_gen.go
+++ b/cmd/fitconv/fitcsv/lookup_gen.go
@@ -1384,7 +1384,7 @@ var fieldNumLookup = [...]map[string]byte{
 		"time_in_power_zone":         5,
 		"hr_zone_high_boundary":      6,
 		"speed_zone_high_boundary":   7,
-		"cadence_zone_high_bondary":  8,
+		"cadence_zone_high_boundary": 8,
 		"power_zone_high_boundary":   9,
 		"hr_calc_type":               10,
 		"max_heart_rate":             11,

--- a/docs/generating_code.md
+++ b/docs/generating_code.md
@@ -27,7 +27,7 @@ After generating code we make sure all existing tests are passes locally and on 
 
 FIT is designed to have the ability to include a `Product Profile`, which contains manufacturer-specific specifications not defined in the `Global Profile`. The `Product Profile` declares manufacturer-specific types and messages used in their FIT-generated files.
 
-To work with these files perfectly, we must include the specification in `Profile.xlsx` and then generate the code. Otherwise, if we encounter a manufactuer specific message, it will be an unknown message.
+To work with these files perfectly, we must include the specification in `Profile.xlsx` and then generate the code. Otherwise, if we encounter a manufacturer specific message, it will be an unknown message.
 
 Here are the steps to follow:
 

--- a/docs/runtime_registration.md
+++ b/docs/runtime_registration.md
@@ -10,7 +10,7 @@ Note: The data presented here is only for demonstration, we don't known any spec
 
 Note: If you don't need stringer for your constants or you have your own custom stringer, you can skip this.
 
-To track your own **MesgNum** constants and its string represantative, you can add your types in typedef. However, unlike `factory` that you can have different Factory instances for different manufacturers, `typedef` is shared globally, so you can only work with one manufacturer for this (this is one of our current limitation that we mention earlier). Other than **MesgNum**, you can register **File** type as well.
+To track your own **MesgNum** constants and its string representative, you can add your types in typedef. However, unlike `factory` that you can have different Factory instances for different manufacturers, `typedef` is shared globally, so you can only work with one manufacturer for this (this is one of our current limitation that we mention earlier). Other than **MesgNum**, you can register **File** type as well.
 
 ```go
 
@@ -34,7 +34,7 @@ func main() {
 
 Let's say you will work with FIT files from two different manufacturers, or maybe you are the manufacturer itself that want to use this SDK to build a service in Go. You can define messages that only your company use in the FIT you are created.
 
-The available range is between `0xFF00 - 0xFFFE (65280 - 65534)`, but we found some company are using lower number such as `68`, so we accomodate that as long as the number is not already defined in original `Profile.xlsx`.
+The available range is between `0xFF00 - 0xFFFE (65280 - 65534)`, but we found some company are using lower number such as `68`, so we accommodate that as long as the number is not already defined in original `Profile.xlsx`.
 
 ```go
 package main

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -147,7 +147,7 @@ func main() {
 }
 ```
 
-2. While the previous example is work for most use cases and probably can be your goto choice to use for small scale, it's slighly inefficient as we only utilize one goroutine (the main goroutine) and also we need to allocate the `fit.Messages` before creating the `activity` file itself. For bigger scale, or in scale that require a streaming process, we can define `filedef's Listener` to create the `activity` file. This not only reduce the need to allocate `fit.Messages` but also we can receive the message as it is decode in other goroutine. As the decoder decode the message, we can create the message in another process concurrently.
+2. While the previous example is work for most use cases and probably can be your goto choice to use for small scale, it's slightly inefficient as we only utilize one goroutine (the main goroutine) and also we need to allocate the `fit.Messages` before creating the `activity` file itself. For bigger scale, or in scale that require a streaming process, we can define `filedef's Listener` to create the `activity` file. This not only reduce the need to allocate `fit.Messages` but also we can receive the message as it is decode in other goroutine. As the decoder decode the message, we can create the message in another process concurrently.
 
 ```go
 package main

--- a/factory/factory_gen.go
+++ b/factory/factory_gen.go
@@ -2976,7 +2976,7 @@ var mesgs = [...]message{
 			},
 			8: {
 				FieldBase: &proto.FieldBase{
-					Name:       "cadence_zone_high_bondary",
+					Name:       "cadence_zone_high_boundary",
 					Num:        8,
 					Type:       profile.Uint8,
 					BaseType:   basetype.Uint8, /* (size: 1) */

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,7 @@ require (
 	golang.org/x/text v0.15.0
 )
 
-require github.com/stretchr/testify v1.8.0 // indirect
+require (
+	github.com/client9/misspell v0.3.4 // indirect
+	github.com/stretchr/testify v1.8.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
+github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/cmd/fitgen/parser/parser.go
+++ b/internal/cmd/fitgen/parser/parser.go
@@ -50,7 +50,8 @@ func (p *Parser) ParseTypes() ([]Type, error) {
 			)
 			name, diff = p.misspellReplacer.Replace(name)
 			if len(diff) > 0 {
-				fmt.Printf("parser: misspell: type: type name: %v\n", formatMisspellDiff(diff))
+				fmt.Printf("parser: misspell: sheet: %q, row index: %d: type: type name: %v\n",
+					"Types", row.Index(), formatMisspellDiff(diff))
 			}
 			ts = append(ts, Type{
 				Name:     name,
@@ -65,14 +66,15 @@ func (p *Parser) ParseTypes() ([]Type, error) {
 			value   = row.Cell("D")
 			comment = row.Cell("E")
 		)
-
 		name, diff = p.misspellReplacer.Replace(name)
 		if len(diff) > 0 {
-			fmt.Printf("parser: misspell: type: value name: %v\n", formatMisspellDiff(diff))
+			fmt.Printf("parser: misspell: sheet: %q, row index: %d: type: value name: %v\n",
+				"Types", row.Index(), formatMisspellDiff(diff))
 		}
 		comment, diff = p.misspellReplacer.Replace(comment)
 		if len(diff) > 0 {
-			fmt.Printf("parser: misspell: type: comment: %v\n", formatMisspellDiff(diff))
+			fmt.Printf("parser: misspell: sheet: %q, row index: %d: type: comment: %v\n",
+				"Types", row.Index(), formatMisspellDiff(diff))
 		}
 
 		ts[cur].Values = append(ts[cur].Values, Value{
@@ -108,11 +110,13 @@ func (p *Parser) ParseMessages() ([]Message, error) {
 			)
 			name, misspellDiff = p.misspellReplacer.Replace(name)
 			if len(misspellDiff) > 0 {
-				fmt.Printf("parser: misspell: mesg.Name: %v\n", formatMisspellDiff(misspellDiff))
+				fmt.Printf("parser: misspell: sheet: %q, row index: %d: mesg.Name: %v\n",
+					"Messages", row.Index(), formatMisspellDiff(misspellDiff))
 			}
 			comment, misspellDiff = p.misspellReplacer.Replace(comment)
 			if len(misspellDiff) > 0 {
-				fmt.Printf("parser: misspell: mesg.Comment: %v\n", formatMisspellDiff(misspellDiff))
+				fmt.Printf("parser: misspell: sheet: %q, row index: %d: mesg.Comment: %v\n",
+					"Messages", row.Index(), formatMisspellDiff(misspellDiff))
 			}
 			ms = append(ms, Message{
 				Name:    name,
@@ -129,8 +133,8 @@ func (p *Parser) ParseMessages() ([]Message, error) {
 		fieldName := row.Cell("C")
 		fieldName, misspellDiff = p.misspellReplacer.Replace(fieldName)
 		if len(misspellDiff) > 0 {
-			fmt.Printf("parser: misspell: mesg.Name: %s: field.Name: %v\n",
-				ms[cur].Name, formatMisspellDiff(misspellDiff))
+			fmt.Printf("parser: misspell: sheet: %q, row index: %d: mesg.Name: %s: field.Name: %v\n",
+				"Messages", row.Index(), ms[cur].Name, formatMisspellDiff(misspellDiff))
 		}
 		fieldType := row.Cell("D")
 		array := row.Cell("E")
@@ -161,8 +165,8 @@ func (p *Parser) ParseMessages() ([]Message, error) {
 		comment := row.Cell("N")
 		comment, misspellDiff = p.misspellReplacer.Replace(comment)
 		if len(misspellDiff) > 0 {
-			fmt.Printf("parser: misspell: mesg.Name: %s: field.Comment: %v\n",
-				ms[cur].Name, formatMisspellDiff(misspellDiff))
+			fmt.Printf("parser: misspell: sheet: %q, row index: %d: mesg.Name: %s: field.Comment: %v\n",
+				"Messages", row.Index(), ms[cur].Name, formatMisspellDiff(misspellDiff))
 		}
 
 		product := row.Cell("O")
@@ -297,7 +301,11 @@ func formatMisspellDiff(diff []misspell.Diff) string {
 	strbuf := new(strings.Builder)
 	fmt.Fprintf(strbuf, "[\n")
 	for i := range diff {
-		fmt.Fprintf(strbuf, "%q is a misspelling of %q\n", diff[i].Original, diff[i].Corrected)
+		fullLine := "full text: <ommited: too long> -> "
+		if len(diff[i].FullLine) <= 50 {
+			fullLine = fmt.Sprintf("full text: %q -> ", diff[i].FullLine)
+		}
+		fmt.Fprintf(strbuf, "- %s%q is a misspelling of %q\n", fullLine, diff[i].Original, diff[i].Corrected)
 	}
 	fmt.Fprintf(strbuf, "]")
 	return strbuf.String()

--- a/internal/cmd/fitgen/parser/parser.go
+++ b/internal/cmd/fitgen/parser/parser.go
@@ -5,9 +5,11 @@
 package parser
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/client9/misspell"
 	"github.com/muktihari/fit/internal/cmd/fitgen/pkg/xlsxlite"
 )
 
@@ -20,13 +22,14 @@ const (
 
 // Parser is Profile.xlsx parser
 type Parser struct {
-	xl     *xlsxlite.XlsxLite
-	sheets map[Sheet]string
+	xl               *xlsxlite.XlsxLite
+	sheets           map[Sheet]string
+	misspellReplacer *misspell.Replacer
 }
 
 // New creates new Parser.
 func New(xl *xlsxlite.XlsxLite, sheetNames map[Sheet]string) *Parser {
-	return &Parser{xl: xl, sheets: sheetNames}
+	return &Parser{xl: xl, sheets: sheetNames, misspellReplacer: misspell.New()}
 }
 
 // ParseTypes parse sheet "Types" in Profile.xlsx
@@ -35,23 +38,47 @@ func (p *Parser) ParseTypes() ([]Type, error) {
 	var cur = -1
 	row := p.xl.RowIterator(p.sheets[SheetTypes])
 
+	var diff []misspell.Diff
 	for row.Next() {
 		if row.Index() == 1 { // header
 			continue
 		}
 		if row.Cell("A") != "" {
+			var (
+				name     = row.Cell("A")
+				baseType = row.Cell("B")
+			)
+			name, diff = p.misspellReplacer.Replace(name)
+			if len(diff) > 0 {
+				fmt.Printf("parser: misspell: type: type name: %v\n", formatMisspellDiff(diff))
+			}
 			ts = append(ts, Type{
-				Name:     row.Cell("A"),
-				BaseType: row.Cell("B"),
+				Name:     name,
+				BaseType: baseType,
 			})
 			cur++
 			continue
 		}
 
+		var (
+			name    = row.Cell("C")
+			value   = row.Cell("D")
+			comment = row.Cell("E")
+		)
+
+		name, diff = p.misspellReplacer.Replace(name)
+		if len(diff) > 0 {
+			fmt.Printf("parser: misspell: type: value name: %v\n", formatMisspellDiff(diff))
+		}
+		comment, diff = p.misspellReplacer.Replace(comment)
+		if len(diff) > 0 {
+			fmt.Printf("parser: misspell: type: comment: %v\n", formatMisspellDiff(diff))
+		}
+
 		ts[cur].Values = append(ts[cur].Values, Value{
-			Name:    row.Cell("C"),
-			Value:   row.Cell("D"),
-			Comment: row.Cell("E"),
+			Name:    name,
+			Value:   value,
+			Comment: comment,
 		})
 	}
 
@@ -68,15 +95,28 @@ func (p *Parser) ParseMessages() ([]Message, error) {
 	var cur = -1 // message cursor
 	row := p.xl.RowIterator(p.sheets[SheetMessages])
 
+	var misspellDiff []misspell.Diff
 	for row.Next() {
 		if row.Index() == 1 { // header
 			continue
 		}
 
 		if row.Cell("A") != "" {
+			var (
+				name    = row.Cell("A")
+				comment = row.Cell("N")
+			)
+			name, misspellDiff = p.misspellReplacer.Replace(name)
+			if len(misspellDiff) > 0 {
+				fmt.Printf("parser: misspell: mesg.Name: %v\n", formatMisspellDiff(misspellDiff))
+			}
+			comment, misspellDiff = p.misspellReplacer.Replace(comment)
+			if len(misspellDiff) > 0 {
+				fmt.Printf("parser: misspell: mesg.Comment: %v\n", formatMisspellDiff(misspellDiff))
+			}
 			ms = append(ms, Message{
-				Name:    row.Cell("A"),
-				Comment: row.Cell("N"),
+				Name:    name,
+				Comment: comment,
 			})
 			cur++
 			continue
@@ -87,6 +127,11 @@ func (p *Parser) ParseMessages() ([]Message, error) {
 		}
 
 		fieldName := row.Cell("C")
+		fieldName, misspellDiff = p.misspellReplacer.Replace(fieldName)
+		if len(misspellDiff) > 0 {
+			fmt.Printf("parser: misspell: mesg.Name: %s: field.Name: %v\n",
+				ms[cur].Name, formatMisspellDiff(misspellDiff))
+		}
 		fieldType := row.Cell("D")
 		array := row.Cell("E")
 		components := splitStringOrNil(row.Cell("F"))
@@ -114,6 +159,12 @@ func (p *Parser) ParseMessages() ([]Message, error) {
 		}
 
 		comment := row.Cell("N")
+		comment, misspellDiff = p.misspellReplacer.Replace(comment)
+		if len(misspellDiff) > 0 {
+			fmt.Printf("parser: misspell: mesg.Name: %s: field.Comment: %v\n",
+				ms[cur].Name, formatMisspellDiff(misspellDiff))
+		}
+
 		product := row.Cell("O")
 		example := row.Cell("P")
 
@@ -240,4 +291,14 @@ func splitBoolsOrNil(s string) ([]bool, error) {
 	}
 
 	return bs, nil
+}
+
+func formatMisspellDiff(diff []misspell.Diff) string {
+	strbuf := new(strings.Builder)
+	fmt.Fprintf(strbuf, "[\n")
+	for i := range diff {
+		fmt.Fprintf(strbuf, "%q is a misspelling of %q\n", diff[i].Original, diff[i].Corrected)
+	}
+	fmt.Fprintf(strbuf, "]")
+	return strbuf.String()
 }

--- a/profile/mesgdef/accelerometer_data_gen.go
+++ b/profile/mesgdef/accelerometer_data_gen.go
@@ -21,7 +21,7 @@ import (
 // Do not rely on field indices, such as when using reflection.
 type AccelerometerData struct {
 	Timestamp                  time.Time // Units: s; Whole second part of the timestamp
-	SampleTimeOffset           []uint16  // Array: [N]; Units: ms; Each time in the array describes the time at which the accelerometer sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in accel_x and accel_y and accel_z
+	SampleTimeOffset           []uint16  // Array: [N]; Units: ms; Each time in the array describes the time at which the accelerometer sample with the corresponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in accel_x and accel_y and accel_z
 	AccelX                     []uint16  // Array: [N]; Units: counts; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
 	AccelY                     []uint16  // Array: [N]; Units: counts; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
 	AccelZ                     []uint16  // Array: [N]; Units: counts; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
@@ -178,7 +178,7 @@ func (m *AccelerometerData) SetTimestampMs(v uint16) *AccelerometerData {
 
 // SetSampleTimeOffset sets AccelerometerData value.
 //
-// Array: [N]; Units: ms; Each time in the array describes the time at which the accelerometer sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in accel_x and accel_y and accel_z
+// Array: [N]; Units: ms; Each time in the array describes the time at which the accelerometer sample with the corresponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in accel_x and accel_y and accel_z
 func (m *AccelerometerData) SetSampleTimeOffset(v []uint16) *AccelerometerData {
 	m.SampleTimeOffset = v
 	return m

--- a/profile/mesgdef/barometer_data_gen.go
+++ b/profile/mesgdef/barometer_data_gen.go
@@ -21,7 +21,7 @@ import (
 // Do not rely on field indices, such as when using reflection.
 type BarometerData struct {
 	Timestamp        time.Time // Units: s; Whole second part of the timestamp
-	SampleTimeOffset []uint16  // Array: [N]; Units: ms; Each time in the array describes the time at which the barometer sample with the corrosponding index was taken. The samples may span across seconds. Array size must match the number of samples in baro_cal
+	SampleTimeOffset []uint16  // Array: [N]; Units: ms; Each time in the array describes the time at which the barometer sample with the corresponding index was taken. The samples may span across seconds. Array size must match the number of samples in baro_cal
 	BaroPres         []uint32  // Array: [N]; Units: Pa; These are the raw ADC reading. The samples may span across seconds. A conversion will need to be done on this data once read.
 	TimestampMs      uint16    // Units: ms; Millisecond part of the timestamp.
 
@@ -122,7 +122,7 @@ func (m *BarometerData) SetTimestampMs(v uint16) *BarometerData {
 
 // SetSampleTimeOffset sets BarometerData value.
 //
-// Array: [N]; Units: ms; Each time in the array describes the time at which the barometer sample with the corrosponding index was taken. The samples may span across seconds. Array size must match the number of samples in baro_cal
+// Array: [N]; Units: ms; Each time in the array describes the time at which the barometer sample with the corresponding index was taken. The samples may span across seconds. Array size must match the number of samples in baro_cal
 func (m *BarometerData) SetSampleTimeOffset(v []uint16) *BarometerData {
 	m.SampleTimeOffset = v
 	return m

--- a/profile/mesgdef/gyroscope_data_gen.go
+++ b/profile/mesgdef/gyroscope_data_gen.go
@@ -21,7 +21,7 @@ import (
 // Do not rely on field indices, such as when using reflection.
 type GyroscopeData struct {
 	Timestamp        time.Time // Units: s; Whole second part of the timestamp
-	SampleTimeOffset []uint16  // Array: [N]; Units: ms; Each time in the array describes the time at which the gyro sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in gyro_x and gyro_y and gyro_z
+	SampleTimeOffset []uint16  // Array: [N]; Units: ms; Each time in the array describes the time at which the gyro sample with the corresponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in gyro_x and gyro_y and gyro_z
 	GyroX            []uint16  // Array: [N]; Units: counts; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
 	GyroY            []uint16  // Array: [N]; Units: counts; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
 	GyroZ            []uint16  // Array: [N]; Units: counts; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
@@ -157,7 +157,7 @@ func (m *GyroscopeData) SetTimestampMs(v uint16) *GyroscopeData {
 
 // SetSampleTimeOffset sets GyroscopeData value.
 //
-// Array: [N]; Units: ms; Each time in the array describes the time at which the gyro sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in gyro_x and gyro_y and gyro_z
+// Array: [N]; Units: ms; Each time in the array describes the time at which the gyro sample with the corresponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in gyro_x and gyro_y and gyro_z
 func (m *GyroscopeData) SetSampleTimeOffset(v []uint16) *GyroscopeData {
 	m.SampleTimeOffset = v
 	return m

--- a/profile/mesgdef/magnetometer_data_gen.go
+++ b/profile/mesgdef/magnetometer_data_gen.go
@@ -21,7 +21,7 @@ import (
 // Do not rely on field indices, such as when using reflection.
 type MagnetometerData struct {
 	Timestamp        time.Time // Units: s; Whole second part of the timestamp
-	SampleTimeOffset []uint16  // Array: [N]; Units: ms; Each time in the array describes the time at which the compass sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in cmps_x and cmps_y and cmps_z
+	SampleTimeOffset []uint16  // Array: [N]; Units: ms; Each time in the array describes the time at which the compass sample with the corresponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in cmps_x and cmps_y and cmps_z
 	MagX             []uint16  // Array: [N]; Units: counts; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
 	MagY             []uint16  // Array: [N]; Units: counts; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
 	MagZ             []uint16  // Array: [N]; Units: counts; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
@@ -157,7 +157,7 @@ func (m *MagnetometerData) SetTimestampMs(v uint16) *MagnetometerData {
 
 // SetSampleTimeOffset sets MagnetometerData value.
 //
-// Array: [N]; Units: ms; Each time in the array describes the time at which the compass sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in cmps_x and cmps_y and cmps_z
+// Array: [N]; Units: ms; Each time in the array describes the time at which the compass sample with the corresponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in cmps_x and cmps_y and cmps_z
 func (m *MagnetometerData) SetSampleTimeOffset(v []uint16) *MagnetometerData {
 	m.SampleTimeOffset = v
 	return m

--- a/profile/mesgdef/obdii_data_gen.go
+++ b/profile/mesgdef/obdii_data_gen.go
@@ -21,7 +21,7 @@ import (
 // Do not rely on field indices, such as when using reflection.
 type ObdiiData struct {
 	Timestamp        time.Time // Units: s; Timestamp message was output
-	TimeOffset       []uint16  // Array: [N]; Units: ms; Offset of PID reading [i] from start_timestamp+start_timestamp_ms. Readings may span accross seconds.
+	TimeOffset       []uint16  // Array: [N]; Units: ms; Offset of PID reading [i] from start_timestamp+start_timestamp_ms. Readings may span across seconds.
 	RawData          []byte    // Array: [N]; Raw parameter data
 	PidDataSize      []uint8   // Array: [N]; Optional, data size of PID[i]. If not specified refer to SAE J1979.
 	SystemTime       []uint32  // Array: [N]; System time associated with sample expressed in ms, can be used instead of time_offset. There will be a system_time value for each raw_data element. For multibyte pids the system_time is repeated.
@@ -160,7 +160,7 @@ func (m *ObdiiData) SetTimestampMs(v uint16) *ObdiiData {
 
 // SetTimeOffset sets ObdiiData value.
 //
-// Array: [N]; Units: ms; Offset of PID reading [i] from start_timestamp+start_timestamp_ms. Readings may span accross seconds.
+// Array: [N]; Units: ms; Offset of PID reading [i] from start_timestamp+start_timestamp_ms. Readings may span across seconds.
 func (m *ObdiiData) SetTimeOffset(v []uint16) *ObdiiData {
 	m.TimeOffset = v
 	return m

--- a/profile/mesgdef/record_gen.go
+++ b/profile/mesgdef/record_gen.go
@@ -59,7 +59,7 @@ type Record struct {
 	StanceTimePercent             uint16    // Scale: 100; Units: percent
 	StanceTime                    uint16    // Scale: 10; Units: ms
 	BallSpeed                     uint16    // Scale: 100; Units: m/s
-	Cadence256                    uint16    // Scale: 256; Units: rpm; Log cadence and fractional cadence for backwards compatability
+	Cadence256                    uint16    // Scale: 256; Units: rpm; Log cadence and fractional cadence for backwards compatibility
 	TotalHemoglobinConc           uint16    // Scale: 100; Units: g/dL; Total saturated and unsaturated hemoglobin
 	TotalHemoglobinConcMin        uint16    // Scale: 100; Units: g/dL; Min saturated and unsaturated hemoglobin
 	TotalHemoglobinConcMax        uint16    // Scale: 100; Units: g/dL; Max saturated and unsaturated hemoglobin
@@ -862,7 +862,7 @@ func (m *Record) BallSpeedScaled() float64 {
 	return scaleoffset.Apply(m.BallSpeed, 100, 0)
 }
 
-// Cadence256Scaled return Cadence256 in its scaled value [Scale: 256; Units: rpm; Log cadence and fractional cadence for backwards compatability].
+// Cadence256Scaled return Cadence256 in its scaled value [Scale: 256; Units: rpm; Log cadence and fractional cadence for backwards compatibility].
 //
 // If Cadence256 value is invalid, float64 invalid value will be returned.
 func (m *Record) Cadence256Scaled() float64 {
@@ -1460,7 +1460,7 @@ func (m *Record) SetBallSpeed(v uint16) *Record {
 
 // SetCadence256 sets Record value.
 //
-// Scale: 256; Units: rpm; Log cadence and fractional cadence for backwards compatability
+// Scale: 256; Units: rpm; Log cadence and fractional cadence for backwards compatibility
 func (m *Record) SetCadence256(v uint16) *Record {
 	m.Cadence256 = v
 	return m

--- a/profile/mesgdef/time_in_zone_gen.go
+++ b/profile/mesgdef/time_in_zone_gen.go
@@ -28,7 +28,7 @@ type TimeInZone struct {
 	TimeInPowerZone          []uint32  // Array: [N]; Scale: 1000; Units: s
 	HrZoneHighBoundary       []uint8   // Array: [N]; Units: bpm
 	SpeedZoneHighBoundary    []uint16  // Array: [N]; Scale: 1000; Units: m/s
-	CadenceZoneHighBondary   []uint8   // Array: [N]; Units: rpm
+	CadenceZoneHighBoundary  []uint8   // Array: [N]; Units: rpm
 	PowerZoneHighBoundary    []uint16  // Array: [N]; Units: watts
 	ReferenceMesg            typedef.MesgNum
 	ReferenceIndex           typedef.MessageIndex
@@ -70,7 +70,7 @@ func NewTimeInZone(mesg *proto.Message) *TimeInZone {
 		TimeInPowerZone:          vals[5].SliceUint32(),
 		HrZoneHighBoundary:       vals[6].SliceUint8(),
 		SpeedZoneHighBoundary:    vals[7].SliceUint16(),
-		CadenceZoneHighBondary:   vals[8].SliceUint8(),
+		CadenceZoneHighBoundary:  vals[8].SliceUint8(),
 		PowerZoneHighBoundary:    vals[9].SliceUint16(),
 		HrCalcType:               typedef.HrZoneCalc(vals[10].Uint8()),
 		MaxHeartRate:             vals[11].Uint8(),
@@ -144,9 +144,9 @@ func (m *TimeInZone) ToMesg(options *Options) proto.Message {
 		field.Value = proto.SliceUint16(m.SpeedZoneHighBoundary)
 		fields = append(fields, field)
 	}
-	if m.CadenceZoneHighBondary != nil {
+	if m.CadenceZoneHighBoundary != nil {
 		field := fac.CreateField(mesg.Num, 8)
-		field.Value = proto.SliceUint8(m.CadenceZoneHighBondary)
+		field.Value = proto.SliceUint8(m.CadenceZoneHighBoundary)
 		fields = append(fields, field)
 	}
 	if m.PowerZoneHighBoundary != nil {
@@ -314,11 +314,11 @@ func (m *TimeInZone) SetSpeedZoneHighBoundary(v []uint16) *TimeInZone {
 	return m
 }
 
-// SetCadenceZoneHighBondary sets TimeInZone value.
+// SetCadenceZoneHighBoundary sets TimeInZone value.
 //
 // Array: [N]; Units: rpm
-func (m *TimeInZone) SetCadenceZoneHighBondary(v []uint8) *TimeInZone {
-	m.CadenceZoneHighBondary = v
+func (m *TimeInZone) SetCadenceZoneHighBoundary(v []uint8) *TimeInZone {
+	m.CadenceZoneHighBoundary = v
 	return m
 }
 

--- a/profile/typedef/connectivity_capabilities_gen.go
+++ b/profile/typedef/connectivity_capabilities_gen.go
@@ -33,7 +33,7 @@ const (
 	ConnectivityCapabilitiesConnectIqWidgetDownload         ConnectivityCapabilities = 0x00020000
 	ConnectivityCapabilitiesConnectIqWatchFaceDownload      ConnectivityCapabilities = 0x00040000
 	ConnectivityCapabilitiesConnectIqDataFieldDownload      ConnectivityCapabilities = 0x00080000
-	ConnectivityCapabilitiesConnectIqAppManagment           ConnectivityCapabilities = 0x00100000 // Device supports delete and reorder of apps via GCM
+	ConnectivityCapabilitiesConnectIqAppManagement          ConnectivityCapabilities = 0x00100000 // Device supports delete and reorder of apps via GCM
 	ConnectivityCapabilitiesSwingSensor                     ConnectivityCapabilities = 0x00200000
 	ConnectivityCapabilitiesSwingSensorRemote               ConnectivityCapabilities = 0x00400000
 	ConnectivityCapabilitiesIncidentDetection               ConnectivityCapabilities = 0x00800000 // Device supports incident detection
@@ -92,8 +92,8 @@ func (c ConnectivityCapabilities) String() string {
 		return "connect_iq_watch_face_download"
 	case ConnectivityCapabilitiesConnectIqDataFieldDownload:
 		return "connect_iq_data_field_download"
-	case ConnectivityCapabilitiesConnectIqAppManagment:
-		return "connect_iq_app_managment"
+	case ConnectivityCapabilitiesConnectIqAppManagement:
+		return "connect_iq_app_management"
 	case ConnectivityCapabilitiesSwingSensor:
 		return "swing_sensor"
 	case ConnectivityCapabilitiesSwingSensorRemote:
@@ -164,8 +164,8 @@ func ConnectivityCapabilitiesFromString(s string) ConnectivityCapabilities {
 		return ConnectivityCapabilitiesConnectIqWatchFaceDownload
 	case "connect_iq_data_field_download":
 		return ConnectivityCapabilitiesConnectIqDataFieldDownload
-	case "connect_iq_app_managment":
-		return ConnectivityCapabilitiesConnectIqAppManagment
+	case "connect_iq_app_management":
+		return ConnectivityCapabilitiesConnectIqAppManagement
 	case "swing_sensor":
 		return ConnectivityCapabilitiesSwingSensor
 	case "swing_sensor_remote":
@@ -216,7 +216,7 @@ func ListConnectivityCapabilities() []ConnectivityCapabilities {
 		ConnectivityCapabilitiesConnectIqWidgetDownload,
 		ConnectivityCapabilitiesConnectIqWatchFaceDownload,
 		ConnectivityCapabilitiesConnectIqDataFieldDownload,
-		ConnectivityCapabilitiesConnectIqAppManagment,
+		ConnectivityCapabilitiesConnectIqAppManagement,
 		ConnectivityCapabilitiesSwingSensor,
 		ConnectivityCapabilitiesSwingSensorRemote,
 		ConnectivityCapabilitiesIncidentDetection,

--- a/profile/typedef/exd_data_units_gen.go
+++ b/profile/typedef/exd_data_units_gen.go
@@ -20,7 +20,7 @@ const (
 	ExdDataUnitsFeetPerHour                    ExdDataUnits = 4
 	ExdDataUnitsMetersPerHour                  ExdDataUnits = 5
 	ExdDataUnitsDegreesCelsius                 ExdDataUnits = 6
-	ExdDataUnitsDegreesFarenheit               ExdDataUnits = 7
+	ExdDataUnitsDegreesFahrenheit              ExdDataUnits = 7
 	ExdDataUnitsZone                           ExdDataUnits = 8
 	ExdDataUnitsGear                           ExdDataUnits = 9
 	ExdDataUnitsRpm                            ExdDataUnits = 10
@@ -84,8 +84,8 @@ func (e ExdDataUnits) String() string {
 		return "meters_per_hour"
 	case ExdDataUnitsDegreesCelsius:
 		return "degrees_celsius"
-	case ExdDataUnitsDegreesFarenheit:
-		return "degrees_farenheit"
+	case ExdDataUnitsDegreesFahrenheit:
+		return "degrees_fahrenheit"
 	case ExdDataUnitsZone:
 		return "zone"
 	case ExdDataUnitsGear:
@@ -192,8 +192,8 @@ func ExdDataUnitsFromString(s string) ExdDataUnits {
 		return ExdDataUnitsMetersPerHour
 	case "degrees_celsius":
 		return ExdDataUnitsDegreesCelsius
-	case "degrees_farenheit":
-		return ExdDataUnitsDegreesFarenheit
+	case "degrees_fahrenheit":
+		return ExdDataUnitsDegreesFahrenheit
 	case "zone":
 		return ExdDataUnitsZone
 	case "gear":
@@ -293,7 +293,7 @@ func ListExdDataUnits() []ExdDataUnits {
 		ExdDataUnitsFeetPerHour,
 		ExdDataUnitsMetersPerHour,
 		ExdDataUnitsDegreesCelsius,
-		ExdDataUnitsDegreesFarenheit,
+		ExdDataUnitsDegreesFahrenheit,
 		ExdDataUnitsZone,
 		ExdDataUnitsGear,
 		ExdDataUnitsRpm,

--- a/profile/untyped/fieldnum/fieldnum_gen.go
+++ b/profile/untyped/fieldnum/fieldnum_gen.go
@@ -29,7 +29,7 @@ const (
 	AccelerometerDataCompressedCalibratedAccelX       = 8   // [ AccelerometerData ] [Type: Sint16, Base: sint16, Array: [N], Units: mG]; Calibrated accel reading
 	AccelerometerDataCompressedCalibratedAccelY       = 9   // [ AccelerometerData ] [Type: Sint16, Base: sint16, Array: [N], Units: mG]; Calibrated accel reading
 	AccelerometerDataCompressedCalibratedAccelZ       = 10  // [ AccelerometerData ] [Type: Sint16, Base: sint16, Array: [N], Units: mG]; Calibrated accel reading
-	AccelerometerDataSampleTimeOffset                 = 1   // [ AccelerometerData ] [Type: Uint16, Base: uint16, Array: [N], Units: ms]; Each time in the array describes the time at which the accelerometer sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in accel_x and accel_y and accel_z
+	AccelerometerDataSampleTimeOffset                 = 1   // [ AccelerometerData ] [Type: Uint16, Base: uint16, Array: [N], Units: ms]; Each time in the array describes the time at which the accelerometer sample with the corresponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in accel_x and accel_y and accel_z
 	AccelerometerDataTimestamp                        = 253 // [ AccelerometerData ] [Type: DateTime, Base: uint32, Units: s]; Whole second part of the timestamp
 	AccelerometerDataTimestampMs                      = 0   // [ AccelerometerData ] [Type: Uint16, Base: uint16, Units: ms]; Millisecond part of the timestamp.
 	ActivityEvent                                     = 3   // [ Activity ] [Type: Event, Base: enum];
@@ -70,7 +70,7 @@ const (
 	AviationAttitudeTurnRate                          = 6   // [ AviationAttitude ] [Type: Sint16, Base: sint16, Array: [N], Scale: 1024, Offset: 0, Units: radians/second]; Range -8.727 to +8.727 (-500 degs/sec to +500 degs/sec)
 	AviationAttitudeValidity                          = 10  // [ AviationAttitude ] [Type: AttitudeValidity, Base: uint16, Array: [N]];
 	BarometerDataBaroPres                             = 2   // [ BarometerData ] [Type: Uint32, Base: uint32, Array: [N], Units: Pa]; These are the raw ADC reading. The samples may span across seconds. A conversion will need to be done on this data once read.
-	BarometerDataSampleTimeOffset                     = 1   // [ BarometerData ] [Type: Uint16, Base: uint16, Array: [N], Units: ms]; Each time in the array describes the time at which the barometer sample with the corrosponding index was taken. The samples may span across seconds. Array size must match the number of samples in baro_cal
+	BarometerDataSampleTimeOffset                     = 1   // [ BarometerData ] [Type: Uint16, Base: uint16, Array: [N], Units: ms]; Each time in the array describes the time at which the barometer sample with the corresponding index was taken. The samples may span across seconds. Array size must match the number of samples in baro_cal
 	BarometerDataTimestamp                            = 253 // [ BarometerData ] [Type: DateTime, Base: uint32, Units: s]; Whole second part of the timestamp
 	BarometerDataTimestampMs                          = 0   // [ BarometerData ] [Type: Uint16, Base: uint16, Units: ms]; Millisecond part of the timestamp.
 	BeatIntervalsTime                                 = 1   // [ BeatIntervals ] [Type: Uint16, Base: uint16, Array: [N], Units: ms]; Array of millisecond times between beats
@@ -421,7 +421,7 @@ const (
 	GyroscopeDataGyroX                                = 2   // [ GyroscopeData ] [Type: Uint16, Base: uint16, Array: [N], Units: counts]; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
 	GyroscopeDataGyroY                                = 3   // [ GyroscopeData ] [Type: Uint16, Base: uint16, Array: [N], Units: counts]; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
 	GyroscopeDataGyroZ                                = 4   // [ GyroscopeData ] [Type: Uint16, Base: uint16, Array: [N], Units: counts]; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
-	GyroscopeDataSampleTimeOffset                     = 1   // [ GyroscopeData ] [Type: Uint16, Base: uint16, Array: [N], Units: ms]; Each time in the array describes the time at which the gyro sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in gyro_x and gyro_y and gyro_z
+	GyroscopeDataSampleTimeOffset                     = 1   // [ GyroscopeData ] [Type: Uint16, Base: uint16, Array: [N], Units: ms]; Each time in the array describes the time at which the gyro sample with the corresponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in gyro_x and gyro_y and gyro_z
 	GyroscopeDataTimestamp                            = 253 // [ GyroscopeData ] [Type: DateTime, Base: uint32, Units: s]; Whole second part of the timestamp
 	GyroscopeDataTimestampMs                          = 0   // [ GyroscopeData ] [Type: Uint16, Base: uint16, Units: ms]; Millisecond part of the timestamp.
 	HrEventTimestamp                                  = 9   // [ Hr ] [Type: Uint32, Base: uint32, Array: [N], Scale: 1024, Offset: 0, Units: s];
@@ -654,7 +654,7 @@ const (
 	MagnetometerDataMagX                              = 2   // [ MagnetometerData ] [Type: Uint16, Base: uint16, Array: [N], Units: counts]; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
 	MagnetometerDataMagY                              = 3   // [ MagnetometerData ] [Type: Uint16, Base: uint16, Array: [N], Units: counts]; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
 	MagnetometerDataMagZ                              = 4   // [ MagnetometerData ] [Type: Uint16, Base: uint16, Array: [N], Units: counts]; These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.
-	MagnetometerDataSampleTimeOffset                  = 1   // [ MagnetometerData ] [Type: Uint16, Base: uint16, Array: [N], Units: ms]; Each time in the array describes the time at which the compass sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in cmps_x and cmps_y and cmps_z
+	MagnetometerDataSampleTimeOffset                  = 1   // [ MagnetometerData ] [Type: Uint16, Base: uint16, Array: [N], Units: ms]; Each time in the array describes the time at which the compass sample with the corresponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in cmps_x and cmps_y and cmps_z
 	MagnetometerDataTimestamp                         = 253 // [ MagnetometerData ] [Type: DateTime, Base: uint32, Units: s]; Whole second part of the timestamp
 	MagnetometerDataTimestampMs                       = 0   // [ MagnetometerData ] [Type: Uint16, Base: uint16, Units: ms]; Millisecond part of the timestamp.
 	MaxMetDataCalibratedData                          = 9   // [ MaxMetData ] [Type: Bool, Base: bool | enum]; Indicates if calibrated data was used in the calculation
@@ -727,7 +727,7 @@ const (
 	ObdiiDataStartTimestamp                           = 6   // [ ObdiiData ] [Type: DateTime, Base: uint32]; Timestamp of first sample recorded in the message. Used with time_offset to generate time of each sample
 	ObdiiDataStartTimestampMs                         = 7   // [ ObdiiData ] [Type: Uint16, Base: uint16, Units: ms]; Fractional part of start_timestamp
 	ObdiiDataSystemTime                               = 5   // [ ObdiiData ] [Type: Uint32, Base: uint32, Array: [N]]; System time associated with sample expressed in ms, can be used instead of time_offset. There will be a system_time value for each raw_data element. For multibyte pids the system_time is repeated.
-	ObdiiDataTimeOffset                               = 1   // [ ObdiiData ] [Type: Uint16, Base: uint16, Array: [N], Units: ms]; Offset of PID reading [i] from start_timestamp+start_timestamp_ms. Readings may span accross seconds.
+	ObdiiDataTimeOffset                               = 1   // [ ObdiiData ] [Type: Uint16, Base: uint16, Array: [N], Units: ms]; Offset of PID reading [i] from start_timestamp+start_timestamp_ms. Readings may span across seconds.
 	ObdiiDataTimestamp                                = 253 // [ ObdiiData ] [Type: DateTime, Base: uint32, Units: s]; Timestamp message was output
 	ObdiiDataTimestampMs                              = 0   // [ ObdiiData ] [Type: Uint16, Base: uint16, Units: ms]; Fractional part of timestamp, added to timestamp
 	OhrSettingsEnabled                                = 0   // [ OhrSettings ] [Type: Switch, Base: enum];
@@ -756,7 +756,7 @@ const (
 	RecordBallSpeed                                   = 51  // [ Record ] [Type: Uint16, Base: uint16, Scale: 100, Offset: 0, Units: m/s];
 	RecordBatterySoc                                  = 81  // [ Record ] [Type: Uint8, Base: uint8, Scale: 2, Offset: 0, Units: percent]; lev battery state of charge
 	RecordCadence                                     = 4   // [ Record ] [Type: Uint8, Base: uint8, Units: rpm];
-	RecordCadence256                                  = 52  // [ Record ] [Type: Uint16, Base: uint16, Scale: 256, Offset: 0, Units: rpm]; Log cadence and fractional cadence for backwards compatability
+	RecordCadence256                                  = 52  // [ Record ] [Type: Uint16, Base: uint16, Scale: 256, Offset: 0, Units: rpm]; Log cadence and fractional cadence for backwards compatibility
 	RecordCalories                                    = 33  // [ Record ] [Type: Uint16, Base: uint16, Units: kcal];
 	RecordCnsLoad                                     = 97  // [ Record ] [Type: Uint8, Base: uint8, Units: percent];
 	RecordCombinedPedalSmoothness                     = 47  // [ Record ] [Type: Uint8, Base: uint8, Scale: 2, Offset: 0, Units: percent];
@@ -1221,7 +1221,7 @@ const (
 	ThreeDSensorCalibrationOrientationMatrix          = 5   // [ ThreeDSensorCalibration ] [Type: Sint32, Base: sint32, Array: [9], Scale: 65535, Offset: 0]; 3 x 3 rotation matrix (row major)
 	ThreeDSensorCalibrationSensorType                 = 0   // [ ThreeDSensorCalibration ] [Type: SensorType, Base: enum]; Indicates which sensor the calibration is for
 	ThreeDSensorCalibrationTimestamp                  = 253 // [ ThreeDSensorCalibration ] [Type: DateTime, Base: uint32, Units: s]; Whole second part of the timestamp
-	TimeInZoneCadenceZoneHighBondary                  = 8   // [ TimeInZone ] [Type: Uint8, Base: uint8, Array: [N], Units: rpm];
+	TimeInZoneCadenceZoneHighBoundary                 = 8   // [ TimeInZone ] [Type: Uint8, Base: uint8, Array: [N], Units: rpm];
 	TimeInZoneFunctionalThresholdPower                = 15  // [ TimeInZone ] [Type: Uint16, Base: uint16];
 	TimeInZoneHrCalcType                              = 10  // [ TimeInZone ] [Type: HrZoneCalc, Base: enum];
 	TimeInZoneHrZoneHighBoundary                      = 6   // [ TimeInZone ] [Type: Uint8, Base: uint8, Array: [N], Units: bpm];


### PR DESCRIPTION
`Profile.xlsx` is containing misspell such as:
Types:
- "connect_iq_app_managment" -> "managment" is a misspelling of "management"
- "degrees_farenheit" -> "farenheit" is a misspelling of "fahrenheit"

Messages:
- "cadence_zone_high_bondary" -> "bondary" is a misspelling of "boundary"

This cause misspelling issues on our generated code, this could lead to breaking our SDK since we rely on the `Profile.xlsx`, for example:
- "connect_iq_app_managment" will genenate constant `ConnectivityCapabilitiesConnectIqAppManagment`, when Garmin fixes the `Profile.xlsx` the spelling issue, the generated constant will be changed to `ConnectivityCapabilitiesConnectIqAppManagement`. When users use the constant in some versions, their code will break on newer version after the update. We should avoid this kind of inconsistent by fixing the misspell before generating code so we get consistent output regardless how Garmin define it the `Profile.xlsx`.

This change does not affect how our FIT SDK works, however this affect `fitconv` CLI program:
- We don't know how the official SDK handle the misspell, in case they generating their SDK solely based on `Profile.xlsx`, CSVs produced by their tool may contains misspell issue as well. In such cases, when we convert those CSVs into FIT files using our fitconv, Field with misspelled name will be treated as unknown field.

NOTE: `fitgen`'s parser will always print the misspell found to stdout so we can verify that the replacement string is correct. We must verify the Github Action's log when generating code using CI.