### PR TITLE
chore: always run ci on updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,9 @@ name: CI
 on:
   push:
     branches: ["master"]
-    paths:
-      - "**.go" # Trigger only when Go files are modified
-      - "go.mod"
-      - "go.sum"
 
   pull_request:
     branches: ["master"]
-    paths:
-      - "**.go" # Trigger only when Go files are modified
-      - "go.mod"
-      - "go.sum"
 
 permissions: {}
 


### PR DESCRIPTION
Always run CI on updates so we can catch any potential error when testing using latest Go version.