### PR TITLE
feat(encoder): implements write buffer

### DIFF
--- a/encoder/stream.go
+++ b/encoder/stream.go
@@ -47,6 +47,9 @@ func (e *StreamEncoder) SequenceCompleted() error {
 	}
 	e.fileHeaderWritten = false
 	e.enc.reset()
+	if f, ok := e.enc.w.(flusher); ok {
+		return f.Flush()
+	}
 	return nil
 }
 

--- a/encoder/writebuffer_test.go
+++ b/encoder/writebuffer_test.go
@@ -1,0 +1,98 @@
+package encoder
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestNewWriteBuffer(t *testing.T) {
+	tt := []struct {
+		name     string
+		size     int
+		w        io.Writer
+		expected io.Writer
+	}{
+		{name: "nil", size: -1, w: nil, expected: nil},
+		{name: "writerAt", size: 4096, w: mockWriterAt{}, expected: &writerAt{}},
+		{name: "writerAt", size: 4096, w: mockWriteSeeker{}, expected: &writeSeeker{}},
+		{name: "writer", size: 4096, w: fnWriteOK, expected: &bufio.Writer{}},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			wr := newWriteBuffer(tc.w, tc.size)
+			if reflect.TypeOf(wr) != reflect.TypeOf(tc.expected) {
+				t.Fatalf("expected type: %T, got: %T", tc.expected, wr)
+			}
+		})
+	}
+}
+
+func TestWriterAt(t *testing.T) {
+	tt := []struct {
+		name string
+		w    io.Writer
+		errs [2]error
+	}{
+		{
+			name: "happy flow",
+			w:    mockWriterAt{Writer: fnWriteOK, WriterAt: fnWriteAtOK},
+			errs: [2]error{nil, nil},
+		},
+		{
+			name: "flush returns error",
+			w:    mockWriterAt{Writer: fnWriteErr, WriterAt: fnWriteAtOK},
+			errs: [2]error{nil, io.EOF},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newWriteBuffer(tc.w, 4096).(*writerAt)
+			_, err := w.Write([]byte{0, 0})
+			if !errors.Is(err, tc.errs[0]) {
+				t.Fatalf("expected error: %v, got: %v", tc.errs[0], err)
+			}
+			_, err = w.WriteAt([]byte{0, 0}, 0)
+			if !errors.Is(err, tc.errs[1]) {
+				t.Fatalf("expected error: %v, got: %v", tc.errs[1], err)
+			}
+		})
+	}
+}
+
+func TestWriteSeeker(t *testing.T) {
+	tt := []struct {
+		name string
+		w    io.Writer
+		errs [2]error
+	}{
+		{
+			name: "happy flow",
+			w:    mockWriteSeeker{Writer: fnWriteOK, Seeker: fnSeekOK},
+			errs: [2]error{nil, nil},
+		},
+		{
+			name: "flush returns error",
+			w:    mockWriteSeeker{Writer: fnWriteErr, Seeker: fnSeekOK},
+			errs: [2]error{nil, io.EOF},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newWriteBuffer(tc.w, 4096).(*writeSeeker)
+			_, err := w.Write([]byte{0, 0})
+			if !errors.Is(err, tc.errs[0]) {
+				t.Fatalf("expected error: %v, got: %v", tc.errs[0], err)
+			}
+			_, err = w.Seek(0, io.SeekStart)
+			if !errors.Is(err, tc.errs[1]) {
+				t.Fatalf("expected error: %v, got: %v", tc.errs[1], err)
+			}
+		})
+	}
+}

--- a/kit/bufferedwriter/doc.go
+++ b/kit/bufferedwriter/doc.go
@@ -5,4 +5,7 @@
 // Package bufferedwriter provides functionality to wrap an io.Writer while keep maintaining
 // the underlying capability to write at specific bytes such as when it's implementing io.WriterAt or io.WriteSeeker.
 // This package differs from bufio.Writer which encapsulates the writer's implementation details as io.Writer.
+//
+// Deprecated: Encoder now implements built-in write buffer so this package is no longer needed.
+// This package will no longer be maintained and might be deleted in the next major/minor release.
 package bufferedwriter


### PR DESCRIPTION
In most cases, we work with FIT protocol in the form of files, it is more make sense to use a buffer by default. We found that having to explicitly create a buffer makes the code more verbose without achieving any tangible benefits. In exceptional cases, when users don't want the Encoder to do buffering, users can direct the Encoder to do so by specifying `WithWriteBufferSize(0)` Option.