### PR TITLE
fix: encoder compress timestamp

### DIFF
--- a/encoder/lru_test.go
+++ b/encoder/lru_test.go
@@ -142,3 +142,26 @@ func BenchmarkLRUReset(b *testing.B) {
 		}
 	})
 }
+
+func TestResetWithSize(t *testing.T) {
+	l := newLRU(1)
+	l.ResetWithNewSize(10)
+	for i := byte(0); i < 10; i++ {
+		index, isNew := l.Put([]byte{i})
+		if index != i && isNew != true {
+			t.Fatalf("expected index: %d, got: %d, expected newItem: %t, got: %t",
+				i, index, true, isNew,
+			)
+		}
+	}
+	if cap(l.bucket) != cap(l.items) {
+		t.Fatalf("expected cap(l.bucket): %d and cap(l.items): %d is same, got mismatch",
+			cap(l.bucket), cap(l.items))
+	}
+
+	l.ResetWithNewSize(3) // should reslice
+	if cap(l.bucket) != 10 && cap(l.bucket) != cap(l.items) {
+		t.Fatalf("expected cap(l.bucket): %d and cap(l.items): %d is same, got mismatch",
+			cap(l.bucket), cap(l.items))
+	}
+}


### PR DESCRIPTION
#### Encoder
- Fix  compress timestamp in header: 
   Previously, we measure rollover event every > 32 seconds where it should be >= 32 seconds. This created the 32 seconds rollover to have timeoffset 0. When this message is decoded, most likely this message would have the same timestamp as the previously decoded message (at least our FIT SDK's decoder handle this way). 
- Fix lru on ResetWithSize
   Previously, when reset with new size > than previous size, only `items` field would be re-allocated as the new size where `bucket` will be allocated automatically by `append`. This does no create any significant issue, however, this was not intended since `cap(bucket)` can be bigger than `cap(items)` as `append` will typically re-allocate doubling the previous cap or round it in a multiple of 8: 8, 16, etc (depend on runtime implementation)
- RolloverEvent is removed as it no longer needed. Moreover, exporting RolloverEvent was a mistake.