### PR TITLE
chore: make all sentinel errors constant

### DIFF
--- a/cmd/fitactivity/combiner/combiner.go
+++ b/cmd/fitactivity/combiner/combiner.go
@@ -5,7 +5,6 @@
 package combiner
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/muktihari/fit/factory"
@@ -18,10 +17,14 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var (
-	ErrMinimalCombine = errors.New("minimal combine")
-	ErrNoSessionFound = errors.New("no session found")
-	ErrSportMismatch  = errors.New("sport mismatch")
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
+const (
+	ErrMinimalCombine = errorString("minimal combine")
+	ErrNoSessionFound = errorString("no session found")
+	ErrSportMismatch  = errorString("sport mismatch")
 )
 
 func Combine(fits ...proto.FIT) (*proto.FIT, error) {

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -7,7 +7,6 @@ package decoder
 import (
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -26,16 +25,20 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var (
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
+const (
 	// Integrity errors
-	ErrNotAFitFile         = errors.New("not a FIT file")
-	ErrDataSizeZero        = errors.New("data size zero")
-	ErrCRCChecksumMismatch = errors.New("crc checksum mismatch")
+	ErrNotAFitFile         = errorString("not a FIT file")
+	ErrDataSizeZero        = errorString("data size zero")
+	ErrCRCChecksumMismatch = errorString("crc checksum mismatch")
 
 	// Message-field related errors
-	ErrMesgDefMissing         = errors.New("message definition missing")
-	ErrFieldValueTypeMismatch = errors.New("field value type mismatch")
-	ErrInvalidBaseType        = errors.New("invalid basetype")
+	ErrMesgDefMissing         = errorString("message definition missing")
+	ErrFieldValueTypeMismatch = errorString("field value type mismatch")
+	ErrInvalidBaseType        = errorString("invalid basetype")
 )
 
 const littleEndian = 0

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -7,7 +7,6 @@ package encoder
 import (
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 
@@ -19,12 +18,16 @@ import (
 	"github.com/muktihari/fit/proto"
 )
 
-var (
-	ErrNilWriter     = errors.New("nil writer")
-	ErrEmptyMessages = errors.New("empty messages")
-	ErrMissingFileId = errors.New("missing file_id mesg")
+type errorString string
 
-	ErrWriterAtOrWriteSeekerIsExpected = errors.New("io.WriterAt or io.WriteSeeker is expected")
+func (e errorString) Error() string { return string(e) }
+
+const (
+	ErrNilWriter     = errorString("nil writer")
+	ErrEmptyMessages = errorString("empty messages")
+	ErrMissingFileId = errorString("missing file_id mesg")
+
+	ErrWriterAtOrWriteSeekerIsExpected = errorString("io.WriterAt or io.WriteSeeker is expected")
 )
 
 const (

--- a/encoder/validator.go
+++ b/encoder/validator.go
@@ -5,7 +5,6 @@
 package encoder
 
 import (
-	"errors"
 	"fmt"
 	"unicode/utf8"
 
@@ -18,13 +17,13 @@ import (
 	"github.com/muktihari/fit/proto"
 )
 
-var (
-	ErrInvalidUTF8String       = errors.New("invalid UTF-8 string")
-	ErrValueTypeMismatch       = errors.New("value type mismatch")
-	ErrNoFields                = errors.New("no fields")
-	ErrMissingDeveloperDataId  = errors.New("missing developer data id")
-	ErrMissingFieldDescription = errors.New("missing field description")
-	ErrExceedMaxAllowed        = errors.New("exceed max allowed")
+const (
+	ErrInvalidUTF8String       = errorString("invalid UTF-8 string")
+	ErrValueTypeMismatch       = errorString("value type mismatch")
+	ErrNoFields                = errorString("no fields")
+	ErrMissingDeveloperDataId  = errorString("missing developer data id")
+	ErrMissingFieldDescription = errorString("missing field description")
+	ErrExceedMaxAllowed        = errorString("exceed max allowed")
 )
 
 // MessageValidator is an interface for implementing message validation before encoding the message.

--- a/factory/factory_gen.go
+++ b/factory/factory_gen.go
@@ -7,7 +7,6 @@
 package factory
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -18,14 +17,16 @@ import (
 	"github.com/muktihari/fit/proto"
 )
 
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
 const (
+	// ErrRegisterForbidden occurs when trying to create manufacturer specific message outside available range.
+	ErrRegisterForbidden = errorString("register is forbidden")
+
 	// NameUnknown is unknown message or field name
 	NameUnknown string = "unknown"
-)
-
-var (
-	// ErrRegisterForbidden occurs when trying to create manufacturer specific message outside available range.
-	ErrRegisterForbidden = errors.New("register is forbidden")
 )
 
 // Factory handles creation and registration for FIT's message and field.

--- a/internal/cmd/fitgen/factory/factory.tmpl
+++ b/internal/cmd/fitgen/factory/factory.tmpl
@@ -15,7 +15,6 @@
 package {{ .Package }}
 
 import (
-	"errors"
 	"fmt"
     "math"
 	"sync"
@@ -26,15 +25,18 @@ import (
 	"github.com/muktihari/fit/profile/typedef"
 )
 
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
 const (
+	// ErrRegisterForbidden occurs when trying to create manufacturer specific message outside available range.
+	ErrRegisterForbidden = errorString("register is forbidden")
+
 	// NameUnknown is unknown message or field name
 	NameUnknown string = "unknown"
 )
 
-var (
-	// ErrRegisterForbidden occurs when trying to create manufacturer specific message outside available range.
-	ErrRegisterForbidden = errors.New("register is forbidden")
-)
 
 // Factory handles creation and registration for FIT's message and field.
 type Factory struct {

--- a/internal/cmd/fitgen/factory/factory.tmpl
+++ b/internal/cmd/fitgen/factory/factory.tmpl
@@ -16,7 +16,7 @@ package {{ .Package }}
 
 import (
 	"fmt"
-    "math"
+	"math"
 	"sync"
 
 	"github.com/muktihari/fit/proto"

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -11,6 +11,10 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
 // NOTE: The term "Global FIT Profile" refers to the definition provided in the Profile.xlsx proto.
 
 const ( // header is 1 byte ->	 0bxxxxxxxx

--- a/proto/validator.go
+++ b/proto/validator.go
@@ -5,13 +5,12 @@
 package proto
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/muktihari/fit/profile/basetype"
 )
 
-var ErrProtocolViolation = errors.New("protocol violation")
+const ErrProtocolViolation = errorString("protocol violation")
 
 // NewValidator creates protocol validator base on given version.
 func NewValidator(version Version) *Validator {

--- a/proto/value_marshal.go
+++ b/proto/value_marshal.go
@@ -6,12 +6,11 @@ package proto
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math"
 )
 
-var ErrTypeNotSupported = errors.New("type is not supported")
+const ErrTypeNotSupported = errorString("type is not supported")
 
 // MarshalAppend appends the FIT format encoding of Value to b. Returning the result.
 // If arch is 0, marshal in Little-Endian, otherwise marshal in Big-Endian.

--- a/proto/version.go
+++ b/proto/version.go
@@ -4,14 +4,12 @@
 
 package proto
 
-import "errors"
-
-var ErrProtocolVersionNotSupported = errors.New("protocol version not supported")
-
 // Version is FIT Protocol Version
 type Version byte
 
 const (
+	ErrProtocolVersionNotSupported = errorString("protocol version not supported")
+
 	MajorVersionShift = 4
 	MajorVersionMask  = 0x0F << MajorVersionShift
 	MinorVersionMask  = 0x0F


### PR DESCRIPTION
Previously:
```go
// decoder/decoder.go
var ErrCRCChecksumMismatch = errors.New("crc checksum mismatch")
```
```go
func init() {
    decoder.ErrCRCChecksumMismatch = nil // allowed :(
}
```

Imagine we have a service for testing FIT file integrity, however, without our knowing, there is another library that silently altering the value, this way we will never get "mismatch" error as the value is now become nil. This will be hard to debug; more importantly, it might pose a security vulnerability.

Now since we change ErrCRCChecksumMismatch as unexported "errorString" string typed constant, the value will never be altered.
```go
// decoder/decoder.go
type errorString string
func (e errorString) Error() string { return string(e) }
const ErrCRCChecksumMismatch = errorString("crc checksum mismatch")
```
```go
func init() {
	decoder.ErrCRCChecksumMismatch = nil                       // cannot assign to constant
	decoder.ErrCRCChecksumMismatch = ""                        // cannot assign to constant
	decoder.ErrCRCChecksumMismatch = decoder.ErrMesgDefMissing // cannot assign to constant
}
```

References: 
- Standard library using constant error pattern: https://pkg.go.dev/syscall#Errno
- An article by Go contributor: https://dave.cheney.net/2016/04/07/constant-errors