### PR TITLE
fix: encoder WriteSeeker now relative to current offset

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -361,16 +361,18 @@ func (e *Encoder) updateFileHeader(header *proto.FileHeader) (err error) {
 
 	switch w := e.w.(type) {
 	case io.WriteSeeker:
-		// Relative to EOF, ensure that we only write in our own data.
-		_, err = w.Seek(-e.n+e.lastFileHeaderPos, io.SeekEnd)
+		// Ensure that we only write in our own data.
+		size := e.n - e.lastFileHeaderPos
+		_, err = w.Seek(-size, io.SeekCurrent)
 		if err != nil {
 			return err
 		}
-		_, err = w.Write(b)
+		var n int
+		n, err = w.Write(b)
 		if err != nil {
 			return err
 		}
-		_, err = w.Seek(0, io.SeekEnd)
+		_, err = w.Seek(size-int64(n), io.SeekCurrent)
 		return err
 	case io.WriterAt:
 		// This might write at the wrong offset if the writer was not

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -157,7 +157,7 @@ func (f *writeSeekerStub) Seek(off int64, whence int) (int64, error) {
 	switch whence {
 	case io.SeekCurrent:
 		l := int64(len(f.buf))
-		l2 := l + off
+		l2 := f.off + off
 		if l2 < 0 {
 			return 0, os.ErrInvalid
 		}


### PR DESCRIPTION
I just remember that we can seek from current offset, this way we ensure that we will write in our own data as we write relative to the current offset.