### PR TITLE
perf: proto.Value remove interface{} overhead

### DIFF
--- a/proto/value_test.go
+++ b/proto/value_test.go
@@ -874,7 +874,7 @@ func TestLen(t *testing.T) {
 		sizeInBytes int
 	}{
 		{value: Value{}, sizeInBytes: 0},
-		{value: Value{any: TypeInvalid}, sizeInBytes: 0},
+		{value: Value{typ: TypeInvalid}, sizeInBytes: 0},
 		{value: Bool(true), sizeInBytes: 1},
 		{value: Int8(10), sizeInBytes: 1},
 		{value: Uint8(10), sizeInBytes: 1},
@@ -922,7 +922,7 @@ func TestLen(t *testing.T) {
 	}
 }
 
-func BenchmarkSliceBool(b *testing.B) {
+func BenchmarkValueSliceBool(b *testing.B) {
 	s := []bool{true, false}
 
 	b.Run("[]bool", func(b *testing.B) {
@@ -933,7 +933,18 @@ func BenchmarkSliceBool(b *testing.B) {
 	})
 }
 
-func BenchmarkValid(b *testing.B) {
+func BenchmarkValueSliceString(b *testing.B) {
+	s := []string{"go", "fit", "sdk"}
+
+	b.Run("[]string", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			v := SliceString(s)
+			_ = v.SliceString()
+		}
+	})
+}
+
+func BenchmarkValueValid(b *testing.B) {
 	v := Uint32(10)
 
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
The idea of using `interface{}` in `proto.Value` is to hold either a pointer to slice data to avoid reallocation the same slice since the slice is typically temporarily used and `proto.Value` is in the hot path (especially proto.Value's `Valid` method), or to store a Type since it can hold dynamic value (the implementation is similar to [go's log/slog.Value](https://github.com/golang/go/blob/27093581b2828a2752a6d2711def09517eb2513b/src/log/slog/value.go#L21-L36)). This, however, create an interface overhead when we try to store/load the data from it. 

Since we define all the Type that we use, we can ensure the safety of casting the value back and forth by storing a pointer directly as `unsafe.Pointer` type instead of putting it to an interface. Unlike `uintptr` that just an integer number, `unsafe.Pointer` keeps the pointer reference so we don't lose the data (it is safe from being garbage-collected).

This change will make our code to be straightforward, currently we use `unsafe` anyway (we use it with extreme care), in the future the implementation may change depend on how Go evolves.


Benchmark:
```js
goos: darwin
goarch: amd64
pkg: github.com/muktihari/fit/proto
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                            │    old.txt   │                new.txt               │
                            │    sec/op    │    sec/op     vs base                │
ValueMarshalAppend-4           90.64n ± 1%    87.83n ± 3%   -3.11% (p=0.002 n=10)
ValueSliceBool/[]bool-4       0.5681n ± 0%   0.5687n ± 1%        ~ (p=0.868 n=10)
ValueSliceString/[]string-4    1.134n ± 2%    1.133n ± 0%        ~ (p=0.268 n=10)
ValueValid-4                   4.853n ± 1%    3.561n ± 0%  -26.62% (p=0.000 n=10)
geomean                        4.103n         3.768n        -8.17%

# B/op and allocs/op are omitted since the results are the same
```