### PR TITLE
perf: remove unnecessary operations

### DIFF
--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -2016,25 +2016,21 @@ func TestExpandMutipleComponentsDynamicField(t *testing.T) {
 
 func TestDecodeDeveloperFields(t *testing.T) {
 	tt := []struct {
-		name             string
-		r                io.Reader
-		developerDataIds []*mesgdef.DeveloperDataId
-		fieldDescription *mesgdef.FieldDescription
-		mesgDef          *proto.MessageDefinition
-		mesg             *proto.Message
-		validateFn       func(mesg proto.Message) error
-		err              error
+		name                 string
+		r                    io.Reader
+		developerDataIndexes []uint8
+		fieldDescription     *mesgdef.FieldDescription
+		mesgDef              *proto.MessageDefinition
+		mesg                 *proto.Message
+		validateFn           func(mesg proto.Message) error
+		err                  error
 	}{
 		{
 			name: "decode developer fields happy flow",
 			r:    fnReaderOK,
-			developerDataIds: []*mesgdef.DeveloperDataId{
-				mesgdef.NewDeveloperDataId(nil).
-					SetApplicationId([]byte{0, 0, 0, 1}).
-					SetDeveloperDataIndex(1), // not used, just to pass code logic
-				mesgdef.NewDeveloperDataId(nil).
-					SetApplicationId([]byte{0, 0, 0, 1}).
-					SetDeveloperDataIndex(0),
+			developerDataIndexes: []uint8{
+				1, // not used, just to pass code logic
+				0,
 			},
 			fieldDescription: mesgdef.NewFieldDescription(
 				kit.Ptr(factory.CreateMesgOnly(mesgnum.FieldDescription).WithFields(
@@ -2266,9 +2262,7 @@ func TestDecodeDeveloperFields(t *testing.T) {
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
 			dec := New(tc.r)
-			if tc.developerDataIds != nil {
-				dec.developerDataIds = append(dec.developerDataIds, tc.developerDataIds...)
-			}
+			dec.developerDataIndexes = append(dec.developerDataIndexes, tc.developerDataIndexes...)
 			dec.fieldDescriptions = append(dec.fieldDescriptions, tc.fieldDescription)
 			err := dec.decodeDeveloperFields(tc.mesgDef, tc.mesg)
 			if !errors.Is(err, tc.err) {

--- a/encoder/validator_test.go
+++ b/encoder/validator_test.go
@@ -68,19 +68,16 @@ func TestMessageValidatorOption(t *testing.T) {
 func TestValidatorReset(t *testing.T) {
 	mv := NewMessageValidator().(*messageValidator)
 
-	mv.developerDataIds = append(mv.developerDataIds, mesgdef.NewDeveloperDataId(nil))
+	mv.developerDataIndexes = append(mv.developerDataIndexes, 0)
 	mv.fieldDescriptions = append(mv.fieldDescriptions, mesgdef.NewFieldDescription(nil))
 
 	mv.Reset()
 
-	mv.developerDataIds = mv.developerDataIds[:cap(mv.developerDataIds)]
-	mv.fieldDescriptions = mv.fieldDescriptions[:cap(mv.developerDataIds)]
-
-	for i, d := range mv.developerDataIds {
-		if d != nil {
-			t.Errorf("developerDataIds[%d]: expected nil: got: %p", i, d)
-		}
+	if len(mv.developerDataIndexes) != 0 {
+		t.Errorf("len(developerDataIndexes): expected 0: got: %d", len(mv.developerDataIndexes))
 	}
+
+	mv.fieldDescriptions = mv.fieldDescriptions[:cap(mv.fieldDescriptions)]
 
 	for i, f := range mv.fieldDescriptions {
 		if f != nil {
@@ -295,15 +292,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 			name: "developer field value size exceed max allowed",
 			mesgValidator: func() MessageValidator {
 				mesgValidator := NewMessageValidator().(*messageValidator)
-				developerDataId := proto.Message{
-					Num: mesgnum.DeveloperDataId,
-					Fields: []proto.Field{
-						factory.CreateField(mesgnum.DeveloperDataId, fieldnum.DeveloperDataIdDeveloperDataIndex).WithValue(uint8(0)),
-					},
-				}
-				mesgValidator.developerDataIds = []*mesgdef.DeveloperDataId{
-					mesgdef.NewDeveloperDataId(&developerDataId),
-				}
+				mesgValidator.developerDataIndexes = []uint8{0}
 
 				fieldDescription := proto.Message{
 					Num: mesgnum.FieldDescription,


### PR DESCRIPTION
Since we only need to know whether we have prior DeveloperDataId messages, we can just collect the DeveloperDataIndex value instead of creating full DeveloperDataId message that most likely we don't need it anyway, this will save memory allocation.