### PR TITLE
feat: encoder enable dynamic protocol version

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -798,7 +798,7 @@ func main() {
 
 Note:
 
-- By default, Encoder use protocol version 1.0 (proto.V1), if you want to use protocol version 2.0 (proto.V2), please specify it using Encode Option: WithProtocolVersion. See [Available Encode Options](#Available-Encode-Options)
+- By default, Encoder will use protocol version in FileHeader for each FIT file, if it's not specified, it will use protocol version 1.0 (proto.V1). If you want to use specific protocol version for the entire encoding regardless the value in FileHeader, please use this Encode Option: WithProtocolVersion. See [Available Encode Options](#Available-Encode-Options)
 - Encoder already implements efficient io.Writer buffering, DO NOT wrap io.Writer (such as \*os.File) with buffer such as using \*bufio.Writer; Doing so will greatly reduce performance.
 
 ### Encode RAW Protocol Messages
@@ -1008,7 +1008,7 @@ func main() {
 
 ### Available Encode Options
 
-1. **WithProtocolVersion**: directs the Encoder to use specific Protocol Version (default: proto.V1).
+1. **WithProtocolVersion**: directs the Encoder to use specific ProtocolVersion for the entire encoding. By default, Encoder will use ProtocolVersion in FileHeader for each FIT file, if it's not specified, it will use proto.V1. This option overrides the FileHeader's ProtocolVersion and forces all FIT files to use this ProtocolVersion during encoding.
 
    Example:
 

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -75,8 +75,8 @@ type Encoder struct {
 
 type options struct {
 	messageValidator         MessageValidator
-	protocolVersion          proto.Version
 	writeBufferSize          int
+	protocolVersion          proto.Version
 	endianness               byte
 	headerOption             headerOption
 	multipleLocalMessageType byte

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -243,7 +243,6 @@ func TestOptions(t *testing.T) {
 			expected: options{
 				multipleLocalMessageType: 0,
 				endianness:               0,
-				protocolVersion:          proto.V1,
 				messageValidator:         NewMessageValidator(),
 				writeBufferSize:          defaultWriteBufferSize,
 			},


### PR DESCRIPTION
- Encoder: enable dynamic protocol version encoding based on the value in FileHeader. Now, Encoder by default will use protocol version in FileHeader for each FIT file, if it's not specified, it will use protocol version 1.0 (proto.V1).