### PR TITLE
fix: decoder on handling developer data and other improvements

### DIFF
--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -2023,6 +2023,7 @@ func TestDecodeDeveloperFields(t *testing.T) {
 	tt := []struct {
 		name             string
 		r                io.Reader
+		developerDataIds []*mesgdef.DeveloperDataId
 		fieldDescription *mesgdef.FieldDescription
 		mesgDef          *proto.MessageDefinition
 		mesg             *proto.Message
@@ -2032,6 +2033,14 @@ func TestDecodeDeveloperFields(t *testing.T) {
 		{
 			name: "decode developer fields happy flow",
 			r:    fnReaderOK,
+			developerDataIds: []*mesgdef.DeveloperDataId{
+				mesgdef.NewDeveloperDataId(nil).
+					SetApplicationId([]byte{0, 0, 0, 1}).
+					SetDeveloperDataIndex(1), // not used, just to pass code logic
+				mesgdef.NewDeveloperDataId(nil).
+					SetApplicationId([]byte{0, 0, 0, 1}).
+					SetDeveloperDataIndex(0),
+			},
 			fieldDescription: mesgdef.NewFieldDescription(
 				kit.Ptr(factory.CreateMesgOnly(mesgnum.FieldDescription).WithFields(
 					factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionDeveloperDataIndex).WithValue(uint8(0)),
@@ -2056,7 +2065,7 @@ func TestDecodeDeveloperFields(t *testing.T) {
 			mesg: &proto.Message{},
 		},
 		{
-			name: "decode developer fields missing developer data index 1",
+			name: "decode developer fields missing fieldDescription with developer data index 1",
 			r:    fnReaderOK,
 			fieldDescription: mesgdef.NewFieldDescription(
 				kit.Ptr(factory.CreateMesgOnly(mesgnum.FieldDescription).WithFields(
@@ -2262,6 +2271,9 @@ func TestDecodeDeveloperFields(t *testing.T) {
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
 			dec := New(tc.r)
+			if tc.developerDataIds != nil {
+				dec.developerDataIds = append(dec.developerDataIds, tc.developerDataIds...)
+			}
 			dec.fieldDescriptions = append(dec.fieldDescriptions, tc.fieldDescription)
 			err := dec.decodeDeveloperFields(tc.mesgDef, tc.mesg)
 			if !errors.Is(err, tc.err) {


### PR DESCRIPTION
- When developer data does not have DeveloperDataId reference, the decoder will try to write log to notify users that the decoder FIT file missing DeveloperDataId (he decoder will only log when logWriter is specified though). From the beginning, the decoder only using FieldDescription messages to decode the developer data, so the data can still be retrieved without error, however having the log as notification can help users debug the FIT file.
- Make decodeFileHeaderOnce func into method, this way we avoid one allocation and simplifying our code.
- Re-arrange decoder's methods order for readability, easier to maintain.
- Decoder will no longer call proto.LocalMesgNum, instead the code logic is copied directly to decoder to avoid bounds check, since compiler could not ensure that the value returned by proto.LocalMesgNum func is in bounds with the `d.localMessageDefinitions` array.
- Copy mesg.Fields will now use slices.Clone to ensure we got the correct data even if mesg.Fields (backed by d.fieldsArray) is mutating due to components expansion. The 255 fields size guarantee is only the fields retrieved directly from the FIT Protocol before the components expansion so the resulting value is allowed to be more than that even if in practice we have not encounter the issue regarding this . Using slices.Clone will also reduce boiler plates as well since it handle the copy nicely (nil value is also handled).
- Remove the pointer item in `d.developerDataIds` and `d.fieldDescriptions` on reset to avoid memory leaks.