### PR TITLE
chore(filedef): clean up unnecessary developer-field-copy

### DIFF
--- a/profile/filedef/activity.go
+++ b/profile/filedef/activity.go
@@ -96,7 +96,6 @@ func (f *Activity) Add(mesg proto.Message) {
 		f.HRVs = append(f.HRVs, mesgdef.NewHrv(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/activity_summary.go
+++ b/profile/filedef/activity_summary.go
@@ -54,7 +54,6 @@ func (f *ActivitySummary) Add(mesg proto.Message) {
 		f.Laps = append(f.Laps, mesgdef.NewLap(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/blood_pressure.go
+++ b/profile/filedef/blood_pressure.go
@@ -54,7 +54,6 @@ func (f *BloodPressure) Add(mesg proto.Message) {
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/course.go
+++ b/profile/filedef/course.go
@@ -70,7 +70,6 @@ func (f *Course) Add(mesg proto.Message) {
 		f.CoursePoints = append(f.CoursePoints, mesgdef.NewCoursePoint(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/device.go
+++ b/profile/filedef/device.go
@@ -60,7 +60,6 @@ func (f *Device) Add(mesg proto.Message) {
 		f.FieldCapabilities = append(f.FieldCapabilities, mesgdef.NewFieldCapabilities(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/goals.go
+++ b/profile/filedef/goals.go
@@ -48,7 +48,6 @@ func (f *Goals) Add(mesg proto.Message) {
 		f.Goals = append(f.Goals, mesgdef.NewGoal(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/monitoring_ab.go
+++ b/profile/filedef/monitoring_ab.go
@@ -58,7 +58,6 @@ func (f *MonitoringAB) Add(mesg proto.Message) {
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/monitoring_daily.go
+++ b/profile/filedef/monitoring_daily.go
@@ -54,7 +54,6 @@ func (f *MonitoringDaily) Add(mesg proto.Message) {
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/schedules.go
+++ b/profile/filedef/schedules.go
@@ -48,7 +48,6 @@ func (f *Schedules) Add(mesg proto.Message) {
 		f.Schedules = append(f.Schedules, mesgdef.NewSchedule(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/segment.go
+++ b/profile/filedef/segment.go
@@ -57,7 +57,6 @@ func (f *Segment) Add(mesg proto.Message) {
 		f.SegmentPoints = append(f.SegmentPoints, mesgdef.NewSegmentPoint(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/segment_list.go
+++ b/profile/filedef/segment_list.go
@@ -51,7 +51,6 @@ func (f *SegmentList) Add(mesg proto.Message) {
 		f.SegmentFiles = append(f.SegmentFiles, mesgdef.NewSegmentFile(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/settings.go
+++ b/profile/filedef/settings.go
@@ -60,7 +60,6 @@ func (f *Settings) Add(mesg proto.Message) {
 		f.DeviceSettings = append(f.DeviceSettings, mesgdef.NewDeviceSettings(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/sport.go
+++ b/profile/filedef/sport.go
@@ -66,7 +66,6 @@ func (f *Sport) Add(mesg proto.Message) {
 		f.CadenceZones = append(f.CadenceZones, mesgdef.NewCadenceZone(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/totals.go
+++ b/profile/filedef/totals.go
@@ -49,7 +49,6 @@ func (f *Totals) Add(mesg proto.Message) {
 		f.Totals = append(f.Totals, mesgdef.NewTotals(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/weight.go
+++ b/profile/filedef/weight.go
@@ -54,7 +54,6 @@ func (f *Weight) Add(mesg proto.Message) {
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/workout.go
+++ b/profile/filedef/workout.go
@@ -55,7 +55,6 @@ func (f *Workout) Add(mesg proto.Message) {
 		f.WorkoutSteps = append(f.WorkoutSteps, mesgdef.NewWorkoutStep(&mesg))
 	default:
 		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }


### PR DESCRIPTION
- Listener has already cloned the developerFields, the common file types should not clone it again.
- Add compile-time type assertion for Listener to satisfy decoder.Listener interface.
- Change Listener's options from pointer into concrete value. (reduce 1 alloc)