### PR TITLE
chore: remove slices.Clone dependency

### DIFF
--- a/cmd/fitconv/fitcsv/csv_to_fit.go
+++ b/cmd/fitconv/fitcsv/csv_to_fit.go
@@ -20,7 +20,6 @@ import (
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 type CSVToFITConv struct {
@@ -135,8 +134,8 @@ loop:
 			}
 
 			if c.streamEnc == nil {
-				mesg.Fields = slices.Clone(mesg.Fields)
-				mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
+				mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+				mesg.DeveloperFields = append(mesg.DeveloperFields[:0:0], mesg.DeveloperFields...)
 				c.fit.Messages = append(c.fit.Messages, mesg)
 				continue loop
 			}

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -22,7 +22,6 @@ import (
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 type errorString string
@@ -669,8 +668,8 @@ func (d *Decoder) decodeMessageData(header byte) error {
 	}
 
 	if !d.options.broadcastOnly || d.options.broadcastMesgCopy {
-		mesg.Fields = slices.Clone(mesg.Fields)
-		mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.DeveloperFields = append(mesg.DeveloperFields[:0:0], mesg.DeveloperFields...)
 	}
 
 	if !d.options.broadcastOnly {

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 var (
@@ -332,7 +331,7 @@ func TestPeekFileHeader(t *testing.T) {
 		{
 			name: "peek file header happy flow",
 			r: func() io.Reader {
-				buf, cur := slices.Clone(buf), 0
+				buf, cur := append(buf[:0:0], buf...), 0
 				return fnReader(func(b []byte) (n int, err error) {
 					if cur >= 14 {
 						return 0, io.EOF
@@ -388,7 +387,7 @@ func TestPeekFileId(t *testing.T) {
 		{
 			name: "peek file id happy flow",
 			r: func() io.Reader {
-				buf, cur := slices.Clone(buf), 0
+				buf, cur := append(buf[:0:0], buf...), 0
 				return fnReader(func(b []byte) (n int, err error) {
 					if cur >= len(buf) {
 						return 0, io.EOF
@@ -417,7 +416,7 @@ func TestPeekFileId(t *testing.T) {
 		{
 			name: "peek file id decode message return error",
 			r: func() io.Reader {
-				buf, cur := slices.Clone(buf), 0
+				buf, cur := append(buf[:0:0], buf...), 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := 14
 					if cur >= m { // only decode header
@@ -466,8 +465,8 @@ func TestCheckIntegrity(t *testing.T) {
 			name: "happy flow",
 			r: func() io.Reader {
 				// Chained FIT File
-				b := slices.Clone(b)
-				nextb := slices.Clone(b)
+				b := append(b[:0:0], b...)
+				nextb := append(b[:0:0], b...)
 				b = append(b, nextb...)
 				return bytes.NewReader(b)
 			}(),
@@ -502,7 +501,7 @@ func TestCheckIntegrity(t *testing.T) {
 		{
 			name: "read message return error",
 			r: func() io.Reader {
-				buf := slices.Clone(b)
+				buf := append(b[:0:0], b...)
 				cur := 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := 14
@@ -523,7 +522,7 @@ func TestCheckIntegrity(t *testing.T) {
 		{
 			name: "decode crc return error",
 			r: func() io.Reader {
-				buf := slices.Clone(b)
+				buf := append(b[:0:0], b...)
 				cur := 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf) - 2
@@ -544,7 +543,7 @@ func TestCheckIntegrity(t *testing.T) {
 		{
 			name: "crc checksum mismatch",
 			r: func() io.Reader {
-				buf := slices.Clone(b)
+				buf := append(b[:0:0], b...)
 				cur := 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf) - 2
@@ -567,7 +566,7 @@ func TestCheckIntegrity(t *testing.T) {
 			name: "second sequence of FIT File return error",
 			r: func() io.Reader {
 				// Chained FIT File but with next sequence header is
-				b := slices.Clone(b)
+				b := append(b[:0:0], b...)
 				h := headerForTest()
 				nextb, _ := h.MarshalBinary()
 				nextb[0] = 100 // alter FileHeader's Size
@@ -715,7 +714,7 @@ func TestDiscard(t *testing.T) {
 		{
 			name: "discard happy flow",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf)
 					if cur == m {
@@ -741,7 +740,7 @@ func TestDiscard(t *testing.T) {
 		{
 			name: "discard error when reading data",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := 14
 					if cur >= m {
@@ -760,7 +759,7 @@ func TestDiscard(t *testing.T) {
 		{
 			name: "discard error when reading crc",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf) - 2
 					if cur == m {
@@ -951,7 +950,7 @@ func makeDecodeTableTest() []decodeTestCase {
 		{
 			name: "decode happy flow",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf)
 					if cur == m {
@@ -970,7 +969,7 @@ func makeDecodeTableTest() []decodeTestCase {
 		{
 			name: "decode header return error",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				buf[0] = 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf)
@@ -990,7 +989,7 @@ func makeDecodeTableTest() []decodeTestCase {
 		{
 			name: "decode messages return error",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := 14
 					if cur == m {
@@ -1010,7 +1009,7 @@ func makeDecodeTableTest() []decodeTestCase {
 		{
 			name: "decode crc return error",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf) - 2
 					if cur == m {
@@ -1030,7 +1029,7 @@ func makeDecodeTableTest() []decodeTestCase {
 		{
 			name: "decode crc checksum mismatch",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf) - 2
 					if cur == m {
@@ -1088,7 +1087,7 @@ func TestDecodeFileHeader(t *testing.T) {
 		{
 			name: "decode header happy flow",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf)
 					if cur == m {
@@ -1113,7 +1112,7 @@ func TestDecodeFileHeader(t *testing.T) {
 		{
 			name: "decode header invalid size",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				buf[0] = 0
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf)
@@ -1133,7 +1132,7 @@ func TestDecodeFileHeader(t *testing.T) {
 		{
 			name: "decode header invalid size",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				buf = buf[:1] // trimmed
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf)
@@ -1153,7 +1152,7 @@ func TestDecodeFileHeader(t *testing.T) {
 		{
 			name: "decode invalid protocol",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				buf[1] = 100 // invalid protocol
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf)
@@ -1173,7 +1172,7 @@ func TestDecodeFileHeader(t *testing.T) {
 		{
 			name: "decode data type not `.FIT`",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				copy(buf[5:9], []byte("F.IT"))
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf)
@@ -1193,7 +1192,7 @@ func TestDecodeFileHeader(t *testing.T) {
 		{
 			name: "decode crc == 0x000",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				buf[12], buf[13] = 0, 0
 
 				return fnReader(func(b []byte) (n int, err error) {
@@ -1224,7 +1223,7 @@ func TestDecodeFileHeader(t *testing.T) {
 		{
 			name: "decode crc mismatch",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf), 0
+				var buf, cur = append(buf[:0:0], buf...), 0
 				buf[12], buf[13] = 0, 1
 
 				return fnReader(func(b []byte) (n int, err error) {
@@ -1281,7 +1280,7 @@ func TestDecodeMessageDefinition(t *testing.T) {
 		{
 			name: "decode message definition happy flow",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf[15:]), 0 // trim header
+				var buf, cur = append(buf[:0:0], buf[15:]...), 0 // trim header
 				return fnReader(func(b []byte) (n int, err error) {
 					m := len(buf)
 					if cur == m {
@@ -1309,7 +1308,7 @@ func TestDecodeMessageDefinition(t *testing.T) {
 		{
 			name: "decode read return io.EOF when retrieving field data",
 			r: func() io.Reader {
-				var buf, cur = slices.Clone(buf[15:]), 0 // trim header
+				var buf, cur = append(buf[:0:0], buf[15:]...), 0 // trim header
 				return fnReader(func(b []byte) (n int, err error) {
 					m := 5
 					if cur == m {
@@ -2463,7 +2462,7 @@ func TestDecodeWithContext(t *testing.T) {
 			func() strct {
 				ctx, cancel := context.WithCancel(context.Background())
 				_, buffer := createFitForTest()
-				buf, cur := slices.Clone(buffer), 0
+				buf, cur := append(buffer[:0:0], buffer...), 0
 				r := fnReader(func(b []byte) (n int, err error) {
 					if cur == len(buf)-3 {
 						cancel() // cancel right after completing decode messages

--- a/decoder/raw_test.go
+++ b/decoder/raw_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 var fnDecodeRawOK = func(flag RawFlag, b []byte) error {
@@ -103,7 +102,7 @@ func TestRawDecoderDecode(t *testing.T) {
 		{
 			name: "invalid FileHeader's Size",
 			r: func() io.Reader {
-				buf := slices.Clone(buf)
+				buf := append(buf[:0:0], buf...)
 				buf[0] = 100
 				cur := 0
 				return fnReader(func(b []byte) (n int, err error) {
@@ -135,7 +134,7 @@ func TestRawDecoderDecode(t *testing.T) {
 		{
 			name: "bytes 8-12 is not .FIT",
 			r: func() io.Reader {
-				buf := slices.Clone(buf)
+				buf := append(buf[:0:0], buf...)
 				copy(buf[8:12], []byte(".FTT"))
 				cur := 0
 				return fnReader(func(b []byte) (n int, err error) {
@@ -152,7 +151,7 @@ func TestRawDecoderDecode(t *testing.T) {
 		{
 			name: "fn FileHeader returns io.EOF",
 			r: func() io.Reader {
-				buf := slices.Clone(buf)
+				buf := append(buf[:0:0], buf...)
 				cur := 0
 				return fnReader(func(b []byte) (n int, err error) {
 					if cur == len(buf) {

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 var (
@@ -759,7 +758,7 @@ func TestEncodeMessageWithMultipleLocalMessageType(t *testing.T) {
 		// We have 3 messages with differents field definitions,
 		// this should produces different localMesgNum in header.
 
-		mesgs := slices.Clone(mesgs)
+		mesgs := append(mesgs[:0:0], mesgs...)
 		for i := range mesgs {
 			mesgs[i] = mesgs[i].Clone()
 		}

--- a/internal/cmd/fitgen/profile/mesgdef/builder.go
+++ b/internal/cmd/fitgen/profile/mesgdef/builder.go
@@ -113,7 +113,7 @@ func (b *mesgdefBuilder) Build() ([]builder.Data, error) {
 		}
 
 		// Optimize memory usage by aligning the memory in the struct.
-		optimizedFields := slices.Clone(fields)
+		optimizedFields := append(fields[:0:0], fields...)
 		b.simpleMemoryAlignment(optimizedFields)
 
 		data := Data{

--- a/profile/filedef/activity.go
+++ b/profile/filedef/activity.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // Activity is a common file type that most wearable device or cycling computer uses to record activities.
@@ -95,7 +94,7 @@ func (f *Activity) Add(mesg proto.Message) {
 	case mesgnum.Hrv:
 		f.HRVs = append(f.HRVs, mesgdef.NewHrv(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/activity_summary.go
+++ b/profile/filedef/activity_summary.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // ActivitySummary is a compact version of the activity file and contain only activity, session and lap messages
@@ -53,7 +52,7 @@ func (f *ActivitySummary) Add(mesg proto.Message) {
 	case mesgnum.Lap:
 		f.Laps = append(f.Laps, mesgdef.NewLap(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/blood_pressure.go
+++ b/profile/filedef/blood_pressure.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // BloodPressure files contain time-stamped discrete measurement data of blood pressure.
@@ -53,7 +52,7 @@ func (f *BloodPressure) Add(mesg proto.Message) {
 	case mesgnum.DeviceInfo:
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/course.go
+++ b/profile/filedef/course.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // Course is a common file type used as points of courses to assist with on- and off-road navigation,
@@ -69,7 +68,7 @@ func (f *Course) Add(mesg proto.Message) {
 	case mesgnum.CoursePoint:
 		f.CoursePoints = append(f.CoursePoints, mesgdef.NewCoursePoint(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/device.go
+++ b/profile/filedef/device.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // Device files contain information about a device’s file structure/capabilities.
@@ -59,7 +58,7 @@ func (f *Device) Add(mesg proto.Message) {
 	case mesgnum.FieldCapabilities:
 		f.FieldCapabilities = append(f.FieldCapabilities, mesgdef.NewFieldCapabilities(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/goals.go
+++ b/profile/filedef/goals.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // Goals files allow a user to communicate their exercise/health goals.
@@ -47,7 +46,7 @@ func (f *Goals) Add(mesg proto.Message) {
 	case mesgnum.Goal:
 		f.Goals = append(f.Goals, mesgdef.NewGoal(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/listener.go
+++ b/profile/filedef/listener.go
@@ -10,7 +10,6 @@ import (
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // Listener is Message Listener.
@@ -151,7 +150,7 @@ func (l *Listener) prep(mesg proto.Message) proto.Message {
 	mesg.Fields = fields
 
 	// Must clone DeveloperFields since it is being referenced in mesgdef's structs.
-	mesg.DeveloperFields = slices.Clone(mesg.DeveloperFields)
+	mesg.DeveloperFields = append(mesg.DeveloperFields[:0:0], mesg.DeveloperFields...)
 
 	return mesg
 }

--- a/profile/filedef/monitoring_ab.go
+++ b/profile/filedef/monitoring_ab.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // MonitoringAB (Monitoring A and Monitoring B) files are used to store data that is logged over varying time intervals.
@@ -57,7 +56,7 @@ func (f *MonitoringAB) Add(mesg proto.Message) {
 	case mesgnum.DeviceInfo:
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/monitoring_ab_test.go
+++ b/profile/filedef/monitoring_ab_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 func newMonitoringAMessageForTest(now time.Time) []proto.Message {
@@ -57,7 +56,7 @@ func newMonitoringAMessageForTest(now time.Time) []proto.Message {
 }
 
 func newMonitoringBMessageForTest(now time.Time) []proto.Message {
-	mesgsB := slices.Clone(newMonitoringAMessageForTest(now))
+	mesgsB := newMonitoringAMessageForTest(now)
 	ftype := mesgsB[0].FieldByNum(fieldnum.FileIdType)
 	ftype.Value = proto.Uint8(uint8(typedef.FileMonitoringB))
 	return mesgsB

--- a/profile/filedef/monitoring_daily.go
+++ b/profile/filedef/monitoring_daily.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // MonitoringDaily files follow the same format as monitoring files, however data is logged at 24 hour time intervals.
@@ -53,7 +52,7 @@ func (f *MonitoringDaily) Add(mesg proto.Message) {
 	case mesgnum.DeviceInfo:
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/schedules.go
+++ b/profile/filedef/schedules.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // Schedules files are used to schedule a user’s workouts and may contain multiple schedule messages each representing the start time of a workout.
@@ -47,7 +46,7 @@ func (f *Schedules) Add(mesg proto.Message) {
 	case mesgnum.Schedule:
 		f.Schedules = append(f.Schedules, mesgdef.NewSchedule(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/segment.go
+++ b/profile/filedef/segment.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // Segment files contain data defining a route and timing information to gauge progress against previous performances or other users
@@ -56,7 +55,7 @@ func (f *Segment) Add(mesg proto.Message) {
 	case mesgnum.SegmentPoint:
 		f.SegmentPoints = append(f.SegmentPoints, mesgdef.NewSegmentPoint(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/segment_list.go
+++ b/profile/filedef/segment_list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // SegmentList files maintain a list of available segments on the device.
@@ -50,7 +49,7 @@ func (f *SegmentList) Add(mesg proto.Message) {
 	case mesgnum.SegmentFile:
 		f.SegmentFiles = append(f.SegmentFiles, mesgdef.NewSegmentFile(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/settings.go
+++ b/profile/filedef/settings.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // Settings files contain user and device information in the form of profiles.
@@ -59,7 +58,7 @@ func (f *Settings) Add(mesg proto.Message) {
 	case mesgnum.DeviceSettings:
 		f.DeviceSettings = append(f.DeviceSettings, mesgdef.NewDeviceSettings(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/sport.go
+++ b/profile/filedef/sport.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // Sport files contain information about the user’s desired target zones.
@@ -65,7 +64,7 @@ func (f *Sport) Add(mesg proto.Message) {
 	case mesgnum.CadenceZone:
 		f.CadenceZones = append(f.CadenceZones, mesgdef.NewCadenceZone(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/totals.go
+++ b/profile/filedef/totals.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // Totals files are used to summarize a user’s activities and may contain multiple totals messages each representing
@@ -48,7 +47,7 @@ func (f *Totals) Add(mesg proto.Message) {
 	case mesgnum.Totals:
 		f.Totals = append(f.Totals, mesgdef.NewTotals(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/weight.go
+++ b/profile/filedef/weight.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // Weight contains time-stamped discrete measurement data of weight.
@@ -53,7 +52,7 @@ func (f *Weight) Add(mesg proto.Message) {
 	case mesgnum.DeviceInfo:
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/workout.go
+++ b/profile/filedef/workout.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // Workout is a file contains instructions for performing a structured activity.
@@ -54,7 +53,7 @@ func (f *Workout) Add(mesg proto.Message) {
 	case mesgnum.WorkoutStep:
 		f.WorkoutSteps = append(f.WorkoutSteps, mesgdef.NewWorkoutStep(&mesg))
 	default:
-		mesg.Fields = slices.Clone(mesg.Fields)
+		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -8,7 +8,6 @@ import (
 	"github.com/muktihari/fit/profile"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
-	"golang.org/x/exp/slices"
 )
 
 type errorString string
@@ -137,8 +136,8 @@ type MessageDefinition struct {
 
 // Clone clones MessageDefinition
 func (m MessageDefinition) Clone() MessageDefinition {
-	m.FieldDefinitions = slices.Clone(m.FieldDefinitions)
-	m.DeveloperFieldDefinitions = slices.Clone(m.DeveloperFieldDefinitions)
+	m.FieldDefinitions = append(m.FieldDefinitions[:0:0], m.FieldDefinitions...)
+	m.DeveloperFieldDefinitions = append(m.DeveloperFieldDefinitions[:0:0], m.DeveloperFieldDefinitions...)
 	return m
 }
 
@@ -226,11 +225,11 @@ func (m *Message) RemoveFieldByNum(num byte) {
 
 // Clone clones Message.
 func (m Message) Clone() Message {
-	m.Fields = slices.Clone(m.Fields)
+	m.Fields = append(m.Fields[:0:0], m.Fields...)
 	for i := range m.Fields {
 		m.Fields[i] = m.Fields[i].Clone()
 	}
-	m.DeveloperFields = slices.Clone(m.DeveloperFields)
+	m.DeveloperFields = append(m.DeveloperFields[:0:0], m.DeveloperFields...)
 	for i := range m.DeveloperFields {
 		m.DeveloperFields[i] = m.DeveloperFields[i].Clone()
 	}
@@ -323,8 +322,8 @@ func (f Field) Clone() Field {
 	}
 
 	fieldBase := *f.FieldBase // also include FieldBase, clone is meant to be a deep copy
-	fieldBase.Components = slices.Clone(fieldBase.Components)
-	fieldBase.SubFields = slices.Clone(fieldBase.SubFields)
+	fieldBase.Components = append(fieldBase.Components[:0:0], fieldBase.Components...)
+	fieldBase.SubFields = append(fieldBase.SubFields[:0:0], fieldBase.SubFields...)
 	for i := range fieldBase.SubFields {
 		fieldBase.SubFields[i] = fieldBase.SubFields[i].Clone()
 	}
@@ -375,8 +374,8 @@ type SubField struct {
 
 // Clone clones SubField
 func (s SubField) Clone() SubField {
-	s.Components = slices.Clone(s.Components)
-	s.Maps = slices.Clone(s.Maps)
+	s.Components = append(s.Components[:0:0], s.Components...)
+	s.Maps = append(s.Maps[:0:0], s.Maps...)
 	return s
 }
 


### PR DESCRIPTION
`a = slices.Clone(a)` can be simplified as `s = append(s[:0:0], s...)`, so we no longer need to depend to slices package just for cloning a slice. This is the default implementation in slices.Clone in go v1.22. Ref: https://github.com/golang/go/commit/b581e447394b4ba7a08ea64b214781cae0f4ef6c

Using `make+copy` is actually slightly more performant but it hurts the readability as the code become more verbose. The performance diff is relatively small, we probably don't need it unless we encounter a really edge case.

Here is the list the drawbacks: https://github.com/go101/go101/wiki/There-is-not-a-perfect-way-to-clone-slices-in-Go