### PR TITLE
refactor/perf(proto)!: simplify DeveloperField structure

### DIFF
--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -638,11 +638,6 @@ func createFitForTest() (proto.FIT, []byte) {
 					proto.DeveloperField{
 						DeveloperDataIndex: 0,
 						Num:                0,
-						Size:               1,
-						Name:               "Heart Rate",
-						NativeMesgNum:      mesgnum.Record,
-						NativeFieldNum:     fieldnum.RecordHeartRate,
-						BaseType:           basetype.Uint8,
 						Value:              proto.Uint8(100),
 					},
 				),
@@ -1577,9 +1572,7 @@ func TestDecodeMessageData(t *testing.T) {
 					dec.localMessageDefinitions[(tc.mesgdef.Header&proto.CompressedLocalMesgNumMask)>>proto.CompressedBitShift] = tc.mesgdef
 				} else {
 					dec.localMessageDefinitions[tc.mesgdef.Header&proto.LocalMesgNumMask] = tc.mesgdef
-
 				}
-
 			}
 			if tc.fieldDescription != nil {
 				dec.fieldDescriptions = append(dec.fieldDescriptions, tc.fieldDescription)

--- a/decoder/raw_test.go
+++ b/decoder/raw_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/hash/crc16"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -229,11 +228,6 @@ func TestRawDecoderDecode(t *testing.T) {
 					proto.DeveloperField{
 						DeveloperDataIndex: 0,
 						Num:                0,
-						Size:               1,
-						Name:               "Heart Rate",
-						NativeMesgNum:      mesgnum.Record,
-						NativeFieldNum:     fieldnum.RecordHeartRate,
-						BaseType:           basetype.Uint8,
 						Value:              proto.Uint8(100),
 					},
 				)
@@ -264,11 +258,6 @@ func TestRawDecoderDecode(t *testing.T) {
 					proto.DeveloperField{
 						DeveloperDataIndex: 0,
 						Num:                0,
-						Size:               1,
-						Name:               "Heart Rate",
-						NativeMesgNum:      mesgnum.Record,
-						NativeFieldNum:     fieldnum.RecordHeartRate,
-						BaseType:           basetype.Uint8,
 						Value:              proto.Uint8(100),
 					},
 				)
@@ -299,11 +288,6 @@ func TestRawDecoderDecode(t *testing.T) {
 					proto.DeveloperField{
 						DeveloperDataIndex: 0,
 						Num:                0,
-						Size:               1,
-						Name:               "Heart Rate",
-						NativeMesgNum:      mesgnum.Record,
-						NativeFieldNum:     fieldnum.RecordHeartRate,
-						BaseType:           basetype.Uint8,
 						Value:              proto.Uint8(100),
 					},
 				)

--- a/encoder/validator_test.go
+++ b/encoder/validator_test.go
@@ -129,11 +129,6 @@ func TestMessageValidatorValidate(t *testing.T) {
 						{
 							DeveloperDataIndex: 0,
 							Num:                0,
-							Size:               1,
-							Name:               "Heart Rate",
-							NativeMesgNum:      mesgnum.Record,
-							NativeFieldNum:     fieldnum.RecordHeartRate,
-							BaseType:           basetype.Uint8,
 							Value:              proto.Uint8(60),
 						},
 					},
@@ -279,11 +274,6 @@ func TestMessageValidatorValidate(t *testing.T) {
 							// dummy data
 							devFields[i].DeveloperDataIndex = 0
 							devFields[i].Num = 0
-							devFields[i].Size = 1
-							devFields[i].Name = "Heart Rate"
-							devFields[i].NativeMesgNum = mesgnum.Record
-							devFields[i].NativeFieldNum = fieldnum.RecordHeartRate
-							devFields[i].BaseType = basetype.Uint8
 							devFields[i].Value = proto.Uint8(60)
 						}
 						return devFields
@@ -319,6 +309,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 					Num: mesgnum.FieldDescription,
 					Fields: []proto.Field{
 						factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionDeveloperDataIndex).WithValue(uint8(0)),
