### PR TITLE
fix: datetime's ToUint32 when time arg is before epoch

### DIFF
--- a/kit/datetime/datetime.go
+++ b/kit/datetime/datetime.go
@@ -82,7 +82,7 @@ func TzOffsetHoursFromUint32(localDateTime, dateTime uint32) int {
 
 // Convert t into uint32 fit representative time value.
 func ToUint32(t time.Time) uint32 {
-	if t.IsZero() {
+	if t.Before(epoch) {
 		return basetype.Uint32Invalid
 	}
 	return uint32(t.Sub(epoch).Seconds())

--- a/kit/datetime/datetime_test.go
+++ b/kit/datetime/datetime_test.go
@@ -179,12 +179,17 @@ func TestToUint32(t *testing.T) {
 			time: time.Time{},
 			u32:  basetype.Uint32Invalid,
 		},
+		{
+			name: "before FIT's epoch",
+			time: time.Date(1945, time.November, 10, 0, 0, 0, 0, time.UTC),
+			u32:  basetype.Uint32Invalid,
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			res := datetime.ToUint32(tc.time)
 			if res != tc.u32 {
-				t.Fatalf("expected time: %d, got: %d", tc.u32, res)
+				t.Fatalf("expected time in uint32: %d, got: %d", tc.u32, res)
 			}
 		})
 	}


### PR DESCRIPTION
When user specified time before epoch, for instance "10 Nov 1945", an invalid uint32 will be returned.