### PR TITLE
chore: make fields/developerFields n buffer size 255 instead of 256

### DIFF
--- a/cmd/fitconv/fitcsv/csv_to_fit.go
+++ b/cmd/fitconv/fitcsv/csv_to_fit.go
@@ -20,6 +20,7 @@ import (
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
 )
 
 type CSVToFITConv struct {
@@ -29,9 +30,9 @@ type CSVToFITConv struct {
 
 	fit proto.FIT
 
-	fieldsArray          [256]proto.Field
-	developerFieldsArray [256]proto.DeveloperField
-	protoValuesArray     [256]proto.Value
+	fieldsArray          [255]proto.Field
+	developerFieldsArray [255]proto.DeveloperField
+	protoValuesArray     [255]proto.Value
 
 	fieldDescriptions []*mesgdef.FieldDescription
 
@@ -134,10 +135,8 @@ loop:
 			}
 
 			if c.streamEnc == nil {
-				mesg.Fields = make([]proto.Field, len(mesg.Fields))
-				copy(mesg.Fields, c.fieldsArray[:])
-				mesg.DeveloperFields = make([]proto.DeveloperField, len(mesg.DeveloperFields))
-				copy(mesg.DeveloperFields, c.developerFieldsArray[:])
+				mesg.Fields = slices.Clone(mesg.Fields)
+				mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
 				c.fit.Messages = append(c.fit.Messages, mesg)
 				continue loop
 			}

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -50,8 +50,8 @@ type Decoder struct {
 	accumulator *Accumulator
 	crc16       hash.Hash16
 
-	fieldsArray           [256]proto.Field
-	developersFieldsArray [256]proto.DeveloperField
+	fieldsArray           [255]proto.Field
+	developersFieldsArray [255]proto.DeveloperField
 
 	options options
 

--- a/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
+++ b/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
@@ -90,7 +90,7 @@ func (m *{{ .Name }}) ToMesg(options *Options) proto.Message {
 
     fac := options.Factory
 
-    arr := pool.Get().(*[256]proto.Field)
+    arr := pool.Get().(*[255]proto.Field)
     defer pool.Put(arr)
     
     fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/aad_accel_features_gen.go
+++ b/profile/mesgdef/aad_accel_features_gen.go
@@ -72,7 +72,7 @@ func (m *AadAccelFeatures) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/accelerometer_data_gen.go
+++ b/profile/mesgdef/accelerometer_data_gen.go
@@ -82,7 +82,7 @@ func (m *AccelerometerData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/activity_gen.go
+++ b/profile/mesgdef/activity_gen.go
@@ -76,7 +76,7 @@ func (m *Activity) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/ant_channel_id_gen.go
+++ b/profile/mesgdef/ant_channel_id_gen.go
@@ -66,7 +66,7 @@ func (m *AntChannelId) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/ant_rx_gen.go
+++ b/profile/mesgdef/ant_rx_gen.go
@@ -80,7 +80,7 @@ func (m *AntRx) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/ant_tx_gen.go
+++ b/profile/mesgdef/ant_tx_gen.go
@@ -80,7 +80,7 @@ func (m *AntTx) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/aviation_attitude_gen.go
+++ b/profile/mesgdef/aviation_attitude_gen.go
@@ -92,7 +92,7 @@ func (m *AviationAttitude) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/barometer_data_gen.go
+++ b/profile/mesgdef/barometer_data_gen.go
@@ -66,7 +66,7 @@ func (m *BarometerData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/beat_intervals_gen.go
+++ b/profile/mesgdef/beat_intervals_gen.go
@@ -64,7 +64,7 @@ func (m *BeatIntervals) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/bike_profile_gen.go
+++ b/profile/mesgdef/bike_profile_gen.go
@@ -122,7 +122,7 @@ func (m *BikeProfile) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/blood_pressure_gen.go
+++ b/profile/mesgdef/blood_pressure_gen.go
@@ -80,7 +80,7 @@ func (m *BloodPressure) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/cadence_zone_gen.go
+++ b/profile/mesgdef/cadence_zone_gen.go
@@ -62,7 +62,7 @@ func (m *CadenceZone) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/camera_event_gen.go
+++ b/profile/mesgdef/camera_event_gen.go
@@ -68,7 +68,7 @@ func (m *CameraEvent) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/capabilities_gen.go
+++ b/profile/mesgdef/capabilities_gen.go
@@ -69,7 +69,7 @@ func (m *Capabilities) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/chrono_shot_data_gen.go
+++ b/profile/mesgdef/chrono_shot_data_gen.go
@@ -66,7 +66,7 @@ func (m *ChronoShotData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/chrono_shot_session_gen.go
+++ b/profile/mesgdef/chrono_shot_session_gen.go
@@ -74,7 +74,7 @@ func (m *ChronoShotSession) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/climb_pro_gen.go
+++ b/profile/mesgdef/climb_pro_gen.go
@@ -74,7 +74,7 @@ func (m *ClimbPro) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/connectivity_gen.go
+++ b/profile/mesgdef/connectivity_gen.go
@@ -82,7 +82,7 @@ func (m *Connectivity) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/course_gen.go
+++ b/profile/mesgdef/course_gen.go
@@ -64,7 +64,7 @@ func (m *Course) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/course_point_gen.go
+++ b/profile/mesgdef/course_point_gen.go
@@ -77,7 +77,7 @@ func (m *CoursePoint) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/developer_data_id_gen.go
+++ b/profile/mesgdef/developer_data_id_gen.go
@@ -58,7 +58,7 @@ func (m *DeveloperDataId) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/device_aux_battery_info_gen.go
+++ b/profile/mesgdef/device_aux_battery_info_gen.go
@@ -70,7 +70,7 @@ func (m *DeviceAuxBatteryInfo) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/device_info_gen.go
+++ b/profile/mesgdef/device_info_gen.go
@@ -98,7 +98,7 @@ func (m *DeviceInfo) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/device_settings_gen.go
+++ b/profile/mesgdef/device_settings_gen.go
@@ -112,7 +112,7 @@ func (m *DeviceSettings) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/dive_alarm_gen.go
+++ b/profile/mesgdef/dive_alarm_gen.go
@@ -89,7 +89,7 @@ func (m *DiveAlarm) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/dive_apnea_alarm_gen.go
+++ b/profile/mesgdef/dive_apnea_alarm_gen.go
@@ -89,7 +89,7 @@ func (m *DiveApneaAlarm) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/dive_gas_gen.go
+++ b/profile/mesgdef/dive_gas_gen.go
@@ -66,7 +66,7 @@ func (m *DiveGas) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/dive_settings_gen.go
+++ b/profile/mesgdef/dive_settings_gen.go
@@ -130,7 +130,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/dive_summary_gen.go
+++ b/profile/mesgdef/dive_summary_gen.go
@@ -106,7 +106,7 @@ func (m *DiveSummary) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/event_gen.go
+++ b/profile/mesgdef/event_gen.go
@@ -106,7 +106,7 @@ func (m *Event) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/exd_data_concept_configuration_gen.go
+++ b/profile/mesgdef/exd_data_concept_configuration_gen.go
@@ -86,7 +86,7 @@ func (m *ExdDataConceptConfiguration) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/exd_data_field_configuration_gen.go
+++ b/profile/mesgdef/exd_data_field_configuration_gen.go
@@ -76,7 +76,7 @@ func (m *ExdDataFieldConfiguration) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/exd_screen_configuration_gen.go
+++ b/profile/mesgdef/exd_screen_configuration_gen.go
@@ -64,7 +64,7 @@ func (m *ExdScreenConfiguration) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/exercise_title_gen.go
+++ b/profile/mesgdef/exercise_title_gen.go
@@ -64,7 +64,7 @@ func (m *ExerciseTitle) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/field_capabilities_gen.go
+++ b/profile/mesgdef/field_capabilities_gen.go
@@ -66,7 +66,7 @@ func (m *FieldCapabilities) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/field_description_gen.go
+++ b/profile/mesgdef/field_description_gen.go
@@ -76,7 +76,7 @@ func (m *FieldDescription) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/file_capabilities_gen.go
+++ b/profile/mesgdef/file_capabilities_gen.go
@@ -68,7 +68,7 @@ func (m *FileCapabilities) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/file_creator_gen.go
+++ b/profile/mesgdef/file_creator_gen.go
@@ -60,7 +60,7 @@ func (m *FileCreator) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/file_id_gen.go
+++ b/profile/mesgdef/file_id_gen.go
@@ -64,7 +64,7 @@ func (m *FileId) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/goal_gen.go
+++ b/profile/mesgdef/goal_gen.go
@@ -84,7 +84,7 @@ func (m *Goal) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/gps_metadata_gen.go
+++ b/profile/mesgdef/gps_metadata_gen.go
@@ -79,7 +79,7 @@ func (m *GpsMetadata) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/gyroscope_data_gen.go
+++ b/profile/mesgdef/gyroscope_data_gen.go
@@ -76,7 +76,7 @@ func (m *GyroscopeData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hr_gen.go
+++ b/profile/mesgdef/hr_gen.go
@@ -80,7 +80,7 @@ func (m *Hr) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hr_zone_gen.go
+++ b/profile/mesgdef/hr_zone_gen.go
@@ -62,7 +62,7 @@ func (m *HrZone) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hrm_profile_gen.go
+++ b/profile/mesgdef/hrm_profile_gen.go
@@ -66,7 +66,7 @@ func (m *HrmProfile) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hrv_gen.go
+++ b/profile/mesgdef/hrv_gen.go
@@ -58,7 +58,7 @@ func (m *Hrv) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hrv_status_summary_gen.go
+++ b/profile/mesgdef/hrv_status_summary_gen.go
@@ -76,7 +76,7 @@ func (m *HrvStatusSummary) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hrv_value_gen.go
+++ b/profile/mesgdef/hrv_value_gen.go
@@ -64,7 +64,7 @@ func (m *HrvValue) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hsa_accelerometer_data_gen.go
+++ b/profile/mesgdef/hsa_accelerometer_data_gen.go
@@ -73,7 +73,7 @@ func (m *HsaAccelerometerData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hsa_body_battery_data_gen.go
+++ b/profile/mesgdef/hsa_body_battery_data_gen.go
@@ -68,7 +68,7 @@ func (m *HsaBodyBatteryData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hsa_configuration_data_gen.go
+++ b/profile/mesgdef/hsa_configuration_data_gen.go
@@ -64,7 +64,7 @@ func (m *HsaConfigurationData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hsa_event_gen.go
+++ b/profile/mesgdef/hsa_event_gen.go
@@ -62,7 +62,7 @@ func (m *HsaEvent) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hsa_gyroscope_data_gen.go
+++ b/profile/mesgdef/hsa_gyroscope_data_gen.go
@@ -73,7 +73,7 @@ func (m *HsaGyroscopeData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hsa_heart_rate_data_gen.go
+++ b/profile/mesgdef/hsa_heart_rate_data_gen.go
@@ -66,7 +66,7 @@ func (m *HsaHeartRateData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hsa_respiration_data_gen.go
+++ b/profile/mesgdef/hsa_respiration_data_gen.go
@@ -65,7 +65,7 @@ func (m *HsaRespirationData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hsa_spo2_data_gen.go
+++ b/profile/mesgdef/hsa_spo2_data_gen.go
@@ -66,7 +66,7 @@ func (m *HsaSpo2Data) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hsa_step_data_gen.go
+++ b/profile/mesgdef/hsa_step_data_gen.go
@@ -64,7 +64,7 @@ func (m *HsaStepData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hsa_stress_data_gen.go
+++ b/profile/mesgdef/hsa_stress_data_gen.go
@@ -64,7 +64,7 @@ func (m *HsaStressData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/hsa_wrist_temperature_data_gen.go
+++ b/profile/mesgdef/hsa_wrist_temperature_data_gen.go
@@ -65,7 +65,7 @@ func (m *HsaWristTemperatureData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/jump_gen.go
+++ b/profile/mesgdef/jump_gen.go
@@ -89,7 +89,7 @@ func (m *Jump) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/lap_gen.go
+++ b/profile/mesgdef/lap_gen.go
@@ -315,7 +315,7 @@ func (m *Lap) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/length_gen.go
+++ b/profile/mesgdef/length_gen.go
@@ -112,7 +112,7 @@ func (m *Length) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/magnetometer_data_gen.go
+++ b/profile/mesgdef/magnetometer_data_gen.go
@@ -76,7 +76,7 @@ func (m *MagnetometerData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/max_met_data_gen.go
+++ b/profile/mesgdef/max_met_data_gen.go
@@ -76,7 +76,7 @@ func (m *MaxMetData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/memo_glob_gen.go
+++ b/profile/mesgdef/memo_glob_gen.go
@@ -68,7 +68,7 @@ func (m *MemoGlob) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/mesg_capabilities_gen.go
+++ b/profile/mesgdef/mesg_capabilities_gen.go
@@ -66,7 +66,7 @@ func (m *MesgCapabilities) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/mesgdef.go
+++ b/profile/mesgdef/mesgdef.go
@@ -8,11 +8,13 @@ import (
 	"github.com/muktihari/fit/proto"
 )
 
+// Factory defines a contract that any Factory containing these method can be used by mesgdef's structs.
 type Factory interface {
+	// CreateField create new field based on defined messages in the factory. If not found, it returns new field with "unknown" name.
 	CreateField(mesgNum typedef.MesgNum, num byte) proto.Field
 }
 
-var pool = sync.Pool{New: func() any { return new([256]proto.Field) }}
+var pool = sync.Pool{New: func() any { return new([255]proto.Field) }}
 
 type Options struct {
 	Factory               Factory // If not specified, factory.StandardFactory() will be used.

--- a/profile/mesgdef/mesgdef_test.go
+++ b/profile/mesgdef/mesgdef_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 func TestFieldPool(t *testing.T) {
-	arr, ok := pool.Get().(*[256]proto.Field)
-	defer pool.Put(arr)
+	arr, ok := pool.Get().(*[255]proto.Field)
 	if !ok {
 		t.Fatalf("expected ok, got not ok")
 	}
+	defer pool.Put(arr)
 }
 
 func TestDefaultOptions(t *testing.T) {

--- a/profile/mesgdef/met_zone_gen.go
+++ b/profile/mesgdef/met_zone_gen.go
@@ -66,7 +66,7 @@ func (m *MetZone) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/monitoring_gen.go
+++ b/profile/mesgdef/monitoring_gen.go
@@ -126,7 +126,7 @@ func (m *Monitoring) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/monitoring_hr_data_gen.go
+++ b/profile/mesgdef/monitoring_hr_data_gen.go
@@ -64,7 +64,7 @@ func (m *MonitoringHrData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/monitoring_info_gen.go
+++ b/profile/mesgdef/monitoring_info_gen.go
@@ -76,7 +76,7 @@ func (m *MonitoringInfo) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/nmea_sentence_gen.go
+++ b/profile/mesgdef/nmea_sentence_gen.go
@@ -64,7 +64,7 @@ func (m *NmeaSentence) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/obdii_data_gen.go
+++ b/profile/mesgdef/obdii_data_gen.go
@@ -76,7 +76,7 @@ func (m *ObdiiData) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/ohr_settings_gen.go
+++ b/profile/mesgdef/ohr_settings_gen.go
@@ -62,7 +62,7 @@ func (m *OhrSettings) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/one_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/one_d_sensor_calibration_gen.go
@@ -70,7 +70,7 @@ func (m *OneDSensorCalibration) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/power_zone_gen.go
+++ b/profile/mesgdef/power_zone_gen.go
@@ -62,7 +62,7 @@ func (m *PowerZone) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/raw_bbi_gen.go
+++ b/profile/mesgdef/raw_bbi_gen.go
@@ -78,7 +78,7 @@ func (m *RawBbi) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/record_gen.go
+++ b/profile/mesgdef/record_gen.go
@@ -237,7 +237,7 @@ func (m *Record) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/respiration_rate_gen.go
+++ b/profile/mesgdef/respiration_rate_gen.go
@@ -64,7 +64,7 @@ func (m *RespirationRate) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/schedule_gen.go
+++ b/profile/mesgdef/schedule_gen.go
@@ -72,7 +72,7 @@ func (m *Schedule) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/sdm_profile_gen.go
+++ b/profile/mesgdef/sdm_profile_gen.go
@@ -74,7 +74,7 @@ func (m *SdmProfile) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/segment_file_gen.go
+++ b/profile/mesgdef/segment_file_gen.go
@@ -79,7 +79,7 @@ func (m *SegmentFile) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/segment_id_gen.go
+++ b/profile/mesgdef/segment_id_gen.go
@@ -74,7 +74,7 @@ func (m *SegmentId) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/segment_lap_gen.go
+++ b/profile/mesgdef/segment_lap_gen.go
@@ -259,7 +259,7 @@ func (m *SegmentLap) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/segment_leaderboard_entry_gen.go
+++ b/profile/mesgdef/segment_leaderboard_entry_gen.go
@@ -72,7 +72,7 @@ func (m *SegmentLeaderboardEntry) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/segment_point_gen.go
+++ b/profile/mesgdef/segment_point_gen.go
@@ -81,7 +81,7 @@ func (m *SegmentPoint) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/session_gen.go
+++ b/profile/mesgdef/session_gen.go
@@ -381,7 +381,7 @@ func (m *Session) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/set_gen.go
+++ b/profile/mesgdef/set_gen.go
@@ -87,7 +87,7 @@ func (m *Set) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/skin_temp_overnight_gen.go
+++ b/profile/mesgdef/skin_temp_overnight_gen.go
@@ -69,7 +69,7 @@ func (m *SkinTempOvernight) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/slave_device_gen.go
+++ b/profile/mesgdef/slave_device_gen.go
@@ -60,7 +60,7 @@ func (m *SlaveDevice) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/sleep_assessment_gen.go
+++ b/profile/mesgdef/sleep_assessment_gen.go
@@ -86,7 +86,7 @@ func (m *SleepAssessment) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/sleep_level_gen.go
+++ b/profile/mesgdef/sleep_level_gen.go
@@ -62,7 +62,7 @@ func (m *SleepLevel) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/software_gen.go
+++ b/profile/mesgdef/software_gen.go
@@ -64,7 +64,7 @@ func (m *Software) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/speed_zone_gen.go
+++ b/profile/mesgdef/speed_zone_gen.go
@@ -64,7 +64,7 @@ func (m *SpeedZone) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/split_gen.go
+++ b/profile/mesgdef/split_gen.go
@@ -99,7 +99,7 @@ func (m *Split) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/split_summary_gen.go
+++ b/profile/mesgdef/split_summary_gen.go
@@ -86,7 +86,7 @@ func (m *SplitSummary) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/spo2_data_gen.go
+++ b/profile/mesgdef/spo2_data_gen.go
@@ -66,7 +66,7 @@ func (m *Spo2Data) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/sport_gen.go
+++ b/profile/mesgdef/sport_gen.go
@@ -62,7 +62,7 @@ func (m *Sport) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/stress_level_gen.go
+++ b/profile/mesgdef/stress_level_gen.go
@@ -62,7 +62,7 @@ func (m *StressLevel) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/tank_summary_gen.go
+++ b/profile/mesgdef/tank_summary_gen.go
@@ -70,7 +70,7 @@ func (m *TankSummary) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/tank_update_gen.go
+++ b/profile/mesgdef/tank_update_gen.go
@@ -66,7 +66,7 @@ func (m *TankUpdate) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/three_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/three_d_sensor_calibration_gen.go
@@ -73,7 +73,7 @@ func (m *ThreeDSensorCalibration) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/time_in_zone_gen.go
+++ b/profile/mesgdef/time_in_zone_gen.go
@@ -93,7 +93,7 @@ func (m *TimeInZone) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/timestamp_correlation_gen.go
+++ b/profile/mesgdef/timestamp_correlation_gen.go
@@ -74,7 +74,7 @@ func (m *TimestampCorrelation) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/totals_gen.go
+++ b/profile/mesgdef/totals_gen.go
@@ -78,7 +78,7 @@ func (m *Totals) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/training_file_gen.go
+++ b/profile/mesgdef/training_file_gen.go
@@ -70,7 +70,7 @@ func (m *TrainingFile) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/user_profile_gen.go
+++ b/profile/mesgdef/user_profile_gen.go
@@ -116,7 +116,7 @@ func (m *UserProfile) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/video_clip_gen.go
+++ b/profile/mesgdef/video_clip_gen.go
@@ -72,7 +72,7 @@ func (m *VideoClip) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/video_description_gen.go
+++ b/profile/mesgdef/video_description_gen.go
@@ -62,7 +62,7 @@ func (m *VideoDescription) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/video_frame_gen.go
+++ b/profile/mesgdef/video_frame_gen.go
@@ -64,7 +64,7 @@ func (m *VideoFrame) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/video_gen.go
+++ b/profile/mesgdef/video_gen.go
@@ -62,7 +62,7 @@ func (m *Video) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/video_title_gen.go
+++ b/profile/mesgdef/video_title_gen.go
@@ -62,7 +62,7 @@ func (m *VideoTitle) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/watchface_settings_gen.go
+++ b/profile/mesgdef/watchface_settings_gen.go
@@ -62,7 +62,7 @@ func (m *WatchfaceSettings) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/weather_alert_gen.go
+++ b/profile/mesgdef/weather_alert_gen.go
@@ -70,7 +70,7 @@ func (m *WeatherAlert) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/weather_conditions_gen.go
+++ b/profile/mesgdef/weather_conditions_gen.go
@@ -93,7 +93,7 @@ func (m *WeatherConditions) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/weight_scale_gen.go
+++ b/profile/mesgdef/weight_scale_gen.go
@@ -88,7 +88,7 @@ func (m *WeightScale) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/workout_gen.go
+++ b/profile/mesgdef/workout_gen.go
@@ -74,7 +74,7 @@ func (m *Workout) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/workout_session_gen.go
+++ b/profile/mesgdef/workout_session_gen.go
@@ -72,7 +72,7 @@ func (m *WorkoutSession) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/workout_step_gen.go
+++ b/profile/mesgdef/workout_step_gen.go
@@ -96,7 +96,7 @@ func (m *WorkoutStep) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/profile/mesgdef/zones_target_gen.go
+++ b/profile/mesgdef/zones_target_gen.go
@@ -66,7 +66,7 @@ func (m *ZonesTarget) ToMesg(options *Options) proto.Message {
 
 	fac := options.Factory
 
-	arr := pool.Get().(*[256]proto.Field)
+	arr := pool.Get().(*[255]proto.Field)
 	defer pool.Put(arr)
 
 	fields := arr[:0] // Create slice from array with zero len.

--- a/proto/value_unmarshal.go
+++ b/proto/value_unmarshal.go
@@ -246,8 +246,8 @@ func trimUTF8NullTerminatedString(b []byte) []byte {
 	return b[:pos]
 }
 
-// smallpool is an [256]byte array pool.
-var smallpool = sync.Pool{New: func() any { return new([256]byte) }}
+// smallpool is an [255]byte array pool.
+var smallpool = sync.Pool{New: func() any { return new([255]byte) }}
 
 // utf8String converts b into a valid utf8 string.
 // Any invalid utf8 character will be converted into utf8.RuneError.
@@ -255,7 +255,7 @@ func utf8String(b []byte) string {
 	if utf8.Valid(b) { // Fast path
 		return string(b)
 	}
-	arr := smallpool.Get().(*[256]byte)
+	arr := smallpool.Get().(*[255]byte)
 	defer smallpool.Put(arr)
 	buf := arr[:0]
 	for len(b) > 0 {


### PR DESCRIPTION
A byte value is between 0-255, so `field's num`, `n Fields` and `field's value size` max value is 255. The same logic applies for developer fields as well. So we only need 255 size for those values such as when creating `fieldsArray` in decoder, fields' `pool` in mesgdef, etc. Even the maximum number of character in a string should not exceed 255.

And for `factory`, we keep the fields' size 256 as we want to ensure O(1) field lookup, and technically, field number 255 is still a valid byte even if it's an invalid field number.