### PR TITLE
perf!: update datetime package

### DIFF
--- a/cmd/fitactivity/combiner/combiner.go
+++ b/cmd/fitactivity/combiner/combiner.go
@@ -156,8 +156,8 @@ func Combine(fits ...proto.FIT) (*proto.FIT, error) {
 	}
 
 	tzOffsetHour := datetime.TzOffsetHours(
-		datetime.ToTime(localTimestampField.Value),
-		datetime.ToTime(timestampField.Value),
+		datetime.ToTime(localTimestampField.Value.Uint32()),
+		datetime.ToTime(timestampField.Value.Uint32()),
 	)
 
 	timestampField.Value = proto.Uint32(lastTimestamp)

--- a/cmd/fitprint/printer/printer.go
+++ b/cmd/fitprint/printer/printer.go
@@ -326,7 +326,7 @@ func formatFieldValue(
 ) string {
 	switch profileType {
 	case profile.DateTime, profile.LocalDateTime: // Special Case: time.Time
-		return fmt.Sprintf("%q (%d)", datetime.ToTime(value).Format(time.RFC3339), value.Uint32())
+		return fmt.Sprintf("%q (%d)", datetime.ToTime(value.Uint32()).Format(time.RFC3339), value.Uint32())
 	}
 
 	if scale != 1 || offset != 0 { // Scaled Value

--- a/kit/datetime/datetime.go
+++ b/kit/datetime/datetime.go
@@ -5,67 +5,38 @@
 package datetime
 
 import (
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/muktihari/fit/profile/basetype"
-	"github.com/muktihari/fit/profile/typedef"
-	"github.com/muktihari/fit/proto"
 )
 
 var epoch = time.Date(1989, time.December, 31, 0, 0, 0, 0, time.UTC)
 
-// Epoch return FIT epoch (31 Dec 1989 00:00:000 UTC) as time.Time
+// Epoch returns FIT epoch (31 Dec 1989 00:00:000 UTC) as time.Time
 func Epoch() time.Time { return epoch }
 
-// ToTime return new time based on given v.
-func ToTime(value any) time.Time {
-	if value == nil {
-		return time.Time{}
+// ToUint32 converts t into uint32 FIT representative time value.
+func ToUint32(t time.Time) uint32 {
+	if t.Before(epoch) {
+		return basetype.Uint32Invalid
 	}
-
-	var val uint32 = basetype.Uint32Invalid
-
-	switch v := value.(type) {
-	case proto.Value:
-		val = v.Uint32()
-	case uint32:
-		val = v
-	case typedef.DateTime:
-		val = uint32(v)
-	case typedef.LocalDateTime:
-		val = uint32(v)
-	}
-
-	if val == basetype.Uint32Invalid {
-		return time.Time{}
-	}
-
-	return epoch.Add(time.Duration(val) * time.Second)
+	return uint32(t.Sub(epoch).Seconds())
 }
 
-// ToLocalTime returns time in local time zone by specifying the time zone offset hours (+7 for GMT+7).
-func ToLocalTime(value any, tzOffsetHours int) time.Time {
-	t, ok := value.(time.Time)
-	if !ok {
-		t = ToTime(value)
+// ToTime converts uint32 value into time.Time.
+func ToTime(value uint32) time.Time {
+	if value == basetype.Uint32Invalid {
+		return time.Time{}
 	}
+	return epoch.Add(time.Duration(value) * time.Second)
+}
 
+// ToLocalTime converts time in local time zone by specifying the time zone offset hours (+7 for GMT+7).
+func ToLocalTime(t time.Time, tzOffsetHours int) time.Time {
 	if t.IsZero() {
 		return t
 	}
-
-	zone := new(strings.Builder)
-	zone.WriteString("UTC")
-	if tzOffsetHours > 0 {
-		zone.WriteRune('+')
-	}
-
-	zone.WriteString(strconv.Itoa(tzOffsetHours)) // e.g. zone name -> UTC+7, UTC-7, etc...
-	loc := time.FixedZone(zone.String(), tzOffsetHours*60*60)
-
-	return t.In(loc)
+	return t.In(time.FixedZone("", tzOffsetHours*60*60)) // Use unnamed fixed zones
 }
 
 // TzOffsetHours calculates time zone offset.
@@ -78,12 +49,4 @@ func TzOffsetHours(localDateTime, dateTime time.Time) int {
 // TzOffsetHoursFromUint32 is similar to TzOffsetHours but it took uint32 as parameters.
 func TzOffsetHoursFromUint32(localDateTime, dateTime uint32) int {
 	return int(localDateTime-dateTime) / 3600
-}
-
-// Convert t into uint32 fit representative time value.
-func ToUint32(t time.Time) uint32 {
-	if t.Before(epoch) {
-		return basetype.Uint32Invalid
-	}
-	return uint32(t.Sub(epoch).Seconds())
 }


### PR DESCRIPTION
Breaking Changes:
- ToTime now accepts uint32 instead of any
- ToLocalTime now accepts time.Time instead on any and it is no longer allocate.

Since we use proto.Value, all timestamp will be represented as uint32 and in mesgdef's structures all timestamp will be represented as time.Time. There are no timestamp being represented as typedef.DateTime or typedef.LocalDateTime anymore. This way we can no longer need to convert the value to an interface, this will improve performance a little bit and we have more clear context when working with time.

Benchmark:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/kit/datetime
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
              │   old.txt    │               new.txt                │
              │    sec/op    │    sec/op     vs base                │
ToTime-4        10.870n ± 1%   7.452n ±  0%  -31.44% (p=0.000 n=10)
ToLocalTime-4   193.70n ± 1%   10.68n ± 23%  -94.48% (p=0.000 n=10)
geomean          45.89n        8.923n        -80.55%

              │   old.txt    │                 new.txt                 │
              │     B/op     │    B/op     vs base                     │
ToTime-4        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
ToLocalTime-4   168.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
geomean                    ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

              │   old.txt    │                 new.txt                 │
              │  allocs/op   │ allocs/op   vs base                     │
ToTime-4        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
ToLocalTime-4   4.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
geomean                    ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

```