### PR TITLE
cli: update fitconv

### DIFF
--- a/cmd/fitconv/README.md
+++ b/cmd/fitconv/README.md
@@ -24,17 +24,17 @@ ls
 
 ### Options
 
-| Options    | Valid For       | Description                                            |
-| ---------- | --------------- | ------------------------------------------------------ |
-| -v         | All             | Show version                                           |
-| -disk      | FIT to CSV only | Use disk instead of load everything in memory          |
-| -unknown   | FIT to CSV only | Print 'unknown(68)' instead of 'unknown'               |
-| -valid     | FIT to CSV only | Print only valid value and omit invalid value          |
-| -raw       | FIT to CSV only | Use raw value instead of scaled value                  |
-| -deg       | FIT to CSV only | Print GPS Positions in degrees instead of semicircles. |
-| -trim      | FIT to CSV only | Trim trailing commas in every line (save storage)      |
-| -no-expand | FIT to CSV only | [Decode Option] Do not expand components               |
-| -checksum  | FIT to CSV only | [Decode Option] Do CRC checksum to ensure integrity    |
+| Options      | Valid For       | Description                                              |
+| ------------ | --------------- | -------------------------------------------------------- |
+| -v           | All             | Show version                                             |
+| -disk        | FIT to CSV only | Use disk instead of load everything in memory            |
+| -unknown     | FIT to CSV only | Print 'unknown(68)' instead of 'unknown'                 |
+| -valid       | FIT to CSV only | Print only valid value and omit invalid value            |
+| -raw         | FIT to CSV only | Use raw value instead of scaled value                    |
+| -deg         | FIT to CSV only | Print GPS Positions in degrees instead of semicircles.   |
+| -trim        | FIT to CSV only | Trim trailing commas in every line (save storage)        |
+| -no-expand   | FIT to CSV only | [Decode Option] Do not expand components                 |
+| -no-checksum | FIT to CSV only | [Decode Option] Do not check integrity (no CRC checksum) |
 
 ```sh
 go run main.go -deg activity.fit activity2.fit

--- a/cmd/fitconv/main.go
+++ b/cmd/fitconv/main.go
@@ -53,8 +53,8 @@ func main() {
 	var flagNoExpandComponents bool
 	flag.BoolVar(&flagNoExpandComponents, "no-expand", false, "[Decode Option] Do not expand components")
 
-	var flagShouldChecksum bool
-	flag.BoolVar(&flagShouldChecksum, "checksum", false, "[Decode Option] should do crc checksum")
+	var flagNoChecksum bool
+	flag.BoolVar(&flagNoChecksum, "no-checksum", false, "[Decode Option] should not do crc checksum")
 
 	flag.Parse()
 
@@ -109,7 +109,7 @@ func main() {
 	if flagNoExpandComponents {
 		decoderOptions = append(decoderOptions, decoder.WithNoComponentExpansion())
 	}
-	if !flagShouldChecksum {
+	if flagNoChecksum {
 		decoderOptions = append(decoderOptions, decoder.WithIgnoreChecksum())
 	}
 


### PR DESCRIPTION
revert `fitconv` behavior regarding calculating checksum, it should do checksum by default just like before. If users want to convert to CSV regardless the integrity, `-no-checksum` flag is now provided. `-checksum` flag is removed. This way, we don't change users' expectation regarding the integrity of the decoded CSV files. We rarely use FIT files that does not have integrity except we try to recover a corrupted FIT files.