### PR TITLE
perf: improve marshal and unmarshal slice value

### DIFF
--- a/proto/value_marshal.go
+++ b/proto/value_marshal.go
@@ -59,10 +59,12 @@ func (v Value) MarshalAppend(b []byte, arch byte) ([]byte, error) {
 		return b, nil
 	case TypeSliceUint16:
 		vals := v.SliceUint16()
-		for i := range vals {
-			if arch == littleEndian {
+		if arch == littleEndian {
+			for i := range vals {
 				b = binary.LittleEndian.AppendUint16(b, uint16(vals[i]))
-			} else {
+			}
+		} else {
+			for i := range vals {
 				b = binary.BigEndian.AppendUint16(b, uint16(vals[i]))
 			}
 		}
@@ -76,10 +78,12 @@ func (v Value) MarshalAppend(b []byte, arch byte) ([]byte, error) {
 		return b, nil
 	case TypeSliceInt16:
 		vals := v.SliceInt16()
-		for i := range vals {
-			if arch == littleEndian {
+		if arch == littleEndian {
+			for i := range vals {
 				b = binary.LittleEndian.AppendUint16(b, uint16(vals[i]))
-			} else {
+			}
+		} else {
+			for i := range vals {
 				b = binary.BigEndian.AppendUint16(b, uint16(vals[i]))
 			}
 		}
@@ -93,10 +97,12 @@ func (v Value) MarshalAppend(b []byte, arch byte) ([]byte, error) {
 		return b, nil
 	case TypeSliceInt32:
 		vals := v.SliceInt32()
-		for i := range vals {
-			if arch == littleEndian {
+		if arch == littleEndian {
+			for i := range vals {
 				b = binary.LittleEndian.AppendUint32(b, uint32(vals[i]))
-			} else {
+			}
+		} else {
+			for i := range vals {
 				b = binary.BigEndian.AppendUint32(b, uint32(vals[i]))
 			}
 		}
@@ -110,10 +116,12 @@ func (v Value) MarshalAppend(b []byte, arch byte) ([]byte, error) {
 		return b, nil
 	case TypeSliceUint32:
 		vals := v.SliceUint32()
-		for i := range vals {
-			if arch == littleEndian {
+		if arch == littleEndian {
+			for i := range vals {
 				b = binary.LittleEndian.AppendUint32(b, vals[i])
-			} else {
+			}
+		} else {
+			for i := range vals {
 				b = binary.BigEndian.AppendUint32(b, vals[i])
 			}
 		}
@@ -127,10 +135,12 @@ func (v Value) MarshalAppend(b []byte, arch byte) ([]byte, error) {
 		return b, nil
 	case TypeSliceInt64:
 		vals := v.SliceInt64()
-		for i := range vals {
-			if arch == littleEndian {
+		if arch == littleEndian {
+			for i := range vals {
 				b = binary.LittleEndian.AppendUint64(b, uint64(vals[i]))
-			} else {
+			}
+		} else {
+			for i := range vals {
 				b = binary.BigEndian.AppendUint64(b, uint64(vals[i]))
 			}
 		}
@@ -144,10 +154,12 @@ func (v Value) MarshalAppend(b []byte, arch byte) ([]byte, error) {
 		return b, nil
 	case TypeSliceUint64:
 		vals := v.SliceUint64()
-		for i := range vals {
-			if arch == littleEndian {
+		if arch == littleEndian {
+			for i := range vals {
 				b = binary.LittleEndian.AppendUint64(b, vals[i])
-			} else {
+			}
+		} else {
+			for i := range vals {
 				b = binary.BigEndian.AppendUint64(b, vals[i])
 			}
 		}
@@ -161,10 +173,12 @@ func (v Value) MarshalAppend(b []byte, arch byte) ([]byte, error) {
 		return b, nil
 	case TypeSliceFloat32:
 		vals := v.SliceFloat32()
-		for i := range vals {
-			if arch == littleEndian {
+		if arch == littleEndian {
+			for i := range vals {
 				b = binary.LittleEndian.AppendUint32(b, math.Float32bits(vals[i]))
-			} else {
+			}
+		} else {
+			for i := range vals {
 				b = binary.BigEndian.AppendUint32(b, math.Float32bits(vals[i]))
 			}
 		}
@@ -178,10 +192,12 @@ func (v Value) MarshalAppend(b []byte, arch byte) ([]byte, error) {
 		return b, nil
 	case TypeSliceFloat64:
 		vals := v.SliceFloat64()
-		for i := range vals {
-			if arch == littleEndian {
+		if arch == littleEndian {
+			for i := range vals {
 				b = binary.LittleEndian.AppendUint64(b, math.Float64bits(vals[i]))
-			} else {
+			}
+		} else {
+			for i := range vals {
 				b = binary.BigEndian.AppendUint64(b, math.Float64bits(vals[i]))
 			}
 		}

--- a/proto/value_marshal_test.go
+++ b/proto/value_marshal_test.go
@@ -154,3 +154,14 @@ func marshalValueWithReflectionForTest(w io.Writer, value Value, arch byte) erro
 	}
 	return binary.Write(w, binary.BigEndian, rv.Interface())
 }
+
+func BenchmarkValueMarshalAppend(b *testing.B) {
+	b.StopTimer()
+	value := SliceUint16(make([]uint16, 256/2))
+	buf := make([]byte, 0, 256)
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = value.MarshalAppend(buf, littleEndian)
+	}
+}

--- a/proto/value_unmarshal.go
+++ b/proto/value_unmarshal.go
@@ -21,22 +21,22 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 	switch baseType {
 	case basetype.Sint8:
 		if isArray {
-			vs := make([]int8, 0, len(b))
-			for i := 0; i < len(b); i++ {
-				vs = append(vs, int8(b[i]))
+			vals := make([]int8, 0, len(b))
+			for i := range b {
+				vals = append(vals, int8(b[i]))
 			}
-			return SliceInt8(vs), nil
+			return SliceInt8(vals), nil
 		}
 		return Int8(int8(b[0])), nil
 	case basetype.Enum, basetype.Byte,
 		basetype.Uint8, basetype.Uint8z:
 		if profileType == profile.Bool { // Special Case
 			if isArray {
-				vs := make([]bool, 0, len(b))
-				for i := 0; i < len(b); i++ {
-					vs = append(vs, b[i] == 1)
+				vals := make([]bool, 0, len(b))
+				for i := range b {
+					vals = append(vals, b[i] == 1)
 				}
-				return SliceBool(vs), nil
+				return SliceBool(vals), nil
 			}
 			return Bool(b[0] == 1), nil
 		}
@@ -49,15 +49,17 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 	case basetype.Sint16:
 		if isArray {
 			const n = 2
-			vs := make([]int16, 0, size(len(b), n))
-			for ; len(b) >= n; b = b[n:] {
-				if arch == littleEndian {
-					vs = append(vs, int16(binary.LittleEndian.Uint16(b[:n])))
-				} else {
-					vs = append(vs, int16(binary.BigEndian.Uint16(b[:n])))
+			vals := make([]int16, 0, size(len(b), n))
+			if arch == littleEndian {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, int16(binary.LittleEndian.Uint16(b[:n])))
+				}
+			} else {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, int16(binary.BigEndian.Uint16(b[:n])))
 				}
 			}
-			return SliceInt16(vs), nil
+			return SliceInt16(vals), nil
 		}
 		if arch == littleEndian {
 			return Int16(int16(binary.LittleEndian.Uint16(b))), nil
@@ -66,15 +68,17 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 	case basetype.Uint16, basetype.Uint16z:
 		if isArray {
 			const n = 2
-			vs := make([]uint16, 0, size(len(b), n))
-			for ; len(b) >= n; b = b[n:] {
-				if arch == littleEndian {
-					vs = append(vs, binary.LittleEndian.Uint16(b[:n]))
-				} else {
-					vs = append(vs, binary.BigEndian.Uint16(b[:n]))
+			vals := make([]uint16, 0, size(len(b), n))
+			if arch == littleEndian {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, binary.LittleEndian.Uint16(b[:n]))
+				}
+			} else {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, binary.BigEndian.Uint16(b[:n]))
 				}
 			}
-			return SliceUint16(vs), nil
+			return SliceUint16(vals), nil
 		}
 		if arch == littleEndian {
 			return Uint16(binary.LittleEndian.Uint16(b)), nil
@@ -83,15 +87,17 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 	case basetype.Sint32:
 		if isArray {
 			const n = 4
-			vs := make([]int32, 0, size(len(b), n))
-			for ; len(b) >= n; b = b[n:] {
-				if arch == littleEndian {
-					vs = append(vs, int32(binary.LittleEndian.Uint32(b[:n])))
-				} else {
-					vs = append(vs, int32(binary.BigEndian.Uint32(b[:n])))
+			vals := make([]int32, 0, size(len(b), n))
+			if arch == littleEndian {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, int32(binary.LittleEndian.Uint32(b[:n])))
+				}
+			} else {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, int32(binary.BigEndian.Uint32(b[:n])))
 				}
 			}
-			return SliceInt32(vs), nil
+			return SliceInt32(vals), nil
 		}
 		if arch == littleEndian {
 			return Int32(int32(binary.LittleEndian.Uint32(b))), nil
@@ -100,15 +106,17 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 	case basetype.Uint32, basetype.Uint32z:
 		if isArray {
 			const n = 4
-			vs := make([]uint32, 0, size(len(b), n))
-			for ; len(b) >= n; b = b[n:] {
-				if arch == littleEndian {
-					vs = append(vs, binary.LittleEndian.Uint32(b[:n]))
-				} else {
-					vs = append(vs, binary.BigEndian.Uint32(b[:n]))
+			vals := make([]uint32, 0, size(len(b), n))
+			if arch == littleEndian {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, binary.LittleEndian.Uint32(b[:n]))
+				}
+			} else {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, binary.BigEndian.Uint32(b[:n]))
 				}
 			}
-			return SliceUint32(vs), nil
+			return SliceUint32(vals), nil
 		}
 		if arch == littleEndian {
 			return Uint32(binary.LittleEndian.Uint32(b)), nil
@@ -117,15 +125,17 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 	case basetype.Sint64:
 		if isArray {
 			const n = 8
-			vs := make([]int64, 0, size(len(b), n))
-			for ; len(b) >= n; b = b[n:] {
-				if arch == littleEndian {
-					vs = append(vs, int64(binary.LittleEndian.Uint64(b[:n])))
-				} else {
-					vs = append(vs, int64(binary.BigEndian.Uint64(b[:n])))
+			vals := make([]int64, 0, size(len(b), n))
+			if arch == littleEndian {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, int64(binary.LittleEndian.Uint64(b[:n])))
+				}
+			} else {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, int64(binary.BigEndian.Uint64(b[:n])))
 				}
 			}
-			return SliceInt64(vs), nil
+			return SliceInt64(vals), nil
 		}
 		if arch == littleEndian {
 			return Int64(int64(binary.LittleEndian.Uint64(b))), nil
@@ -134,15 +144,17 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 	case basetype.Uint64, basetype.Uint64z:
 		if isArray {
 			const n = 8
-			vs := make([]uint64, 0, size(len(b), n))
-			for ; len(b) >= n; b = b[n:] {
-				if arch == littleEndian {
-					vs = append(vs, binary.LittleEndian.Uint64(b[:n]))
-				} else {
-					vs = append(vs, binary.BigEndian.Uint64(b[:n]))
+			vals := make([]uint64, 0, size(len(b), n))
+			if arch == littleEndian {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, binary.LittleEndian.Uint64(b[:n]))
+				}
+			} else {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, binary.BigEndian.Uint64(b[:n]))
 				}
 			}
-			return SliceUint64(vs), nil
+			return SliceUint64(vals), nil
 		}
 		if arch == littleEndian {
 			return Uint64(binary.LittleEndian.Uint64(b)), nil
@@ -151,15 +163,17 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 	case basetype.Float32:
 		if isArray {
 			const n = 4
-			vs := make([]float32, 0, size(len(b), n))
-			for ; len(b) >= n; b = b[n:] {
-				if arch == littleEndian {
-					vs = append(vs, math.Float32frombits(binary.LittleEndian.Uint32(b[:n])))
-				} else {
-					vs = append(vs, math.Float32frombits(binary.BigEndian.Uint32(b[:n])))
+			vals := make([]float32, 0, size(len(b), n))
+			if arch == littleEndian {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, math.Float32frombits(binary.LittleEndian.Uint32(b[:n])))
+				}
+			} else {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, math.Float32frombits(binary.BigEndian.Uint32(b[:n])))
 				}
 			}
-			return SliceFloat32(vs), nil
+			return SliceFloat32(vals), nil
 		}
 		if arch == littleEndian {
 			return Float32(math.Float32frombits(binary.LittleEndian.Uint32(b))), nil
@@ -168,15 +182,17 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 	case basetype.Float64:
 		if isArray {
 			const n = 8
-			vs := make([]float64, 0, size(len(b), n))
-			for ; len(b) >= n; b = b[n:] {
-				if arch == littleEndian {
-					vs = append(vs, math.Float64frombits(binary.LittleEndian.Uint64(b[:n])))
-				} else {
-					vs = append(vs, math.Float64frombits(binary.BigEndian.Uint64(b[:n])))
+			vals := make([]float64, 0, size(len(b), n))
+			if arch == littleEndian {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, math.Float64frombits(binary.LittleEndian.Uint64(b[:n])))
+				}
+			} else {
+				for ; len(b) >= n; b = b[n:] {
+					vals = append(vals, math.Float64frombits(binary.BigEndian.Uint64(b[:n])))
 				}
 			}
-			return SliceFloat64(vs), nil
+			return SliceFloat64(vals), nil
 		}
 		if arch == littleEndian {
 			return Float64(math.Float64frombits(binary.LittleEndian.Uint64(b))), nil
@@ -195,16 +211,16 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 				}
 			}
 			last = 0
-			vs := make([]string, 0, size)
+			vals := make([]string, 0, size)
 			for i := range b {
 				if b[i] == '\x00' {
 					if last != i { // only if not an invalid string
-						vs = append(vs, utf8String(b[last:i]))
+						vals = append(vals, utf8String(b[last:i]))
 					}
 					last = i + 1
 				}
 			}
-			return SliceString(vs), nil
+			return SliceString(vals), nil
 		}
 		b = trimUTF8NullTerminatedString(b)
 		return String(utf8String(b)), nil


### PR DESCRIPTION
Sample Benchmark:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/proto
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                     │ valueold.txt │             valuenew.txt             │
                     │    sec/op    │    sec/op     vs base                │
ValueMarshalAppend-4    160.8n ± 4%   100.9n ± 12%  -37.27% (p=0.000 n=10)

                     │ valueold.txt │          valuenew.txt          │
                     │     B/op     │    B/op     vs base            │
ValueMarshalAppend-4     0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                     │ valueold.txt │          valuenew.txt          │
                     │  allocs/op   │ allocs/op   vs base            │
ValueMarshalAppend-4     0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```