### PR TITLE
perf(decoder): optimize decode mesage definition

### DIFF
--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -1407,6 +1407,9 @@ func TestDecodeMessageDefinition(t *testing.T) {
 				return
 			}
 			mesgDef := *dec.localMessageDefinitions[proto.MesgDefinitionMask&proto.LocalMesgNumMask]
+			if len(mesgDef.DeveloperFieldDefinitions) == 0 {
+				mesgDef.DeveloperFieldDefinitions = nil
+			}
 			if diff := cmp.Diff(mesgDef, tc.mesgDef); diff != "" {
 				t.Fatal(diff)
 			}


### PR DESCRIPTION
Previously, we allocate new object for every new message definition then removing the new object on reset, this cause decoder to create new object again and again. And on every new message definition, we allocate its slices as needed, so we need to re-allocate slice when the current slice's cap is less than the new one, here is the sample of `cap(mesgDef.FieldDefinitions)` when decoding `from_garmin_forums/triathlon_summary_first.fit`:

```go
LocalNum: 1, cap: 5   // alloc
LocalNum: 1, cap: 18  // re-alloc since 18 > 5
LocalNum: 3, cap: 13  // alloc
LocalNum: 3, cap: 14  // re-alloc since 14 > 13
LocalNum: 2, cap: 10  // alloc
LocalNum: 2, cap: 123 // re-alloc since 123 > 10
LocalNum: 2, cap: 49  // reslice
LocalNum: 2, cap: 47  // reslice
LocalNum: 2, cap: 41  // reslice
```

This PR removes the need to create new message definition object and allocate slices with max cap (only for targeted localMesgNum) for more deterministic performance by avoiding slice re-allocation.