### PR TITLE
perf: optimize functional options

### DIFF
--- a/decoder/decoder_bench_test.go
+++ b/decoder/decoder_bench_test.go
@@ -139,17 +139,25 @@ func BenchmarkCheckIntegrity(b *testing.B) {
 
 func BenchmarkReset(b *testing.B) {
 	b.Run("benchmark New()", func(b *testing.B) {
+		b.StopTimer()
+		lis := filedef.NewListener()
+		defer lis.Close()
+		b.StartTimer()
+
 		for i := 0; i < b.N; i++ {
-			_ = decoder.New(nil)
+			_ = decoder.New(nil, decoder.WithMesgListener(lis))
 		}
 	})
 	b.Run("benchmark Reset()", func(b *testing.B) {
 		b.StopTimer()
-		dec := decoder.New(nil)
+		lis := filedef.NewListener()
+		defer lis.Close()
+
+		dec := decoder.New(nil, decoder.WithMesgListener(lis))
 		b.StartTimer()
 
 		for i := 0; i < b.N; i++ {
-			dec.Reset(nil)
+			dec.Reset(nil, decoder.WithMesgListener(lis))
 		}
 	})
 }

--- a/encoder/validator.go
+++ b/encoder/validator.go
@@ -47,12 +47,8 @@ type validatorOptions struct {
 	factory           Factory
 }
 
-// ValidatorOptions is message validator's option.
-type ValidatorOption interface{ apply(o *validatorOptions) }
-
-type fnApplyValidatorOption func(o *validatorOptions)
-
-func (f fnApplyValidatorOption) apply(o *validatorOptions) { f(o) }
+// ValidatorOption is message validator's option.
+type ValidatorOption func(o *validatorOptions)
 
 func defaultValidatorOptions() validatorOptions {
 	return validatorOptions{
@@ -69,19 +65,19 @@ type Factory interface {
 
 // ValidatorWithPreserveInvalidValues directs the message validator to preserve invalid value instead of omit it.
 func ValidatorWithPreserveInvalidValues() ValidatorOption {
-	return fnApplyValidatorOption(func(o *validatorOptions) {
+	return func(o *validatorOptions) {
 		o.omitInvalidValues = false
-	})
+	}
 }
 
 // ValidatorWithFactory directs the message validator to use this factory instead of standard factory.
 // The factory is only used for validating developer fields that have valid native data.
 func ValidatorWithFactory(factory Factory) ValidatorOption {
-	return fnApplyValidatorOption(func(o *validatorOptions) {
+	return func(o *validatorOptions) {
 		if o.factory != nil {
 			o.factory = factory
 		}
-	})
+	}
 }
 
 type messageValidator struct {
@@ -96,7 +92,7 @@ func NewMessageValidator(opts ...ValidatorOption) MessageValidator {
 	mv := &messageValidator{}
 	mv.options = defaultValidatorOptions()
 	for i := range opts {
-		opts[i].apply(&mv.options)
+		opts[i](&mv.options)
 	}
 	return mv
 }

--- a/profile/filedef/listener.go
+++ b/profile/filedef/listener.go
@@ -61,26 +61,23 @@ func PredefinedFileSet() FileSets {
 	}
 }
 
-type Option interface{ apply(o *options) }
-
-type fnApply func(o *options)
-
-func (f fnApply) apply(o *options) { f(o) }
+// Option is Listener's option.
+type Option func(o *options)
 
 // WithChannelBuffer sets the size of buffered channel, default is 128.
 func WithChannelBuffer(size uint) Option {
-	return fnApply(func(o *options) { o.channelBuffer = size })
+	return func(o *options) { o.channelBuffer = size }
 }
 
 // WithFileSets sets what kind of file listener should listen to, when we encounter a file type that is not listed in fileset,
 // that file type will be skipped. This will replace the default filesets registered in listener, if you intend to append your own
 // file types, please call PredefinedFileSet() and add your file types.
 func WithFileSets(fileSets FileSets) Option {
-	return fnApply(func(o *options) {
+	return func(o *options) {
 		if o.fileSets != nil {
 			o.fileSets = fileSets
 		}
-	})
+	}
 }
 
 var _ decoder.MesgListener = (*Listener)(nil)
@@ -92,7 +89,7 @@ func NewListener(opts ...Option) *Listener {
 		active:  true,
 	}
 	for i := range opts {
-		opts[i].apply(&l.options)
+		opts[i](&l.options)
 	}
 
 	l.reset()


### PR DESCRIPTION
Previously, we wrapped functional options with interface (`interface { apply(o *options) }`) following the [Uber style](https://github.com/uber-go/guide/blob/master/style.md#functional-options). While this style (arguably) provides more flexibility, this comes with a trade-off too: "arguments passed to interface's method typically be heap-allocated".

I don't think we need such flexibility in our code and [ordinary functional options](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) would be sufficient for our cases. Additionally, we make Decoder to reuse listeners' slices to reduce allocation needed. By doing this, we can get zero allocation when resetting Decoder and Encoder.

Here is the update and the benchmark regarding this change:

#### Decoder:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/decoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                          │   old.txt    │               new.txt                │
                          │    sec/op    │    sec/op     vs base                │
Reset/benchmark_New()-4      4.975µ ± 8%   4.869µ ± 22%        ~ (p=0.447 n=10)
Reset/benchmark_Reset()-4   177.60n ± 1%   49.34n ±  6%  -72.22% (p=0.000 n=10)
geomean                      939.9n        490.2n        -47.85%

                          │   old.txt    │                  new.txt                  │
                          │     B/op     │     B/op      vs base                     │
Reset/benchmark_New()-4     23.54Ki ± 0%   23.49Ki ± 0%    -0.20% (p=0.000 n=10)
Reset/benchmark_Reset()-4     64.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)
geomean                     1.213Ki                      ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                          │  old.txt   │                 new.txt                 │
                          │ allocs/op  │ allocs/op   vs base                     │
Reset/benchmark_New()-4     8.000 ± 0%   6.000 ± 0%   -25.00% (p=0.000 n=10)
Reset/benchmark_Reset()-4   3.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
geomean                     4.899                    ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```

#### Encoder:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/encoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                          │   old.txt   │               new.txt                │
                          │   sec/op    │    sec/op     vs base                │
Reset/benchmark_New()-4     24.01µ ± 2%   23.96µ ± 49%        ~ (p=0.579 n=10)
Reset/benchmark_Reset()-4   72.90n ± 1%   30.97n ±  3%  -57.51% (p=0.000 n=10)
geomean                     1.323µ        861.4n        -34.89%

                          │   old.txt    │                  new.txt                  │
                          │     B/op     │     B/op      vs base                     │
Reset/benchmark_New()-4     128.1Ki ± 0%   128.1Ki ± 0%    -0.02% (p=0.000 n=10)
Reset/benchmark_Reset()-4     24.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)
geomean                     1.733Ki                      ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                          │  old.txt   │                 new.txt                 │
                          │ allocs/op  │ allocs/op   vs base                     │
Reset/benchmark_New()-4     7.000 ± 0%   6.000 ± 0%   -14.29% (p=0.000 n=10)
Reset/benchmark_Reset()-4   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
geomean                     2.646                    ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```