### PR TITLE
chore: filedef clean up code

### DIFF
--- a/profile/filedef/activity.go
+++ b/profile/filedef/activity.go
@@ -54,7 +54,6 @@ func NewActivity(mesgs ...proto.Message) *Activity {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -118,30 +117,54 @@ func (f *Activity) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
-	ToMesgs(&fit.Messages, options, mesgnum.DeviceInfo, f.DeviceInfos)
-
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
+	for i := range f.DeviceInfos {
+		fit.Messages = append(fit.Messages, f.DeviceInfos[i].ToMesg(options))
+	}
 	if f.UserProfile != nil {
 		fit.Messages = append(fit.Messages, f.UserProfile.ToMesg(options))
 	}
-
 	if f.Activity != nil {
 		fit.Messages = append(fit.Messages, f.Activity.ToMesg(options))
 	}
-
-	ToMesgs(&fit.Messages, options, mesgnum.Session, f.Sessions)
-	ToMesgs(&fit.Messages, options, mesgnum.Lap, f.Laps)
-	ToMesgs(&fit.Messages, options, mesgnum.Record, f.Records)
-	ToMesgs(&fit.Messages, options, mesgnum.Event, f.Events)
-	ToMesgs(&fit.Messages, options, mesgnum.Length, f.Lengths)
-	ToMesgs(&fit.Messages, options, mesgnum.SegmentLap, f.SegmentLap)
-	ToMesgs(&fit.Messages, options, mesgnum.ZonesTarget, f.ZonesTargets)
-	ToMesgs(&fit.Messages, options, mesgnum.Workout, f.Workouts)
-	ToMesgs(&fit.Messages, options, mesgnum.WorkoutStep, f.WorkoutSteps)
-	ToMesgs(&fit.Messages, options, mesgnum.Hr, f.HRs)
-	ToMesgs(&fit.Messages, options, mesgnum.Hrv, f.HRVs)
+	for i := range f.Sessions {
+		fit.Messages = append(fit.Messages, f.Sessions[i].ToMesg(options))
+	}
+	for i := range f.Laps {
+		fit.Messages = append(fit.Messages, f.Laps[i].ToMesg(options))
+	}
+	for i := range f.Records {
+		fit.Messages = append(fit.Messages, f.Records[i].ToMesg(options))
+	}
+	for i := range f.Events {
+		fit.Messages = append(fit.Messages, f.Events[i].ToMesg(options))
+	}
+	for i := range f.Lengths {
+		fit.Messages = append(fit.Messages, f.Lengths[i].ToMesg(options))
+	}
+	for i := range f.SegmentLap {
+		fit.Messages = append(fit.Messages, f.SegmentLap[i].ToMesg(options))
+	}
+	for i := range f.ZonesTargets {
+		fit.Messages = append(fit.Messages, f.ZonesTargets[i].ToMesg(options))
+	}
+	for i := range f.Workouts {
+		fit.Messages = append(fit.Messages, f.Workouts[i].ToMesg(options))
+	}
+	for i := range f.WorkoutSteps {
+		fit.Messages = append(fit.Messages, f.WorkoutSteps[i].ToMesg(options))
+	}
+	for i := range f.HRs {
+		fit.Messages = append(fit.Messages, f.HRs[i].ToMesg(options))
+	}
+	for i := range f.HRVs {
+		fit.Messages = append(fit.Messages, f.HRVs[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/activity_summary.go
+++ b/profile/filedef/activity_summary.go
@@ -34,7 +34,6 @@ func NewActivitySummary(mesgs ...proto.Message) *ActivitySummary {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -74,15 +73,21 @@ func (f *ActivitySummary) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
 	if f.Activity != nil {
 		fit.Messages = append(fit.Messages, f.Activity.ToMesg(options))
 	}
-
-	ToMesgs(&fit.Messages, options, mesgnum.Session, f.Sessions)
-	ToMesgs(&fit.Messages, options, mesgnum.Lap, f.Laps)
+	for i := range f.Sessions {
+		fit.Messages = append(fit.Messages, f.Sessions[i].ToMesg(options))
+	}
+	for i := range f.Laps {
+		fit.Messages = append(fit.Messages, f.Laps[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/blood_pressure.go
+++ b/profile/filedef/blood_pressure.go
@@ -34,7 +34,6 @@ func NewBloodPressure(mesgs ...proto.Message) *BloodPressure {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -74,15 +73,21 @@ func (f *BloodPressure) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
 	if f.UserProfile != nil {
 		fit.Messages = append(fit.Messages, f.UserProfile.ToMesg(options))
 	}
-
-	ToMesgs(&fit.Messages, options, mesgnum.BloodPressure, f.BloodPressures)
-	ToMesgs(&fit.Messages, options, mesgnum.DeviceInfo, f.DeviceInfos)
+	for i := range f.BloodPressures {
+		fit.Messages = append(fit.Messages, f.BloodPressures[i].ToMesg(options))
+	}
+	for i := range f.DeviceInfos {
+		fit.Messages = append(fit.Messages, f.DeviceInfos[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/course.go
+++ b/profile/filedef/course.go
@@ -46,7 +46,6 @@ func NewCourse(mesgs ...proto.Message) *Course {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -90,20 +89,27 @@ func (f *Course) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
 	if f.Course != nil {
 		fit.Messages = append(fit.Messages, f.Course.ToMesg(options))
 	}
-
 	if f.Lap != nil {
 		fit.Messages = append(fit.Messages, f.Lap.ToMesg(options))
 	}
-
-	ToMesgs(&fit.Messages, options, mesgnum.Record, f.Records)
-	ToMesgs(&fit.Messages, options, mesgnum.Event, f.Events)
-	ToMesgs(&fit.Messages, options, mesgnum.CoursePoint, f.CoursePoints)
+	for i := range f.Records {
+		fit.Messages = append(fit.Messages, f.Records[i].ToMesg(options))
+	}
+	for i := range f.Events {
+		fit.Messages = append(fit.Messages, f.Events[i].ToMesg(options))
+	}
+	for i := range f.CoursePoints {
+		fit.Messages = append(fit.Messages, f.CoursePoints[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/device.go
+++ b/profile/filedef/device.go
@@ -36,7 +36,6 @@ func NewDevice(mesgs ...proto.Message) *Device {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -81,14 +80,27 @@ func (f *Device) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
-	ToMesgs(&fit.Messages, options, mesgnum.Software, f.Softwares)
-	ToMesgs(&fit.Messages, options, mesgnum.Capabilities, f.Capabilities)
-	ToMesgs(&fit.Messages, options, mesgnum.FileCapabilities, f.FileCapabilities)
-	ToMesgs(&fit.Messages, options, mesgnum.MesgCapabilities, f.MesgCapabilities)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldCapabilities, f.FieldCapabilities)
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
+	for i := range f.Softwares {
+		fit.Messages = append(fit.Messages, f.Softwares[i].ToMesg(options))
+	}
+	for i := range f.Capabilities {
+		fit.Messages = append(fit.Messages, f.Capabilities[i].ToMesg(options))
+	}
+	for i := range f.FileCapabilities {
+		fit.Messages = append(fit.Messages, f.FileCapabilities[i].ToMesg(options))
+	}
+	for i := range f.MesgCapabilities {
+		fit.Messages = append(fit.Messages, f.MesgCapabilities[i].ToMesg(options))
+	}
+	for i := range f.FieldCapabilities {
+		fit.Messages = append(fit.Messages, f.FieldCapabilities[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/filedef.go
+++ b/profile/filedef/filedef.go
@@ -22,6 +22,8 @@ type File interface {
 }
 
 // ToMesgs bulks convert mesgdef into proto.Message and append it to messages
+//
+// Deprecated: no longer used in filedef, will be removed in the next major/minor release.
 func ToMesgs[S []E, E ToMesg](messages *[]proto.Message, options *mesgdef.Options, mesgNum typedef.MesgNum, s S) {
 	for i := range s {
 		*messages = append(*messages, s[i].ToMesg(options))
@@ -29,6 +31,8 @@ func ToMesgs[S []E, E ToMesg](messages *[]proto.Message, options *mesgdef.Option
 }
 
 // ToMesg is a type constraint to retrieve all mesgdef structures which implement ToMesg method.
+//
+// Deprecated: no longer used in filedef, will be removed in the next major/minor release.
 type ToMesg interface {
 	ToMesg(options *mesgdef.Options) proto.Message
 }

--- a/profile/filedef/filedef_test.go
+++ b/profile/filedef/filedef_test.go
@@ -1,0 +1,70 @@
+package filedef_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/kit/datetime"
+	"github.com/muktihari/fit/profile/filedef"
+	"github.com/muktihari/fit/profile/mesgdef"
+	"github.com/muktihari/fit/profile/typedef"
+	"github.com/muktihari/fit/profile/untyped/fieldnum"
+	"github.com/muktihari/fit/profile/untyped/mesgnum"
+	"github.com/muktihari/fit/proto"
+)
+
+func TestToMesgs(t *testing.T) {
+	messages := make([]proto.Message, 0, 1)
+	records := make([]*mesgdef.Record, 1)
+	records[0] = mesgdef.NewRecord(nil).
+		SetTimestamp(time.Now())
+
+	filedef.ToMesgs(&messages, nil, mesgnum.Record, records)
+	if len(messages) != 1 {
+		t.Fatalf("expected 1: got: %d", len(messages))
+	}
+}
+
+func TestSortMessagesByTimestamp(t *testing.T) {
+	now := time.Now()
+
+	messages := []proto.Message{
+		0: factory.CreateMesgOnly(mesgnum.FileId).WithFields(
+			factory.CreateField(mesgnum.FileId, fieldnum.FileIdManufacturer).WithValue(typedef.ManufacturerDevelopment.Uint16()),
+		),
+		1: factory.CreateMesgOnly(mesgnum.Record).WithFields(
+			factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now)),
+		),
+		2: factory.CreateMesgOnly(mesgnum.Record).WithFields(
+			factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now.Add(2 * time.Second))),
+		),
+		3: factory.CreateMesgOnly(mesgnum.Record).WithFields(
+			factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now.Add(1 * time.Second))),
+		),
+		4: factory.CreateMesgOnly(mesgnum.Event).WithFields(
+			factory.CreateField(mesgnum.Event, fieldnum.EventTimestamp).WithValue(datetime.ToUint32(now.Add(2 * time.Second))),
+		),
+		5: factory.CreateMesgOnly(mesgnum.Session).WithFields(
+			factory.CreateField(mesgnum.Session, fieldnum.SessionTimestamp).WithValue(datetime.ToUint32(now.Add(2 * time.Second))),
+		),
+	}
+
+	expected := []proto.Message{
+		messages[0],
+		messages[1],
+		messages[3],
+		messages[2],
+		messages[4],
+		messages[5],
+	}
+
+	filedef.SortMessagesByTimestamp(messages)
+	if diff := cmp.Diff(messages, expected,
+		cmpopts.IgnoreTypes(proto.Value{}), // We only care the ordering
+	); diff != "" {
+		t.Fatal(diff)
+	}
+}

--- a/profile/filedef/goals.go
+++ b/profile/filedef/goals.go
@@ -32,7 +32,6 @@ func NewGoals(mesgs ...proto.Message) *Goals {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -68,10 +67,15 @@ func (f *Goals) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
-	ToMesgs(&fit.Messages, options, mesgnum.Goal, f.Goals)
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
+	for i := range f.Goals {
+		fit.Messages = append(fit.Messages, f.Goals[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/monitoring_ab.go
+++ b/profile/filedef/monitoring_ab.go
@@ -38,7 +38,6 @@ func NewMonitoringAB(mesgs ...proto.Message) *MonitoringAB {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -78,15 +77,21 @@ func (f *MonitoringAB) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
 	if f.MonitoringInfo != nil {
 		fit.Messages = append(fit.Messages, f.MonitoringInfo.ToMesg(options))
 	}
-
-	ToMesgs(&fit.Messages, options, mesgnum.Monitoring, f.Monitorings)
-	ToMesgs(&fit.Messages, options, mesgnum.DeviceInfo, f.DeviceInfos)
+	for i := range f.Monitorings {
+		fit.Messages = append(fit.Messages, f.Monitorings[i].ToMesg(options))
+	}
+	for i := range f.DeviceInfos {
+		fit.Messages = append(fit.Messages, f.DeviceInfos[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/monitoring_daily.go
+++ b/profile/filedef/monitoring_daily.go
@@ -34,7 +34,6 @@ func NewMonitoringDaily(mesgs ...proto.Message) *MonitoringDaily {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -74,15 +73,21 @@ func (f *MonitoringDaily) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
 	if f.MonitoringInfo != nil {
 		fit.Messages = append(fit.Messages, f.MonitoringInfo.ToMesg(options))
 	}
-
-	ToMesgs(&fit.Messages, options, mesgnum.Monitoring, f.Monitorings)
-	ToMesgs(&fit.Messages, options, mesgnum.DeviceInfo, f.DeviceInfos)
+	for i := range f.Monitorings {
+		fit.Messages = append(fit.Messages, f.Monitorings[i].ToMesg(options))
+	}
+	for i := range f.DeviceInfos {
+		fit.Messages = append(fit.Messages, f.DeviceInfos[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/schedules.go
+++ b/profile/filedef/schedules.go
@@ -32,7 +32,6 @@ func NewSchedules(mesgs ...proto.Message) *Schedules {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -68,10 +67,15 @@ func (f *Schedules) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
-	ToMesgs(&fit.Messages, options, mesgnum.Schedule, f.Schedules)
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
+	for i := range f.Schedules {
+		fit.Messages = append(fit.Messages, f.Schedules[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/segment.go
+++ b/profile/filedef/segment.go
@@ -35,7 +35,6 @@ func NewSegment(mesgs ...proto.Message) *Segment {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -77,22 +76,24 @@ func (f *Segment) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
 	if f.SegmentId != nil {
 		fit.Messages = append(fit.Messages, f.SegmentId.ToMesg(options))
 	}
-
 	if f.SegmentLeaderboardEntry != nil {
 		fit.Messages = append(fit.Messages, f.SegmentLeaderboardEntry.ToMesg(options))
 	}
-
 	if f.SegmentLap != nil {
 		fit.Messages = append(fit.Messages, f.SegmentLap.ToMesg(options))
 	}
-
-	ToMesgs(&fit.Messages, options, mesgnum.SegmentPoint, f.SegmentPoints)
+	for i := range f.SegmentPoints {
+		fit.Messages = append(fit.Messages, f.SegmentPoints[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/segment_list.go
+++ b/profile/filedef/segment_list.go
@@ -33,7 +33,6 @@ func NewSegmentList(mesgs ...proto.Message) *SegmentList {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -71,14 +70,18 @@ func (f *SegmentList) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
 	if f.FileCreator != nil {
 		fit.Messages = append(fit.Messages, f.FileCreator.ToMesg(options))
 	}
-
-	ToMesgs(&fit.Messages, options, mesgnum.SegmentFile, f.SegmentFiles)
+	for i := range f.SegmentFiles {
+		fit.Messages = append(fit.Messages, f.SegmentFiles[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/settings.go
+++ b/profile/filedef/settings.go
@@ -36,7 +36,6 @@ func NewSettings(mesgs ...proto.Message) *Settings {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -81,14 +80,27 @@ func (f *Settings) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
-	ToMesgs(&fit.Messages, options, mesgnum.UserProfile, f.UserProfiles)
-	ToMesgs(&fit.Messages, options, mesgnum.HrmProfile, f.HrmProfiles)
-	ToMesgs(&fit.Messages, options, mesgnum.SdmProfile, f.SdmProfiles)
-	ToMesgs(&fit.Messages, options, mesgnum.BikeProfile, f.BikeProfiles)
-	ToMesgs(&fit.Messages, options, mesgnum.DeviceSettings, f.DeviceSettings)
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
+	for i := range f.UserProfiles {
+		fit.Messages = append(fit.Messages, f.UserProfiles[i].ToMesg(options))
+	}
+	for i := range f.HrmProfiles {
+		fit.Messages = append(fit.Messages, f.HrmProfiles[i].ToMesg(options))
+	}
+	for i := range f.SdmProfiles {
+		fit.Messages = append(fit.Messages, f.SdmProfiles[i].ToMesg(options))
+	}
+	for i := range f.BikeProfiles {
+		fit.Messages = append(fit.Messages, f.BikeProfiles[i].ToMesg(options))
+	}
+	for i := range f.DeviceSettings {
+		fit.Messages = append(fit.Messages, f.DeviceSettings[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/sport.go
+++ b/profile/filedef/sport.go
@@ -38,7 +38,6 @@ func NewSport(mesgs ...proto.Message) *Sport {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -87,20 +86,33 @@ func (f *Sport) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
-	ToMesgs(&fit.Messages, options, mesgnum.ZonesTarget, f.ZonesTargets)
-
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
+	for i := range f.ZonesTargets {
+		fit.Messages = append(fit.Messages, f.ZonesTargets[i].ToMesg(options))
+	}
 	if f.Sport != nil {
 		fit.Messages = append(fit.Messages, f.Sport.ToMesg(options))
 	}
-
-	ToMesgs(&fit.Messages, options, mesgnum.HrZone, f.HrZones)
-	ToMesgs(&fit.Messages, options, mesgnum.PowerZone, f.PowerZones)
-	ToMesgs(&fit.Messages, options, mesgnum.MetZone, f.MetZones)
-	ToMesgs(&fit.Messages, options, mesgnum.SpeedZone, f.SpeedZones)
-	ToMesgs(&fit.Messages, options, mesgnum.CadenceZone, f.CadenceZones)
+	for i := range f.HrZones {
+		fit.Messages = append(fit.Messages, f.HrZones[i].ToMesg(options))
+	}
+	for i := range f.PowerZones {
+		fit.Messages = append(fit.Messages, f.PowerZones[i].ToMesg(options))
+	}
+	for i := range f.MetZones {
+		fit.Messages = append(fit.Messages, f.MetZones[i].ToMesg(options))
+	}
+	for i := range f.SpeedZones {
+		fit.Messages = append(fit.Messages, f.SpeedZones[i].ToMesg(options))
+	}
+	for i := range f.CadenceZones {
+		fit.Messages = append(fit.Messages, f.CadenceZones[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/totals.go
+++ b/profile/filedef/totals.go
@@ -33,7 +33,6 @@ func NewTotals(mesgs ...proto.Message) *Totals {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -69,10 +68,15 @@ func (f *Totals) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
-	ToMesgs(&fit.Messages, options, mesgnum.Totals, f.Totals)
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
+	for i := range f.Totals {
+		fit.Messages = append(fit.Messages, f.Totals[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/weight.go
+++ b/profile/filedef/weight.go
@@ -34,7 +34,6 @@ func NewWeight(mesgs ...proto.Message) *Weight {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -74,15 +73,21 @@ func (f *Weight) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
 	if f.UserProfile != nil {
 		fit.Messages = append(fit.Messages, f.UserProfile.ToMesg(options))
 	}
-
-	ToMesgs(&fit.Messages, options, mesgnum.WeightScale, f.WeightScales)
-	ToMesgs(&fit.Messages, options, mesgnum.DeviceInfo, f.DeviceInfos)
+	for i := range f.WeightScales {
+		fit.Messages = append(fit.Messages, f.WeightScales[i].ToMesg(options))
+	}
+	for i := range f.DeviceInfos {
+		fit.Messages = append(fit.Messages, f.DeviceInfos[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 

--- a/profile/filedef/workout.go
+++ b/profile/filedef/workout.go
@@ -37,7 +37,6 @@ func NewWorkout(mesgs ...proto.Message) *Workout {
 	for i := range mesgs {
 		f.Add(mesgs[i])
 	}
-
 	return f
 }
 
@@ -74,14 +73,18 @@ func (f *Workout) ToFIT(options *mesgdef.Options) proto.FIT {
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
-	ToMesgs(&fit.Messages, options, mesgnum.DeveloperDataId, f.DeveloperDataIds)
-	ToMesgs(&fit.Messages, options, mesgnum.FieldDescription, f.FieldDescriptions)
-
+	for i := range f.DeveloperDataIds {
+		fit.Messages = append(fit.Messages, f.DeveloperDataIds[i].ToMesg(options))
+	}
+	for i := range f.FieldDescriptions {
+		fit.Messages = append(fit.Messages, f.FieldDescriptions[i].ToMesg(options))
+	}
 	if f.Workout != nil {
 		fit.Messages = append(fit.Messages, f.Workout.ToMesg(options))
 	}
-
-	ToMesgs(&fit.Messages, options, mesgnum.WorkoutStep, f.WorkoutSteps)
+	for i := range f.WorkoutSteps {
+		fit.Messages = append(fit.Messages, f.WorkoutSteps[i].ToMesg(options))
+	}
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 


### PR DESCRIPTION
- Remove the usage of `filedef.ToMesgs` func in filedef and use loop directly, so we have less dependency code.
- Mark `filedef.ToMesg` interface and `filedef.ToMesgs` func as deprecated as it is no longer used, these can be removed in the next major/minor release. These items does not add any significant value, by removing it, we have less code to maintain.