### PR TITLE
chore: update release workflow go version to stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: ">=1.18"
+          go-version: "stable"
 
       - name: Build [macOS]
         if: matrix.os == 'macOS'


### PR DESCRIPTION
Ensure the library can be compiled and is compiled using latest stable version of Go.