### PR TITLE
fix: encoder reset did not assign new writer

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -189,6 +189,7 @@ func New(w io.Writer, opts ...Option) *Encoder {
 // default options so any options needs to be inputed again. It is similar to New()
 // but it retains the underlying storage for use by future encode to reduce memory allocs.
 func (e *Encoder) Reset(w io.Writer, opts ...Option) {
+	e.w = w
 	e.n = 0
 	e.lastFileHeaderPos = 0
 


### PR DESCRIPTION
Previously, Reset() does not assign the new writer properly, so encoder still refer to the old writer.