### PR TITLE
fix!: filedef ToFIT's timestamp sorting algorithm

### DIFF
--- a/profile/filedef/activity.go
+++ b/profile/filedef/activity.go
@@ -115,6 +115,7 @@ func (f *Activity) ToFIT(options *mesgdef.Options) proto.FIT {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
+	var sortStartPos = 1 + len(f.DeveloperDataIds) + len(f.FieldDescriptions)
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
 	for i := range f.DeveloperDataIds {
@@ -168,7 +169,7 @@ func (f *Activity) ToFIT(options *mesgdef.Options) proto.FIT {
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
-	SortMessagesByTimestamp(fit.Messages)
+	SortMessagesByTimestamp(fit.Messages[sortStartPos:])
 
 	return fit
 }

--- a/profile/filedef/activity_summary.go
+++ b/profile/filedef/activity_summary.go
@@ -71,6 +71,7 @@ func (f *ActivitySummary) ToFIT(options *mesgdef.Options) proto.FIT {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
+	var sortStartPos = 1 + len(f.DeveloperDataIds) + len(f.FieldDescriptions)
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
 	for i := range f.DeveloperDataIds {
@@ -91,7 +92,7 @@ func (f *ActivitySummary) ToFIT(options *mesgdef.Options) proto.FIT {
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
-	SortMessagesByTimestamp(fit.Messages)
+	SortMessagesByTimestamp(fit.Messages[sortStartPos:])
 
 	return fit
 }

--- a/profile/filedef/activity_test.go
+++ b/profile/filedef/activity_test.go
@@ -54,15 +54,20 @@ func incrementSecond(v *time.Time) time.Time {
 }
 
 func newActivityMessageForTest(now time.Time) []proto.Message {
-	return []proto.Message{
-		factory.CreateMesgOnly(mesgnum.FileId).WithFields(
+	mesgs, _ := newActivityMessagesWithExpectedOrder(now)
+	return mesgs
+}
+
+func newActivityMessagesWithExpectedOrder(now time.Time) (mesgs []proto.Message, ordered []proto.Message) {
+	mesgs = []proto.Message{
+		0: factory.CreateMesgOnly(mesgnum.FileId).WithFields(
 			factory.CreateField(mesgnum.FileId, fieldnum.FileIdType).WithValue(uint8(typedef.FileActivity)),
 			factory.CreateField(mesgnum.FileId, fieldnum.FileIdTimeCreated).WithValue(datetime.ToUint32(now)),
 		),
-		factory.CreateMesgOnly(mesgnum.DeveloperDataId).WithFields(
+		1: factory.CreateMesgOnly(mesgnum.DeveloperDataId).WithFields(
 			factory.CreateField(mesgnum.DeveloperDataId, fieldnum.DeveloperDataIdDeveloperDataIndex).WithValue(uint8(0)),
 		),
-		factory.CreateMesgOnly(mesgnum.FieldDescription).WithFields(
+		2: factory.CreateMesgOnly(mesgnum.FieldDescription).WithFields(
 			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionDeveloperDataIndex).WithValue(uint8(0)),
 			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionFieldDefinitionNumber).WithValue(uint8(0)),
 			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionFieldName).WithValue([]string{"Heart Rate"}),
@@ -70,78 +75,108 @@ func newActivityMessageForTest(now time.Time) []proto.Message {
 			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionNativeFieldNum).WithValue(uint8(fieldnum.RecordHeartRate)),
 			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionFitBaseTypeId).WithValue(uint8(basetype.Uint8)),
 		),
-		factory.CreateMesgOnly(mesgnum.DeviceInfo).WithFields(
+		3: factory.CreateMesgOnly(mesgnum.DeviceInfo).WithFields(
 			factory.CreateField(mesgnum.DeviceInfo, fieldnum.DeviceInfoManufacturer).WithValue(uint16(typedef.ManufacturerGarmin)),
 		),
-		factory.CreateMesgOnly(mesgnum.UserProfile).WithFields(
+		4: factory.CreateMesgOnly(mesgnum.UserProfile).WithFields(
 			factory.CreateField(mesgnum.UserProfile, fieldnum.UserProfileFriendlyName).WithValue("Mary Jane"),
 			factory.CreateField(mesgnum.UserProfile, fieldnum.UserProfileAge).WithValue(uint8(21)),
 		),
-		factory.CreateMesgOnly(mesgnum.Event).WithFields(
+		5: factory.CreateMesgOnly(mesgnum.Event).WithFields(
 			factory.CreateField(mesgnum.Event, fieldnum.EventTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 			factory.CreateField(mesgnum.Event, fieldnum.EventEvent).WithValue(uint8(typedef.EventActivity)),
 			factory.CreateField(mesgnum.Event, fieldnum.EventEventType).WithValue(uint8(typedef.EventTypeStart)),
 		),
-		factory.CreateMesgOnly(mesgnum.Record).WithFields(
+		6: factory.CreateMesgOnly(mesgnum.Record).WithFields(
 			factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		),
-		factory.CreateMesgOnly(mesgnum.Record).WithFields(
+		7: factory.CreateMesgOnly(mesgnum.Record).WithFields(
 			factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		),
-		factory.CreateMesgOnly(mesgnum.Event).WithFields(
+		8: factory.CreateMesgOnly(mesgnum.Event).WithFields(
 			factory.CreateField(mesgnum.Event, fieldnum.EventTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		),
-		factory.CreateMesgOnly(mesgnum.Record).WithFields(
+		9: factory.CreateMesgOnly(mesgnum.Record).WithFields(
 			factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		),
-		factory.CreateMesgOnly(mesgnum.Event).WithFields(
+		10: factory.CreateMesgOnly(mesgnum.Event).WithFields(
 			// Intentionally using same timestamp as last message.
-			// Record's Num is 20 and Event's Num is 21, when there are identical timestamp, smaller num ordered first.
 			factory.CreateField(mesgnum.Event, fieldnum.EventTimestamp).WithValue(datetime.ToUint32(now)),
 		),
-		factory.CreateMesgOnly(mesgnum.Lap).WithFields(
+		11: factory.CreateMesgOnly(mesgnum.Lap).WithFields(
 			factory.CreateField(mesgnum.Lap, fieldnum.LapTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		),
-		factory.CreateMesgOnly(mesgnum.Session).WithFields(
+		12: factory.CreateMesgOnly(mesgnum.Session).WithFields(
 			factory.CreateField(mesgnum.Session, fieldnum.SessionTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		),
-		factory.CreateMesgOnly(mesgnum.Activity).WithFields(
+		13: factory.CreateMesgOnly(mesgnum.Activity).WithFields(
 			factory.CreateField(mesgnum.Activity, fieldnum.ActivityTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		),
 		// Unordered optional Messages
-		factory.CreateMesgOnly(mesgnum.Length).WithFields(
+		14: factory.CreateMesgOnly(mesgnum.Length).WithFields(
 			factory.CreateField(mesgnum.Length, fieldnum.LengthAvgSpeed).WithValue(uint16(1000)),
 		),
-		factory.CreateMesgOnly(mesgnum.SegmentLap).WithFields(
+		15: factory.CreateMesgOnly(mesgnum.SegmentLap).WithFields(
 			factory.CreateField(mesgnum.SegmentLap, fieldnum.SegmentLapAvgCadence).WithValue(uint8(100)),
 		),
-		factory.CreateMesgOnly(mesgnum.ZonesTarget).WithFields(
+		16: factory.CreateMesgOnly(mesgnum.ZonesTarget).WithFields(
 			factory.CreateField(mesgnum.ZonesTarget, fieldnum.ZonesTargetMaxHeartRate).WithValue(uint8(190)),
 		),
-		factory.CreateMesgOnly(mesgnum.Workout).WithFields(
+		17: factory.CreateMesgOnly(mesgnum.Workout).WithFields(
 			factory.CreateField(mesgnum.Workout, fieldnum.WorkoutSport).WithValue(uint8(typedef.SportCycling)),
 		),
-		factory.CreateMesgOnly(mesgnum.WorkoutStep).WithFields(
+		18: factory.CreateMesgOnly(mesgnum.WorkoutStep).WithFields(
 			factory.CreateField(mesgnum.WorkoutStep, fieldnum.WorkoutStepIntensity).WithValue(uint8(typedef.IntensityActive)),
 		),
-		factory.CreateMesgOnly(mesgnum.Hr).WithFields(
+		19: factory.CreateMesgOnly(mesgnum.Hr).WithFields(
 			factory.CreateField(mesgnum.Hr, fieldnum.HrTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		),
-		factory.CreateMesgOnly(mesgnum.Hrv).WithFields(
+		20: factory.CreateMesgOnly(mesgnum.Hrv).WithFields(
 			factory.CreateField(mesgnum.Hrv, fieldnum.HrvTime).WithValue([]uint16{uint16(1000)}),
 		),
 		// Unrelated messages
-		factory.CreateMesgOnly(mesgnum.BarometerData).WithFields(
+		21: factory.CreateMesgOnly(mesgnum.BarometerData).WithFields(
 			factory.CreateField(mesgnum.BarometerData, fieldnum.BarometerDataTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		),
-		factory.CreateMesgOnly(mesgnum.CoursePoint).WithFields(
+		// Special case these messages are not counted:
+		// 1. CoursePoint's Timestamp Num is 1
+		// 2. Set's Timestamp Num is 254
+		22: factory.CreateMesgOnly(mesgnum.CoursePoint).WithFields(
 			factory.CreateField(mesgnum.CoursePoint, fieldnum.CoursePointTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		),
 	}
+
+	ordered = []proto.Message{
+		0:  mesgs[0],
+		1:  mesgs[1],
+		2:  mesgs[2],
+		3:  mesgs[3],
+		4:  mesgs[4],
+		5:  mesgs[14],
+		6:  mesgs[15],
+		7:  mesgs[16],
+		8:  mesgs[17],
+		9:  mesgs[18],
+		10: mesgs[20],
+		11: mesgs[22],
+		12: mesgs[5],
+		13: mesgs[6],
+		14: mesgs[7],
+		15: mesgs[8],
+		16: mesgs[9],
+		17: mesgs[10],
+		18: mesgs[11],
+		19: mesgs[12],
+		20: mesgs[13],
+		21: mesgs[19],
+		22: mesgs[21],
+	}
+	return
 }
 
 func TestActivityCorrectness(t *testing.T) {
-	mesgs := newActivityMessageForTest(time.Now())
+	mesgs, expected := newActivityMessagesWithExpectedOrder(time.Now())
+
 	activity := filedef.NewActivity(mesgs...)
 	if activity.FileId.Type != typedef.FileActivity {
 		t.Fatalf("expected: %v, got: %v", typedef.FileActivity, activity.FileId.Type)
@@ -149,21 +184,40 @@ func TestActivityCorrectness(t *testing.T) {
 
 	fit := activity.ToFIT(nil) // use standard factory
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if !isMessageOrdered(mesgs, fit.Messages, t) {
+	if !isMessageOrdered(expected, fit.Messages, t) {
 		t.Fatalf("messages order mismatch")
 	}
 
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
+	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
+	sortFields(expected)
+	sortFields(fit.Messages)
+
+	if diff := cmp.Diff(expected, fit.Messages, valueTransformer()); diff != "" {
 		t.Fatal(diff)
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
+	// Test if message is being referenced instead of copy:
+	//  - Change any of message in the expected messages should not reflect on the resulting messages.
+	expected[len(expected)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
+	if diff := cmp.Diff(expected, fit.Messages, valueTransformer()); diff == "" {
 		t.Fatalf("the modification reflect on the resulting messages")
 	}
+}
+
+func isMessageOrdered(expected, result []proto.Message, t *testing.T) bool {
+	var ordered = true
+	for i := range expected {
+		if expected[i].Num != result[i].Num {
+			ordered = false
+			t.Logf("[%d]: expected: %s, got: %s, timestamps: [%v, %v]",
+				i, expected[i].Num, result[i].Num,
+				expected[i].FieldValueByNum(proto.FieldNumTimestamp).Any(),
+				result[i].FieldValueByNum(proto.FieldNumTimestamp).Any())
+			continue
+		}
+
+		t.Logf("[%d]: OK! (%s), timestamp: %v", expected[i].Num,
+			expected[i].Num, expected[i].FieldValueByNum(proto.FieldNumTimestamp).Any())
+	}
+	return ordered
 }

--- a/profile/filedef/blood_pressure.go
+++ b/profile/filedef/blood_pressure.go
@@ -71,6 +71,7 @@ func (f *BloodPressure) ToFIT(options *mesgdef.Options) proto.FIT {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
+	var sortStartPos = 1 + len(f.DeveloperDataIds) + len(f.FieldDescriptions)
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
 	for i := range f.DeveloperDataIds {
@@ -91,7 +92,7 @@ func (f *BloodPressure) ToFIT(options *mesgdef.Options) proto.FIT {
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
-	SortMessagesByTimestamp(fit.Messages)
+	SortMessagesByTimestamp(fit.Messages[sortStartPos:])
 
 	return fit
 }

--- a/profile/filedef/blood_pressure_test.go
+++ b/profile/filedef/blood_pressure_test.go
@@ -5,11 +5,9 @@
 package filedef_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/filedef"
@@ -63,23 +61,23 @@ func TestBloodPressureCorrectness(t *testing.T) {
 
 	fit := bloodPressure.ToFIT(nil) // use standard factory
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
-		fmt.Println("messages order:")
-		for i := range fit.Messages {
-			mesg := fit.Messages[i]
-			fmt.Printf("%d: %s\n", mesg.Num, mesg.Num)
-		}
-		fmt.Println("")
-		t.Fatal(diff)
+	histogramExpected := map[typedef.MesgNum]int{}
+	for i := range mesgs {
+		histogramExpected[mesgs[i].Num]++
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
-		t.Fatalf("the modification reflect on the resulting messages")
+	histogramResult := map[typedef.MesgNum]int{}
+	for i := range fit.Messages {
+		histogramResult[fit.Messages[i].Num]++
+	}
+
+	if len(histogramExpected) != len(histogramResult) {
+		t.Fatalf("expected len: %d, got: %d", len(histogramExpected), len(histogramResult))
+	}
+
+	for key, expectedCount := range histogramExpected {
+		if resultCount := histogramResult[key]; expectedCount != resultCount {
+			t.Errorf("expected message count: %d, got: %d", expectedCount, resultCount)
+		}
 	}
 }

--- a/profile/filedef/course.go
+++ b/profile/filedef/course.go
@@ -87,6 +87,7 @@ func (f *Course) ToFIT(options *mesgdef.Options) proto.FIT {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
+	var sortStartPos = 1 + len(f.DeveloperDataIds) + len(f.FieldDescriptions)
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
 	for i := range f.DeveloperDataIds {
@@ -113,7 +114,7 @@ func (f *Course) ToFIT(options *mesgdef.Options) proto.FIT {
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
-	SortMessagesByTimestamp(fit.Messages)
+	SortMessagesByTimestamp(fit.Messages[sortStartPos:])
 
 	return fit
 }

--- a/profile/filedef/course_test.go
+++ b/profile/filedef/course_test.go
@@ -5,11 +5,9 @@
 package filedef_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/filedef"
@@ -78,23 +76,23 @@ func TestCourseCorrectness(t *testing.T) {
 
 	fit := course.ToFIT(nil)
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
-		fmt.Println("messages order:")
-		for i := range fit.Messages {
-			mesg := fit.Messages[i]
-			fmt.Printf("%d: %s\n", mesg.Num, mesg.Num)
-		}
-		fmt.Println("")
-		t.Fatal(diff)
+	histogramExpected := map[typedef.MesgNum]int{}
+	for i := range mesgs {
+		histogramExpected[mesgs[i].Num]++
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
-		t.Fatalf("the modification reflect on the resulting messages")
+	histogramResult := map[typedef.MesgNum]int{}
+	for i := range fit.Messages {
+		histogramResult[fit.Messages[i].Num]++
+	}
+
+	if len(histogramExpected) != len(histogramResult) {
+		t.Fatalf("expected len: %d, got: %d", len(histogramExpected), len(histogramResult))
+	}
+
+	for k, expectedCount := range histogramExpected {
+		if resultCount := histogramResult[k]; expectedCount != resultCount {
+			t.Errorf("expected message count: %d, got: %d", expectedCount, resultCount)
+		}
 	}
 }

--- a/profile/filedef/device.go
+++ b/profile/filedef/device.go
@@ -102,6 +102,10 @@ func (f *Device) ToFIT(options *mesgdef.Options) proto.FIT {
 		fit.Messages = append(fit.Messages, f.FieldCapabilities[i].ToMesg(options))
 	}
 
+	// Device File does not have fields require sorting,
+	// only sort unrelated messages in case it matters.
+	SortMessagesByTimestamp(f.UnrelatedMessages)
+
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
 	return fit

--- a/profile/filedef/device_test.go
+++ b/profile/filedef/device_test.go
@@ -5,11 +5,9 @@
 package filedef_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/filedef"
@@ -70,23 +68,23 @@ func TestDeviceCorrectness(t *testing.T) {
 
 	fit := device.ToFIT(nil) // use standard factory
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
-		fmt.Println("messages order:")
-		for i := range fit.Messages {
-			mesg := fit.Messages[i]
-			fmt.Printf("%d: %s\n", mesg.Num, mesg.Num)
-		}
-		fmt.Println("")
-		t.Fatal(diff)
+	histogramExpected := map[typedef.MesgNum]int{}
+	for i := range mesgs {
+		histogramExpected[mesgs[i].Num]++
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
-		t.Fatalf("the modification reflect on the resulting messages")
+	histogramResult := map[typedef.MesgNum]int{}
+	for i := range fit.Messages {
+		histogramResult[fit.Messages[i].Num]++
+	}
+
+	if len(histogramExpected) != len(histogramResult) {
+		t.Fatalf("expected len: %d, got: %d", len(histogramExpected), len(histogramResult))
+	}
+
+	for k, expectedCount := range histogramExpected {
+		if resultCount := histogramResult[k]; expectedCount != resultCount {
+			t.Errorf("expected message count: %d, got: %d", expectedCount, resultCount)
+		}
 	}
 }

--- a/profile/filedef/doc.go
+++ b/profile/filedef/doc.go
@@ -2,6 +2,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package filedef contains the implementation of known common file types and its listener
-// to convert decoded FIT file into the desired common file type as soon as the message is decoded.
+// Package filedef contains general implementation of known common file types retrieved from
+// Garmin or its affiliates website and a listener building block convert decoded FIT file into
+// the desired common file type as soon as the message is decoded.
+//
+// You may find that the common file types declared here are not sufficient for your need,
+// but don't worry, you can always create your own common file types that suit your need more;
+// whether creating a fresh one or embedding the existing; and still be able to use listener
+// building block as long as it satisfy the File interface.
 package filedef

--- a/profile/filedef/filedef_test.go
+++ b/profile/filedef/filedef_test.go
@@ -22,7 +22,10 @@ func TestToMesgs(t *testing.T) {
 	records[0] = mesgdef.NewRecord(nil).
 		SetTimestamp(time.Now())
 
-	filedef.ToMesgs(&messages, nil, mesgnum.Record, records)
+	for i := range records {
+		messages = append(messages, records[i].ToMesg(nil))
+	}
+
 	if len(messages) != 1 {
 		t.Fatalf("expected 1: got: %d", len(messages))
 	}
@@ -50,15 +53,23 @@ func TestSortMessagesByTimestamp(t *testing.T) {
 		5: factory.CreateMesgOnly(mesgnum.Session).WithFields(
 			factory.CreateField(mesgnum.Session, fieldnum.SessionTimestamp).WithValue(datetime.ToUint32(now.Add(2 * time.Second))),
 		),
+		6: factory.CreateMesgOnly(mesgnum.UserProfile).WithFields(
+			factory.CreateField(mesgnum.UserProfile, fieldnum.UserProfileFriendlyName).WithValue("muktihari"),
+		),
+		7: factory.CreateMesgOnly(mesgnum.Record).WithFields(
+			factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now.Add(2 * time.Second))),
+		),
 	}
 
 	expected := []proto.Message{
 		messages[0],
+		messages[6],
 		messages[1],
 		messages[3],
 		messages[2],
 		messages[4],
 		messages[5],
+		messages[7],
 	}
 
 	filedef.SortMessagesByTimestamp(messages)

--- a/profile/filedef/goals.go
+++ b/profile/filedef/goals.go
@@ -77,6 +77,10 @@ func (f *Goals) ToFIT(options *mesgdef.Options) proto.FIT {
 		fit.Messages = append(fit.Messages, f.Goals[i].ToMesg(options))
 	}
 
+	// Goals File does not have fields require sorting,
+	// only sort unrelated messages in case it matters.
+	SortMessagesByTimestamp(f.UnrelatedMessages)
+
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
 	return fit

--- a/profile/filedef/goals_test.go
+++ b/profile/filedef/goals_test.go
@@ -5,11 +5,9 @@
 package filedef_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/filedef"
@@ -54,23 +52,23 @@ func TestGoalsCorrectness(t *testing.T) {
 
 	fit := goals.ToFIT(nil) // use standard factory
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
-		fmt.Println("messages order:")
-		for i := range fit.Messages {
-			mesg := fit.Messages[i]
-			fmt.Printf("%d: %s\n", mesg.Num, mesg.Num)
-		}
-		fmt.Println("")
-		t.Fatal(diff)
+	histogramExpected := map[typedef.MesgNum]int{}
+	for i := range mesgs {
+		histogramExpected[mesgs[i].Num]++
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
-		t.Fatalf("the modification reflect on the resulting messages")
+	histogramResult := map[typedef.MesgNum]int{}
+	for i := range fit.Messages {
+		histogramResult[fit.Messages[i].Num]++
+	}
+
+	if len(histogramExpected) != len(histogramResult) {
+		t.Fatalf("expected len: %d, got: %d", len(histogramExpected), len(histogramResult))
+	}
+
+	for k, expectedCount := range histogramExpected {
+		if resultCount := histogramResult[k]; expectedCount != resultCount {
+			t.Errorf("expected message count: %d, got: %d", expectedCount, resultCount)
+		}
 	}
 }

--- a/profile/filedef/monitoring_ab.go
+++ b/profile/filedef/monitoring_ab.go
@@ -75,6 +75,7 @@ func (f *MonitoringAB) ToFIT(options *mesgdef.Options) proto.FIT {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
+	var sortStartPos = 1 + len(f.DeveloperDataIds) + len(f.FieldDescriptions)
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
 	for i := range f.DeveloperDataIds {
@@ -95,7 +96,7 @@ func (f *MonitoringAB) ToFIT(options *mesgdef.Options) proto.FIT {
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
-	SortMessagesByTimestamp(fit.Messages)
+	SortMessagesByTimestamp(fit.Messages[sortStartPos:])
 
 	return fit
 }

--- a/profile/filedef/monitoring_daily.go
+++ b/profile/filedef/monitoring_daily.go
@@ -71,6 +71,7 @@ func (f *MonitoringDaily) ToFIT(options *mesgdef.Options) proto.FIT {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
+	var sortStartPos = 1 + len(f.DeveloperDataIds) + len(f.FieldDescriptions)
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
 	for i := range f.DeveloperDataIds {
@@ -91,7 +92,7 @@ func (f *MonitoringDaily) ToFIT(options *mesgdef.Options) proto.FIT {
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
-	SortMessagesByTimestamp(fit.Messages)
+	SortMessagesByTimestamp(fit.Messages[sortStartPos:])
 
 	return fit
 }

--- a/profile/filedef/monitoring_daily_test.go
+++ b/profile/filedef/monitoring_daily_test.go
@@ -5,11 +5,9 @@
 package filedef_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/filedef"
@@ -60,23 +58,23 @@ func TestDailyMonitoringCorrectness(t *testing.T) {
 
 	fit := monitoringDaily.ToFIT(nil) // use standard factory
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
-		fmt.Println("messages order:")
-		for i := range fit.Messages {
-			mesg := fit.Messages[i]
-			fmt.Printf("%d: %s\n", mesg.Num, mesg.Num)
-		}
-		fmt.Println("")
-		t.Fatal(diff)
+	histogramExpected := map[typedef.MesgNum]int{}
+	for i := range mesgs {
+		histogramExpected[mesgs[i].Num]++
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
-		t.Fatalf("the modification reflect on the resulting messages")
+	histogramResult := map[typedef.MesgNum]int{}
+	for i := range fit.Messages {
+		histogramResult[fit.Messages[i].Num]++
+	}
+
+	if len(histogramExpected) != len(histogramResult) {
+		t.Fatalf("expected len: %d, got: %d", len(histogramExpected), len(histogramResult))
+	}
+
+	for k, expectedCount := range histogramExpected {
+		if resultCount := histogramResult[k]; expectedCount != resultCount {
+			t.Errorf("expected message count: %d, got: %d", expectedCount, resultCount)
+		}
 	}
 }

--- a/profile/filedef/schedules.go
+++ b/profile/filedef/schedules.go
@@ -77,6 +77,10 @@ func (f *Schedules) ToFIT(options *mesgdef.Options) proto.FIT {
 		fit.Messages = append(fit.Messages, f.Schedules[i].ToMesg(options))
 	}
 
+	// Schedules File does not have fields require sorting,
+	// only sort unrelated messages in case it matters.
+	SortMessagesByTimestamp(f.UnrelatedMessages)
+
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
 	return fit

--- a/profile/filedef/schedules_test.go
+++ b/profile/filedef/schedules_test.go
@@ -5,11 +5,9 @@
 package filedef_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/filedef"
@@ -54,23 +52,23 @@ func TestSchedulesCorrectness(t *testing.T) {
 
 	fit := schedules.ToFIT(nil) // use standard factory
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
-		fmt.Println("messages order:")
-		for i := range fit.Messages {
-			mesg := fit.Messages[i]
-			fmt.Printf("%d: %s\n", mesg.Num, mesg.Num)
-		}
-		fmt.Println("")
-		t.Fatal(diff)
+	histogramExpected := map[typedef.MesgNum]int{}
+	for i := range mesgs {
+		histogramExpected[mesgs[i].Num]++
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
-		t.Fatalf("the modification reflect on the resulting messages")
+	histogramResult := map[typedef.MesgNum]int{}
+	for i := range fit.Messages {
+		histogramResult[fit.Messages[i].Num]++
+	}
+
+	if len(histogramExpected) != len(histogramResult) {
+		t.Fatalf("expected len: %d, got: %d", len(histogramExpected), len(histogramResult))
+	}
+
+	for k, expectedCount := range histogramExpected {
+		if resultCount := histogramResult[k]; expectedCount != resultCount {
+			t.Errorf("expected message count: %d, got: %d", expectedCount, resultCount)
+		}
 	}
 }

--- a/profile/filedef/segment.go
+++ b/profile/filedef/segment.go
@@ -95,6 +95,10 @@ func (f *Segment) ToFIT(options *mesgdef.Options) proto.FIT {
 		fit.Messages = append(fit.Messages, f.SegmentPoints[i].ToMesg(options))
 	}
 
+	// Segment File does not have fields require sorting,
+	// only sort unrelated messages in case it matters.
+	SortMessagesByTimestamp(f.UnrelatedMessages)
+
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
 	return fit

--- a/profile/filedef/segment_list.go
+++ b/profile/filedef/segment_list.go
@@ -83,6 +83,10 @@ func (f *SegmentList) ToFIT(options *mesgdef.Options) proto.FIT {
 		fit.Messages = append(fit.Messages, f.SegmentFiles[i].ToMesg(options))
 	}
 
+	// SegmentList File does not have fields require sorting,
+	// only sort unrelated messages in case it matters.
+	SortMessagesByTimestamp(f.UnrelatedMessages)
+
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
 	return fit

--- a/profile/filedef/segment_list_test.go
+++ b/profile/filedef/segment_list_test.go
@@ -5,11 +5,9 @@
 package filedef_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/filedef"
@@ -57,23 +55,23 @@ func TestSegmentListCorrectness(t *testing.T) {
 
 	fit := segmentList.ToFIT(nil) // use standard factory
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
-		fmt.Println("messages order:")
-		for i := range fit.Messages {
-			mesg := fit.Messages[i]
-			fmt.Printf("%d: %s\n", mesg.Num, mesg.Num)
-		}
-		fmt.Println("")
-		t.Fatal(diff)
+	histogramExpected := map[typedef.MesgNum]int{}
+	for i := range mesgs {
+		histogramExpected[mesgs[i].Num]++
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
-		t.Fatalf("the modification reflect on the resulting messages")
+	histogramResult := map[typedef.MesgNum]int{}
+	for i := range fit.Messages {
+		histogramResult[fit.Messages[i].Num]++
+	}
+
+	if len(histogramExpected) != len(histogramResult) {
+		t.Fatalf("expected len: %d, got: %d", len(histogramExpected), len(histogramResult))
+	}
+
+	for k, expectedCount := range histogramExpected {
+		if resultCount := histogramResult[k]; expectedCount != resultCount {
+			t.Errorf("expected message count: %d, got: %d", expectedCount, resultCount)
+		}
 	}
 }

--- a/profile/filedef/settings.go
+++ b/profile/filedef/settings.go
@@ -102,6 +102,10 @@ func (f *Settings) ToFIT(options *mesgdef.Options) proto.FIT {
 		fit.Messages = append(fit.Messages, f.DeviceSettings[i].ToMesg(options))
 	}
 
+	// Settings File does not have fields require sorting,
+	// only sort unrelated messages in case it matters.
+	SortMessagesByTimestamp(f.UnrelatedMessages)
+
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
 	return fit

--- a/profile/filedef/settings_test.go
+++ b/profile/filedef/settings_test.go
@@ -5,11 +5,9 @@
 package filedef_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/filedef"
@@ -66,23 +64,23 @@ func TestSettingsCorrectness(t *testing.T) {
 
 	fit := settings.ToFIT(nil) // use standard factory
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
-		fmt.Println("messages order:")
-		for i := range fit.Messages {
-			mesg := fit.Messages[i]
-			fmt.Printf("%d: %s\n", mesg.Num, mesg.Num)
-		}
-		fmt.Println("")
-		t.Fatal(diff)
+	histogramExpected := map[typedef.MesgNum]int{}
+	for i := range mesgs {
+		histogramExpected[mesgs[i].Num]++
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
-		t.Fatalf("the modification reflect on the resulting messages")
+	histogramResult := map[typedef.MesgNum]int{}
+	for i := range fit.Messages {
+		histogramResult[fit.Messages[i].Num]++
+	}
+
+	if len(histogramExpected) != len(histogramResult) {
+		t.Fatalf("expected len: %d, got: %d", len(histogramExpected), len(histogramResult))
+	}
+
+	for k, expectedCount := range histogramExpected {
+		if resultCount := histogramResult[k]; expectedCount != resultCount {
+			t.Errorf("expected message count: %d, got: %d", expectedCount, resultCount)
+		}
 	}
 }

--- a/profile/filedef/sport.go
+++ b/profile/filedef/sport.go
@@ -114,6 +114,10 @@ func (f *Sport) ToFIT(options *mesgdef.Options) proto.FIT {
 		fit.Messages = append(fit.Messages, f.CadenceZones[i].ToMesg(options))
 	}
 
+	// Sport File does not have fields require sorting,
+	// only sort unrelated messages in case it matters.
+	SortMessagesByTimestamp(f.UnrelatedMessages)
+
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
 	return fit

--- a/profile/filedef/sport_test.go
+++ b/profile/filedef/sport_test.go
@@ -5,11 +5,9 @@
 package filedef_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/filedef"
@@ -72,23 +70,23 @@ func TestSportCorrectness(t *testing.T) {
 
 	fit := sport.ToFIT(nil) // use standard factory
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
-		fmt.Println("messages order:")
-		for i := range fit.Messages {
-			mesg := fit.Messages[i]
-			fmt.Printf("%d: %s\n", mesg.Num, mesg.Num)
-		}
-		fmt.Println("")
-		t.Fatal(diff)
+	histogramExpected := map[typedef.MesgNum]int{}
+	for i := range mesgs {
+		histogramExpected[mesgs[i].Num]++
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
-		t.Fatalf("the modification reflect on the resulting messages")
+	histogramResult := map[typedef.MesgNum]int{}
+	for i := range fit.Messages {
+		histogramResult[fit.Messages[i].Num]++
+	}
+
+	if len(histogramExpected) != len(histogramResult) {
+		t.Fatalf("expected len: %d, got: %d", len(histogramExpected), len(histogramResult))
+	}
+
+	for k, expectedCount := range histogramExpected {
+		if resultCount := histogramResult[k]; expectedCount != resultCount {
+			t.Errorf("expected message count: %d, got: %d", expectedCount, resultCount)
+		}
 	}
 }

--- a/profile/filedef/totals.go
+++ b/profile/filedef/totals.go
@@ -66,6 +66,7 @@ func (f *Totals) ToFIT(options *mesgdef.Options) proto.FIT {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
+	var sortStartPos = 1 + len(f.DeveloperDataIds) + len(f.FieldDescriptions)
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
 	for i := range f.DeveloperDataIds {
@@ -80,7 +81,7 @@ func (f *Totals) ToFIT(options *mesgdef.Options) proto.FIT {
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
-	SortMessagesByTimestamp(fit.Messages)
+	SortMessagesByTimestamp(fit.Messages[sortStartPos:])
 
 	return fit
 }

--- a/profile/filedef/totals_test.go
+++ b/profile/filedef/totals_test.go
@@ -5,11 +5,9 @@
 package filedef_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/filedef"
@@ -54,23 +52,23 @@ func TestTotalsCorrectness(t *testing.T) {
 
 	fit := totals.ToFIT(nil) // use standard factory
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
-		fmt.Println("messages order:")
-		for i := range fit.Messages {
-			mesg := fit.Messages[i]
-			fmt.Printf("%d: %s\n", mesg.Num, mesg.Num)
-		}
-		fmt.Println("")
-		t.Fatal(diff)
+	histogramExpected := map[typedef.MesgNum]int{}
+	for i := range mesgs {
+		histogramExpected[mesgs[i].Num]++
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
-		t.Fatalf("the modification reflect on the resulting messages")
+	histogramResult := map[typedef.MesgNum]int{}
+	for i := range fit.Messages {
+		histogramResult[fit.Messages[i].Num]++
+	}
+
+	if len(histogramExpected) != len(histogramResult) {
+		t.Fatalf("expected len: %d, got: %d", len(histogramExpected), len(histogramResult))
+	}
+
+	for k, expectedCount := range histogramExpected {
+		if resultCount := histogramResult[k]; expectedCount != resultCount {
+			t.Errorf("expected message count: %d, got: %d", expectedCount, resultCount)
+		}
 	}
 }

--- a/profile/filedef/weight.go
+++ b/profile/filedef/weight.go
@@ -71,6 +71,7 @@ func (f *Weight) ToFIT(options *mesgdef.Options) proto.FIT {
 	}
 
 	// Should be as ordered: FieldId, DeveloperDataId and FieldDescription
+	var sortStartPos = 1 + len(f.DeveloperDataIds) + len(f.FieldDescriptions)
 	fit.Messages = append(fit.Messages, f.FileId.ToMesg(options))
 
 	for i := range f.DeveloperDataIds {
@@ -91,7 +92,7 @@ func (f *Weight) ToFIT(options *mesgdef.Options) proto.FIT {
 
 	fit.Messages = append(fit.Messages, f.UnrelatedMessages...)
 
-	SortMessagesByTimestamp(fit.Messages)
+	SortMessagesByTimestamp(fit.Messages[sortStartPos:])
 
 	return fit
 }

--- a/profile/filedef/weight_test.go
+++ b/profile/filedef/weight_test.go
@@ -5,11 +5,9 @@
 package filedef_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/filedef"
@@ -60,23 +58,23 @@ func TestWeightCorrectness(t *testing.T) {
 
 	fit := weight.ToFIT(nil) // use standard factory
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
-		fmt.Println("messages order:")
-		for i := range fit.Messages {
-			mesg := fit.Messages[i]
-			fmt.Printf("%d: %s\n", mesg.Num, mesg.Num)
-		}
-		fmt.Println("")
-		t.Fatal(diff)
+	histogramExpected := map[typedef.MesgNum]int{}
+	for i := range mesgs {
+		histogramExpected[mesgs[i].Num]++
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
-		t.Fatalf("the modification reflect on the resulting messages")
+	histogramResult := map[typedef.MesgNum]int{}
+	for i := range fit.Messages {
+		histogramResult[fit.Messages[i].Num]++
+	}
+
+	if len(histogramExpected) != len(histogramResult) {
+		t.Fatalf("expected len: %d, got: %d", len(histogramExpected), len(histogramResult))
+	}
+
+	for k, expectedCount := range histogramExpected {
+		if resultCount := histogramResult[k]; expectedCount != resultCount {
+			t.Errorf("expected message count: %d, got: %d", expectedCount, resultCount)
+		}
 	}
 }

--- a/profile/filedef/workout_test.go
+++ b/profile/filedef/workout_test.go
@@ -5,11 +5,9 @@
 package filedef_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/filedef"
@@ -60,23 +58,23 @@ func TestWorkoutCorrectness(t *testing.T) {
 
 	fit := workout.ToFIT(nil)
 
-	// ignore fields order, make the order asc, as long as the data is equal, we consider equal.
-	sortFields(mesgs)
-	sortFields(fit.Messages)
-
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff != "" {
-		fmt.Println("messages order:")
-		for i := range fit.Messages {
-			mesg := fit.Messages[i]
-			fmt.Printf("%d: %s\n", mesg.Num, mesg.Num)
-		}
-		fmt.Println("")
-		t.Fatal(diff)
+	histogramExpected := map[typedef.MesgNum]int{}
+	for i := range mesgs {
+		histogramExpected[mesgs[i].Num]++
 	}
 
-	// Edit unrelated message, should not change the resulting messages.
-	mesgs[len(mesgs)-1].Fields[0].Value = proto.Uint32(datetime.ToUint32(time.Now()))
-	if diff := cmp.Diff(mesgs, fit.Messages, valueTransformer()); diff == "" {
-		t.Fatalf("the modification reflect on the resulting messages")
+	histogramResult := map[typedef.MesgNum]int{}
+	for i := range fit.Messages {
+		histogramResult[fit.Messages[i].Num]++
+	}
+
+	if len(histogramExpected) != len(histogramResult) {
+		t.Fatalf("expected len: %d, got: %d", len(histogramExpected), len(histogramResult))
+	}
+
+	for k, expectedCount := range histogramExpected {
+		if resultCount := histogramResult[k]; expectedCount != resultCount {
+			t.Errorf("expected message count: %d, got: %d", expectedCount, resultCount)
+		}
 	}
 }


### PR DESCRIPTION
- Previously, for most common file types, let's say Activity, when calling ToFIT, it will sorting the messages based on timestamp, however the previous sorting contains bug for some messages may not be sorted properly if we encounter message without a timestamp or have invalid timestamp in the middle of the process. This PR fix this issue with few rules being changed, here is the details:
  - FileId, DeveloperDataId and FieldDescription messages will not be included in sorting and will remain at the beginning of the slice.
  - Any message without timestamp field will be placed to the beginning of the slice to enable these messages to be retrieved early such as UserProfile.
  - Any message with invalid timestamp will be places at the end of the slices.
  - Any common file types that does not have fields require sorting, we will only try sorting the unrelated messages since those massages may contains timestamp field requires sorting (in case it matters).
- filedef's `ToMesgs func` and `ToMesg interface` are now removed as it was previously marked as deprecated.
