### PR TITLE
perf: encoder options and validatorOptions are no longer allocate

### DIFF
--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -105,12 +105,12 @@ func TestOptions(t *testing.T) {
 	tt := []struct {
 		name     string
 		opts     []Option
-		expected *options
+		expected options
 	}{
 		{
 			name: "defaultOptions",
 			opts: nil,
-			expected: &options{
+			expected: options{
 				multipleLocalMessageType: 0,
 				endianness:               0,
 				protocolVersion:          proto.V1,
@@ -126,7 +126,7 @@ func TestOptions(t *testing.T) {
 				WithCompressedTimestampHeader(),
 				WithMessageValidator(fnValidateOK),
 			},
-			expected: &options{
+			expected: options{
 				multipleLocalMessageType: 15,
 				endianness:               1,
 				protocolVersion:          proto.V2,
@@ -866,7 +866,7 @@ func TestCompressTimestampInHeader(t *testing.T) {
 			},
 		},
 		{
-			name: "compress timestamp in header happy flow: roll over occured exactly after 32 seconds",
+			name: "compress timestamp in header happy flow: roll over occurred exactly after 32 seconds",
 			mesgs: []proto.Message{
 				factory.CreateMesg(mesgnum.FileId).WithFieldValues(map[byte]any{
 					fieldnum.FileIdManufacturer: typedef.ManufacturerGarmin,
@@ -885,7 +885,7 @@ func TestCompressTimestampInHeader(t *testing.T) {
 			headers: []byte{
 				proto.MesgNormalHeaderMask, // file_id: has no timestamp
 				proto.MesgNormalHeaderMask, // record: the message containing timestamp reference prior to the use of compressed header.
-				proto.MesgNormalHeaderMask, // record: roll over has occured, the timestamp is used new timestamp reference.
+				proto.MesgNormalHeaderMask, // record: roll over has occurred, the timestamp is used new timestamp reference.
 				proto.MesgCompressedHeaderMask | (offset+1)&proto.CompressedTimeMask,
 			},
 		},

--- a/encoder/validator_test.go
+++ b/encoder/validator_test.go
@@ -29,11 +29,11 @@ func TestMessageValidatorOption(t *testing.T) {
 	tt := []struct {
 		name    string
 		opts    []ValidatorOption
-		options *validatorOptions
+		options validatorOptions
 	}{
 		{
 			name: "defaultValidatorOptions",
-			options: &validatorOptions{
+			options: validatorOptions{
 				omitInvalidValues: true,
 				factory:           factory.StandardFactory(),
 			},
@@ -44,7 +44,7 @@ func TestMessageValidatorOption(t *testing.T) {
 				ValidatorWithPreserveInvalidValues(),
 				ValidatorWithFactory(fac),
 			},
-			options: &validatorOptions{
+			options: validatorOptions{
 				omitInvalidValues: false,
 				factory:           fac,
 			},


### PR DESCRIPTION
- defaultOptions and defaultValidatorOptions are now returning concrete value, and encoder's options field and messageValidator's options field are now concrete values as well. Encoder's mesgDef is now a concrete value to reduce another heap allocated object. Encoder and messageValidator instances will be heap allocated anyway, it's better to have one big struct. This reduce allocated object when creating and resetting the instances.
- Reset() object allocation reduced to 1 alloc, we can't make zero alloc since we let user to create their own implementation of MessageValidator through Option, so this object will always alloc.
- Fix misspelled words on encoder_test.go