### PR TITLE
fix: decoder's CheckIntegrity should not remember error

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -298,7 +298,6 @@ func (d *Decoder) CheckIntegrity() (seq int, err error) {
 	// Reset used variables so that the decoder can be reused by the same reader.
 	d.reset()
 	d.n = 0 // Must reset bytes counter
-	d.err = err
 	d.options.shouldChecksum = shouldChecksum
 
 	return seq, err

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -590,6 +590,9 @@ func TestCheckIntegrity(t *testing.T) {
 			if n != tc.n {
 				t.Fatalf("expected n sequence of FIT: %d, got: %d", tc.n, n)
 			}
+			if dec.err != nil { // Should not remember error.
+				t.Fatalf("decoder's error should be nil, got: %v", dec.err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
CheckIntegrity is a standalone method so it should not remember error, otherwise the decoder could not be reused. On previous version, users need to call Reset() to be able to reuse the Decoder but this was not what we intended.