+						factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionFitBaseTypeId).WithValue(uint8(basetype.String)),
 						factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionFieldDefinitionNumber).WithValue(uint8(1)),
 					},
 				}
@@ -332,7 +323,6 @@ func TestMessageValidatorValidate(t *testing.T) {
 					proto.DeveloperField{
 						DeveloperDataIndex: 0,
 						Num:                1,
-						BaseType:           basetype.String,
 						Value:              proto.String(strings.Repeat("a", 256)),
 					},
 				),
@@ -362,12 +352,39 @@ func TestMessageValidatorValidate(t *testing.T) {
 						{
 							DeveloperDataIndex: 0,
 							Num:                0,
-							Size:               1,
-							Name:               "Heart Rate",
-							NativeMesgNum:      mesgnum.Record,
-							NativeFieldNum:     fieldnum.RecordHeartRate,
-							BaseType:           basetype.Uint8,
 							Value:              proto.Uint8(basetype.Uint8Invalid),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "mesg contain developer field value scaled",
+			mesgs: []proto.Message{
+				factory.CreateMesg(mesgnum.DeveloperDataId).WithFieldValues(map[byte]any{
+					fieldnum.DeveloperDataIdDeveloperDataIndex: uint8(0),
+					fieldnum.DeveloperDataIdApplicationId:      []byte{0, 1, 2, 3},
+				}),
+				factory.CreateMesg(mesgnum.FieldDescription).WithFieldValues(map[byte]any{
+					fieldnum.FieldDescriptionDeveloperDataIndex:    uint8(0),
+					fieldnum.FieldDescriptionFieldDefinitionNumber: uint8(0),
+					fieldnum.FieldDescriptionFieldName:             "Custom Distance",
+					fieldnum.FieldDescriptionNativeMesgNum:         uint16(basetype.Uint16Invalid),
+					fieldnum.FieldDescriptionNativeFieldNum:        uint8(basetype.Uint8Invalid),
+					fieldnum.FieldDescriptionScale:                 uint8(100),
+					fieldnum.FieldDescriptionOffset:                int8(0),
+					fieldnum.FieldDescriptionFitBaseTypeId:         uint8(basetype.Uint16),
+				}),
+				{
+					Num: mesgnum.Record,
+					Fields: []proto.Field{
+						factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(time.Now())),
+					},
+					DeveloperFields: []proto.DeveloperField{
+						{
+							DeveloperDataIndex: 0,
+							Num:                0,
+							Value:              proto.Float64(6960.8),
 						},
 					},
 				},
@@ -396,11 +413,6 @@ func TestMessageValidatorValidate(t *testing.T) {
 						{
 							DeveloperDataIndex: 0,
 							Num:                0,
-							Size:               1,
-							Name:               "Heart Rate",
-							NativeMesgNum:      mesgnum.Record,
-							NativeFieldNum:     fieldnum.RecordAltitude,
-							BaseType:           basetype.Uint16,
 							Value:              proto.Float64(6960.8),
 						},
 					},
@@ -430,11 +442,6 @@ func TestMessageValidatorValidate(t *testing.T) {
 						{
 							DeveloperDataIndex: 0,
 							Num:                0,
-							Size:               1,
-							Name:               "??",
-							NativeMesgNum:      mesgnum.Record,
-							NativeFieldNum:     255,
-							BaseType:           basetype.Uint16,
 							Value:              proto.Float64(0), // Scaled value + targeted Native Field not found
 						},
 					},
@@ -486,21 +493,11 @@ func TestMessageValidatorValidate(t *testing.T) {
 						{
 							DeveloperDataIndex: 0,
 							Num:                0,
-							Size:               1,
-							Name:               "Heart Rate",
-							NativeMesgNum:      mesgnum.Record,
-							NativeFieldNum:     fieldnum.RecordHeartRate,
-							BaseType:           basetype.Uint8,
 							Value:              proto.Value{}, // invalid value
 						},
 						{
 							DeveloperDataIndex: 0,
 							Num:                0,
-							Size:               1,
-							Name:               "Heart Rate",
-							NativeMesgNum:      mesgnum.Record,
-							NativeFieldNum:     fieldnum.RecordHeartRate,
-							BaseType:           basetype.Uint8,
 							Value:              proto.Uint8(60),
 						},
 					},

--- a/profile/filedef/listener_test.go
+++ b/profile/filedef/listener_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/filedef"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
@@ -151,11 +150,6 @@ func TestListenerForSingleFitFile(t *testing.T) {
 						proto.DeveloperField{
 							DeveloperDataIndex: 0,
 							Num:                0,
-							Size:               1,
-							Name:               "Heart Rate",
-							NativeMesgNum:      mesgnum.Record,
-							NativeFieldNum:     fieldnum.RecordHeartRate,
-							BaseType:           basetype.Uint8,
 							Value:              proto.Uint8(100),
 						},
 					),

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -78,7 +78,7 @@ func CreateMessageDefinitionTo(target *MessageDefinition, mesg *Message) {
 	for i := range mesg.Fields {
 		target.FieldDefinitions = append(target.FieldDefinitions, FieldDefinition{
 			Num:      mesg.Fields[i].Num,
-			Size:     byte(Sizeof(mesg.Fields[i].Value, mesg.Fields[i].BaseType)),
+			Size:     byte(Sizeof(mesg.Fields[i].Value)),
 			BaseType: mesg.Fields[i].BaseType,
 		})
 	}
@@ -96,7 +96,7 @@ func CreateMessageDefinitionTo(target *MessageDefinition, mesg *Message) {
 	for i := range mesg.DeveloperFields {
 		target.DeveloperFieldDefinitions = append(target.DeveloperFieldDefinitions, DeveloperFieldDefinition{
 			Num:                mesg.DeveloperFields[i].Num,
-			Size:               byte(Sizeof(mesg.DeveloperFields[i].Value, mesg.DeveloperFields[i].BaseType)),
+			Size:               byte(Sizeof(mesg.DeveloperFields[i].Value)),
 			DeveloperDataIndex: mesg.DeveloperFields[i].DeveloperDataIndex,
 		})
 	}
@@ -151,9 +151,9 @@ type FieldDefinition struct {
 
 // FieldDefinition is the definition of the upcoming developer field within the message's structure.
 type DeveloperFieldDefinition struct { // 3 bits
-	Num                byte // Maps to the `field_definition_number` of a `field_description` Message.
+	Num                byte // Maps to `field_definition_number` of a `field_description` message.
 	Size               byte // Size (in bytes) of the specified FIT message’s field
-	DeveloperDataIndex byte // Maps to the `developer_data_index`` of a `developer_data_id` Message
+	DeveloperDataIndex byte // Maps to `developer_data_index` of a `developer_data_id` and a `field_description` messages.
 }
 
 // Message is a FIT protocol message containing the data defined in the Message Definition
@@ -333,22 +333,17 @@ func (f Field) Clone() Field {
 	return f
 }
 
-// Developer Field is a way to add custom data fields to existing messages. Developer Data Fields can be added to
-// any message at runtime by providing a self-describing field definition. Developer Data Fields are also used by
-// the Connect IQ FIT Contributor library, allowing Connect IQ apps and data fields to include custom data in
-// FIT Activity files during the recording of activities. [Added since protocol version 2.0]
+// DeveloperField is a way to add custom data fields to existing messages. Developer Data Fields can be added
+// to any message at runtime by providing a self-describing FieldDefinition messages prior to that message.
+// The combination of the DeveloperDataIndex and FieldDefinitionNumber create a unique id for each FieldDescription.
+// Developer Data Fields are also used by the Connect IQ FIT Contributor library, allowing Connect IQ apps
+// and data fields to include custom data in FIT Activity files during the recording of activities.
 //
-// NOTE: If Developer Field contains a valid NativeMesgNum and NativeFieldNum,
-// the value should be treated as native value (scale, offset, etc shall apply).
+// NOTE: If DeveloperField contains a valid NativeMesgNum and NativeFieldNum, the value should be treated as
+// native value (scale, offset, etc shall apply). [Added since protocol version 2.0]
 type DeveloperField struct {
-	Num                byte
-	DeveloperDataIndex byte
-	Size               byte
-	NativeMesgNum      typedef.MesgNum
-	NativeFieldNum     byte
-	BaseType           basetype.BaseType
-	Name               string
-	Units              string
+	Num                byte // Maps to `field_definition_number` of a `field_description` message.
+	DeveloperDataIndex byte // Maps to `developer_data_index` of a `developer_data_id` and a `field_description` messages.
 	Value              Value
 }
 

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -253,8 +253,6 @@ func TestMessageClone(t *testing.T) {
 		proto.DeveloperField{
 			Num:                0,
 			DeveloperDataIndex: 0,
-			Size:               1,
-			BaseType:           basetype.Uint8,
 			Value:              proto.Uint8(1),
 		},
 		proto.DeveloperField{},
@@ -437,7 +435,7 @@ func TestCreateMessageDefinition(t *testing.T) {
 					factory.CreateField(mesgnum.UserProfile, fieldnum.UserProfileGlobalId).WithValue([]byte{byte(2), byte(9)})).
 				WithDeveloperFields(
 					proto.DeveloperField{
-						Num: 0, Name: "FIT SDK Go", BaseType: basetype.Byte, DeveloperDataIndex: 0, Value: proto.Uint8(1),
+						Num: 0, DeveloperDataIndex: 0, Value: proto.Uint8(1),
 					},
 				),
 			mesgDef: proto.MessageDefinition{
@@ -464,7 +462,7 @@ func TestCreateMessageDefinition(t *testing.T) {
 					factory.CreateField(mesgnum.UserProfile, fieldnum.UserProfileGlobalId).WithValue([]byte{byte(2), byte(9)})).
 				WithDeveloperFields(
 					proto.DeveloperField{
-						Num: 0, Name: "FIT SDK Go", BaseType: basetype.String, DeveloperDataIndex: 0, Value: proto.String("FIT SDK Go"),
+						Num: 0, DeveloperDataIndex: 0, Value: proto.String("FIT SDK Go"),
 					},
 				),
 			mesgDef: proto.MessageDefinition{
@@ -491,7 +489,7 @@ func TestCreateMessageDefinition(t *testing.T) {
 					factory.CreateField(mesgnum.UserProfile, fieldnum.UserProfileGlobalId).WithValue([]byte{byte(2), byte(9)})).
 				WithDeveloperFields(
 					proto.DeveloperField{
-						Num: 0, Name: "FIT SDK Go", BaseType: basetype.Uint16, DeveloperDataIndex: 0, Value: proto.SliceUint16([]uint16{1, 2, 3}),
+						Num: 0, DeveloperDataIndex: 0, Value: proto.SliceUint16([]uint16{1, 2, 3}),
 					},
 				),
 			mesgDef: proto.MessageDefinition{

--- a/proto/value_test.go
+++ b/proto/value_test.go
@@ -871,46 +871,50 @@ func TestValueValid(t *testing.T) {
 func TestLen(t *testing.T) {
 	tt := []struct {
 		value       Value
-		baseType    basetype.BaseType
 		sizeInBytes int
 	}{
-		{value: Value{}, sizeInBytes: 0, baseType: basetype.Sint8},
-		{value: Int8(10), sizeInBytes: 1, baseType: basetype.Sint8},
-		{value: Uint8(10), sizeInBytes: 1, baseType: basetype.Uint8},
-		{value: Int16(10), sizeInBytes: 2, baseType: basetype.Sint16},
-		{value: Uint16(10), sizeInBytes: 2, baseType: basetype.Uint16},
-		{value: Int32(10), sizeInBytes: 4, baseType: basetype.Sint32},
-		{value: Uint32(10), sizeInBytes: 4, baseType: basetype.Uint32},
-		{value: Float32(10), sizeInBytes: 4, baseType: basetype.Float32},
-		{value: Float64(10), sizeInBytes: 8, baseType: basetype.Float64},
-		{value: Int64(10), sizeInBytes: 8, baseType: basetype.Sint64},
-		{value: Uint64(10), sizeInBytes: 8, baseType: basetype.Uint64},
-		{value: SliceInt8([]int8{10, 9, 8, 7}), sizeInBytes: 4, baseType: basetype.Sint8},
-		{value: SliceUint8([]uint8{10, 9, 8, 7}), sizeInBytes: 4, baseType: basetype.Uint8},
-		{value: SliceInt16([]int16{10, 9, 8, 7}), sizeInBytes: 4 * 2, baseType: basetype.Uint16},
-		{value: SliceUint16([]uint16{10, 9, 8, 7}), sizeInBytes: 4 * 2, baseType: basetype.Uint16},
-		{value: SliceInt32([]int32{10, 9, 8, 7}), sizeInBytes: 4 * 4, baseType: basetype.Sint32},
-		{value: SliceUint32([]uint32{10, 9, 8, 7}), sizeInBytes: 4 * 4, baseType: basetype.Uint32},
-		{value: String(""), sizeInBytes: 1, baseType: basetype.String},
-		{value: String("\x00"), sizeInBytes: 1, baseType: basetype.String},
-		{value: String("fit sdk"), sizeInBytes: 8, baseType: basetype.String},
-		{value: String("fit sdk\x00"), sizeInBytes: 8, baseType: basetype.String},
-		{value: SliceString([]string{"fit sdk"}), sizeInBytes: 8, baseType: basetype.String},
-		{value: SliceString([]string{}), sizeInBytes: 1, baseType: basetype.String},
-		{value: SliceString([]string{""}), sizeInBytes: 1, baseType: basetype.String},
-		{value: SliceString([]string{"\x00"}), sizeInBytes: 1, baseType: basetype.String},
-		{value: SliceString([]string{"\x00\x00\x00"}), sizeInBytes: 3, baseType: basetype.String},
-		{value: SliceString([]string{"\x00", "\x00", "\x00"}), sizeInBytes: 3, baseType: basetype.String},
-		{value: SliceString([]string{"fit sdk", "a"}), sizeInBytes: 10, baseType: basetype.String},
-		{value: SliceString([]string{"fit sdk\x00", "a\x00"}), sizeInBytes: 10, baseType: basetype.String},
-		{value: SliceFloat32([]float32{10, 9, 8, 7}), sizeInBytes: 4 * 4, baseType: basetype.Float32},
-		{value: SliceFloat64([]float64{10, 9, 8, 7}), sizeInBytes: 4 * 8, baseType: basetype.Float64},
-		{value: SliceInt64([]int64{10, 9, 8, 7}), sizeInBytes: 4 * 8, baseType: basetype.Sint64},
-		{value: SliceUint64([]uint64{10, 9, 8, 7}), sizeInBytes: 4 * 8, baseType: basetype.Uint64},
+		{value: Value{}, sizeInBytes: 0},
+		{value: Value{any: TypeInvalid}, sizeInBytes: 0},
+		{value: Bool(true), sizeInBytes: 1},
+		{value: Int8(10), sizeInBytes: 1},
+		{value: Uint8(10), sizeInBytes: 1},
+		{value: Int16(10), sizeInBytes: 2},
+		{value: Uint16(10), sizeInBytes: 2},
+		{value: Int32(10), sizeInBytes: 4},
+		{value: Uint32(10), sizeInBytes: 4},
+		{value: Float32(10), sizeInBytes: 4},
+		{value: Float64(10), sizeInBytes: 8},
+		{value: Int64(10), sizeInBytes: 8},
+		{value: Uint64(10), sizeInBytes: 8},
+		{value: SliceBool([]bool{}), sizeInBytes: 0},
+		{value: SliceBool([]bool{true, false}), sizeInBytes: 2},
+		{value: SliceInt8([]int8{10, 9, 8, 7}), sizeInBytes: 4},
+		{value: SliceUint8([]uint8{10, 9, 8, 7}), sizeInBytes: 4},
+		{value: SliceInt16([]int16{10, 9, 8, 7}), sizeInBytes: 4 * 2},
+		{value: SliceUint16([]uint16{10, 9, 8, 7}), sizeInBytes: 4 * 2},
+		{value: SliceInt32([]int32{10, 9, 8, 7}), sizeInBytes: 4 * 4},
+		{value: SliceUint32([]uint32{10, 9, 8, 7}), sizeInBytes: 4 * 4},
+		{value: String(""), sizeInBytes: 1},
+		{value: String("\x00"), sizeInBytes: 1},
+		{value: String("fit sdk"), sizeInBytes: 8},
+		{value: String("fit sdk\x00"), sizeInBytes: 8},
+		{value: SliceString([]string{"fit sdk"}), sizeInBytes: 8},
+		{value: SliceString([]string{}), sizeInBytes: 1},
+		{value: SliceString([]string{""}), sizeInBytes: 1},
+		{value: SliceString([]string{"\x00"}), sizeInBytes: 1},
+		{value: SliceString([]string{"\x00\x00\x00"}), sizeInBytes: 3},
+		{value: SliceString([]string{"\x00", "\x00", "\x00"}), sizeInBytes: 3},
+		{value: SliceString([]string{"fit sdk", "a"}), sizeInBytes: 10},
+		{value: SliceString([]string{"fit sdk\x00", "a\x00"}), sizeInBytes: 10},
+		{value: SliceFloat32([]float32{10, 9, 8, 7}), sizeInBytes: 4 * 4},
+		{value: SliceFloat64([]float64{10, 9, 8, 7}), sizeInBytes: 4 * 8},
+		{value: SliceInt64([]int64{10, 9, 8, 7}), sizeInBytes: 4 * 8},
+		{value: SliceUint64([]uint64{10, 9, 8, 7}), sizeInBytes: 4 * 8},
 	}
-	for _, tc := range tt {
-		t.Run(fmt.Sprintf("%T(%v)", tc.value, tc.value.Any()), func(t *testing.T) {
-			size := Sizeof(tc.value, tc.baseType)
+	for i, tc := range tt {
+		val := tc.value.Any()
+		t.Run(fmt.Sprintf("[%d] %T(%v)", i, val, val), func(t *testing.T) {
+			size := Sizeof(tc.value)
 			if size != tc.sizeInBytes {
 				t.Fatalf("expected: %d, got: %d", tc.sizeInBytes, size)
 			}


### PR DESCRIPTION
DeveloperField is now consist of three fields: 
```go
type DeveloperField struct {
	Num                byte 
	DeveloperDataIndex byte 
	Value              Value
}
```

This reduces redundant data compared to previous version that copied some values from `Field Description` message while missing the others (I found it was not complete). Instead of make a change to copy everything to DeveloperField that will make the size of the struct bigger (will affect performance, use a lot of memory space), let's make it simpler and when we need to get the reference details of the `DeveloperField`, let's just find the `Field Description` message reference using the combination of `Num` and `DeveloperDataIndex` in the prior messages.  Given that a 'Field Description' can serve multiple 'DeveloperField' instances, mirroring the concept of 'FieldBase' for 'Field', duplicating it would be inefficient. Although we could not embed `*mesgdef.FieldDescription` directly to `DeveloperField` as it will make cyclic dependency (mesgdef depends on proto), I believe this new implementation is already sufficient.

Another rationale is that when encoding FIT data, we are expected to manually create the `Field Description` as the data reference before creating any message contains developer data. The presence of redundant data confuses me as to which value I should fill. Should I also input data such as `Name`, `Size`, `BaseType`, etc  into the `DeveloperField` struct as well, or would it be unnecessary. This changes should simplify this logic, only those 3 values in `DeveloperField` matters and the corresponding `Field Description` message should be created.

Due to this change, some functions need to be adjusted such as `proto.Sizeof` now will only receive a `proto.Value`, since we no longer have the BaseType in `DeveloperField`. Well, it turns out we don't need BaseType at all.