### PR TITLE
perf: decoder options is no longer allocate

### DIFF
--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -165,11 +165,11 @@ func TestOptions(t *testing.T) {
 	tt := []struct {
 		name    string
 		opts    []Option
-		options *options
+		options options
 	}{
 		{
 			name: "defaultOptions",
-			options: &options{
+			options: options{
 				factory:               factory.StandardFactory(),
 				logWriter:             nil,
 				readBufferSize:        defaultReadBufferSize,
@@ -192,7 +192,7 @@ func TestOptions(t *testing.T) {
 				WithReadBufferSize(8192),
 				WithBroadcastMesgCopy(),
 			},
-			options: &options{
+			options: options{
 				factory:               decoderFactory,
 				readBufferSize:        8192,
 				shouldChecksum:        false,
@@ -2520,9 +2520,8 @@ func TestDecodeMessagesWithContext(t *testing.T) {
 		err  error
 	}{
 		{
-			name: "context DeadlineExceeded",
+			name: "context ContextExceeded",
 			r: fnReader(func(b []byte) (n int, err error) {
-				time.Sleep(1 * time.Second) // Let's make our process take longer, 1s per reader Read call.
 				return len(b), nil
 			}),
 			ctx: func() context.Context {

--- a/decoder/readbuffer.go
+++ b/decoder/readbuffer.go
@@ -43,11 +43,6 @@ type readBuffer struct {
 // allowing us to read bytes directly from the buffer without extra copying.
 // This is unlike *bufio.Reader, which requires us to copy the bytes on every Read() method call.
 func newReadBuffer(rd io.Reader, size int) *readBuffer {
-	if size < minReadBufferSize {
-		size = minReadBufferSize
-	} else if size > maxReadBufferSize {
-		size = maxReadBufferSize
-	}
 	r := new(readBuffer)
 	r.Reset(rd, size)
 	return r
@@ -80,6 +75,12 @@ func (b *readBuffer) ReadN(n int) ([]byte, error) {
 
 // Reset resets buf reader.
 func (b *readBuffer) Reset(rd io.Reader, size int) {
+	if size < minReadBufferSize {
+		size = minReadBufferSize
+	} else if size > maxReadBufferSize {
+		size = maxReadBufferSize
+	}
+
 	oldsize := cap(b.buf) - reservedbuf
 	if size > oldsize {
 		b.buf = make([]byte, reservedbuf+size)


### PR DESCRIPTION
- Creating default options is no longer allocate since now we return value instead of pointer, and decoder's options field is now a concrete value as well. Decoder instance will be heap allocated anyway, it's better to have one big struct. 
- Now calling Reset() do not allocate.