### PR TITLE
cli: refactor fitactivity

### DIFF
--- a/cmd/fitactivity/combiner/combiner.go
+++ b/cmd/fitactivity/combiner/combiner.go
@@ -25,22 +25,17 @@ type errorString string
 func (e errorString) Error() string { return string(e) }
 
 const (
-	ErrMinimalCombine = errorString("minimal combine")
-	ErrNoSessionFound = errorString("no session found")
-	ErrSportMismatch  = errorString("sport mismatch")
+	errNoSessionFound = errorString("no session found")
+	errSportMismatch  = errorString("sport mismatch")
 )
 
-func Combine(fits ...*proto.FIT) (result *proto.FIT, err error) {
+// Combine combines multiple FIT activities into one continous activity.
+func Combine(fits []*proto.FIT) (result *proto.FIT, err error) {
 	for i := 0; i < len(fits); i++ {
 		if len(fits[i].Messages) == 0 {
 			fits = append(fits[:i], fits[i+1:]...)
 			i--
 		}
-	}
-
-	if len(fits) < 2 {
-		return nil, fmt.Errorf("provide at least 2 valid FIT files to combine: %w",
-			ErrMinimalCombine)
 	}
 
 	slices.SortStableFunc(fits, func(f1, f2 *proto.FIT) int {
@@ -93,7 +88,7 @@ func Combine(fits ...*proto.FIT) (result *proto.FIT, err error) {
 			valid++
 		}
 		if len(sessionsByIndex[i]) == 0 {
-			return nil, fmt.Errorf("fits[%d]: %w", i, ErrNoSessionFound)
+			return nil, fmt.Errorf("fits[%d]: %w", i, errNoSessionFound)
 		}
 		fit.Messages = fit.Messages[:valid]
 	}
@@ -108,7 +103,7 @@ func Combine(fits ...*proto.FIT) (result *proto.FIT, err error) {
 		)
 		if ses.Sport != nextSes.Sport {
 			return nil, fmt.Errorf("fits[%d] %q != %q: %w",
-				i, ses.Sport, nextSes.Sport, ErrSportMismatch)
+				i, ses.Sport, nextSes.Sport, errSportMismatch)
 		}
 
 		var lastDistance uint32

--- a/cmd/fitactivity/combiner/combiner_test.go
+++ b/cmd/fitactivity/combiner/combiner_test.go
@@ -158,7 +158,7 @@ func TestCombine(t *testing.T) {
 
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
-			fit, err := Combine(tc.fits...)
+			fit, err := Combine(tc.fits)
 			if !errors.Is(err, tc.err) {
 				t.Fatalf("expected error: %v, got: %v", tc.err, err)
 			}

--- a/cmd/fitactivity/combiner/combiner_test.go
+++ b/cmd/fitactivity/combiner/combiner_test.go
@@ -1,0 +1,367 @@
+// Copyright 2024 The FIT SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package combiner
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/kit/datetime"
+	"github.com/muktihari/fit/profile/basetype"
+	"github.com/muktihari/fit/profile/mesgdef"
+	"github.com/muktihari/fit/profile/typedef"
+	"github.com/muktihari/fit/profile/untyped/fieldnum"
+	"github.com/muktihari/fit/profile/untyped/mesgnum"
+	"github.com/muktihari/fit/proto"
+	"golang.org/x/exp/slices"
+)
+
+func TestCombine(t *testing.T) {
+	now := time.Now()
+	tt := []struct {
+		name     string
+		fits     []*proto.FIT
+		expected *proto.FIT
+		err      error
+	}{
+		{
+			name: "cycling + cycling",
+			fits: []*proto.FIT{
+				{Messages: []proto.Message{
+					{Num: mesgnum.FileId, Fields: []proto.Field{
+						factory.CreateField(mesgnum.FileId, fieldnum.FileIdTimeCreated).WithValue(datetime.ToUint32(now)),
+					}},
+					{Num: mesgnum.Record, Fields: []proto.Field{
+						factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 1),
+						factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(100)),
+					}},
+					{Num: mesgnum.SplitSummary, Fields: []proto.Field{
+						factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummarySplitType).WithValue(typedef.SplitTypeRunActive),
+						factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummaryNumSplits).WithValue(uint16(1)),
+					}},
+					{Num: mesgnum.SplitSummary, Fields: []proto.Field{
+						factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummarySplitType).WithValue(typedef.SplitTypeRunRest),
+						factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummaryNumSplits).WithValue(uint16(1)),
+					}},
+					{Num: mesgnum.Record, Fields: []proto.Field{
+						factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 2),
+						factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(200)),
+					}},
+					{Num: mesgnum.Session, Fields: []proto.Field{
+						factory.CreateField(mesgnum.Session, fieldnum.SessionSport).WithValue(typedef.SportCycling),
+						factory.CreateField(mesgnum.Session, fieldnum.SessionTimestamp).WithValue(datetime.ToUint32(now) + 2),
+						factory.CreateField(mesgnum.Session, fieldnum.SessionStartTime).WithValue(datetime.ToUint32(now)),
+						factory.CreateField(mesgnum.Session, fieldnum.SessionTotalDistance).WithValue(uint32(200)),
+						factory.CreateField(mesgnum.Session, fieldnum.SessionTotalMovingTime).WithValue(uint32(2000)),
+						factory.CreateField(mesgnum.Session, fieldnum.SessionTotalElapsedTime).WithValue(uint32(3000)),
+						factory.CreateField(mesgnum.Session, fieldnum.SessionTotalTimerTime).WithValue(uint32(3000)),
+					}},
+					{Num: mesgnum.Activity, Fields: []proto.Field{
+						factory.CreateField(mesgnum.Activity, fieldnum.ActivityType).WithValue(typedef.ActivityAutoMultiSport),
+						factory.CreateField(mesgnum.Activity, fieldnum.ActivityTotalTimerTime).WithValue(uint32(3000)),
+						factory.CreateField(mesgnum.Activity, fieldnum.ActivityTimestamp).WithValue(datetime.ToUint32(now) + 2),
+						factory.CreateField(mesgnum.Activity, fieldnum.ActivityLocalTimestamp).WithValue(datetime.ToUint32(now.Add(7*time.Hour)) + 2),
+						factory.CreateField(mesgnum.Activity, fieldnum.ActivityNumSessions).WithValue(uint16(1)),
+					}},
+				}},
+				{Messages: []proto.Message{
+					{Num: mesgnum.FileId, Fields: []proto.Field{
+						factory.CreateField(mesgnum.FileId, fieldnum.FileIdTimeCreated).WithValue(datetime.ToUint32(now) + 10),
+					}},
+					{Num: mesgnum.Record, Fields: []proto.Field{
+						factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 10),
+						factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(100)),
+					}},
+					{Num: mesgnum.SplitSummary, Fields: []proto.Field{
+						factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummarySplitType).WithValue(typedef.SplitTypeRunActive),
+						factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummaryNumSplits).WithValue(uint16(1)),
+					}},
+					{Num: mesgnum.Record, Fields: []proto.Field{
+						factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 20),
+						factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(200)),
+					}},
+					{Num: mesgnum.Session, Fields: []proto.Field{
+						factory.CreateField(mesgnum.Session, fieldnum.SessionSport).WithValue(typedef.SportCycling),
+						factory.CreateField(mesgnum.Session, fieldnum.SessionTimestamp).WithValue(datetime.ToUint32(now) + 20),
+						factory.CreateField(mesgnum.Session, fieldnum.SessionStartTime).WithValue(datetime.ToUint32(now) + 10),
+						factory.CreateField(mesgnum.Session, fieldnum.SessionTotalDistance).WithValue(uint32(200)),
+						factory.CreateField(mesgnum.Session, fieldnum.SessionTotalMovingTime).WithValue(uint32(2000)),
+						factory.CreateField(mesgnum.Session, fieldnum.SessionTotalElapsedTime).WithValue(uint32(3000)),
+						factory.CreateField(mesgnum.Session, fieldnum.SessionTotalTimerTime).WithValue(uint32(3000)),
+					}},
+					{Num: mesgnum.Activity, Fields: []proto.Field{
+						factory.CreateField(mesgnum.Activity, fieldnum.ActivityType).WithValue(typedef.ActivityAutoMultiSport),
+						factory.CreateField(mesgnum.Activity, fieldnum.ActivityTotalTimerTime).WithValue(uint32(3000)),
+						factory.CreateField(mesgnum.Activity, fieldnum.ActivityTimestamp).WithValue(datetime.ToUint32(now) + 12),
+						factory.CreateField(mesgnum.Activity, fieldnum.ActivityLocalTimestamp).WithValue(datetime.ToUint32(now.Add(7*time.Hour)) + 12),
+						factory.CreateField(mesgnum.Activity, fieldnum.ActivityNumSessions).WithValue(uint16(1)),
+					}},
+				}},
+			},
+			expected: &proto.FIT{Messages: []proto.Message{
+				{Num: mesgnum.FileId, Fields: []proto.Field{
+					factory.CreateField(mesgnum.FileId, fieldnum.FileIdTimeCreated).WithValue(datetime.ToUint32(now)),
+				}},
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 1),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(100)),
+				}},
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 2),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(200)),
+				}},
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 10),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(300)),
+				}},
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 20),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(400)),
+				}},
+				{Num: mesgnum.SplitSummary, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Session, proto.FieldNumTimestamp).WithValue(datetime.ToUint32(now) + 20), // Additional
+					factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummarySplitType).WithValue(typedef.SplitTypeRunActive),
+					factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummaryNumSplits).WithValue(uint16(2)),
+				}},
+				{Num: mesgnum.SplitSummary, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Session, proto.FieldNumTimestamp).WithValue(datetime.ToUint32(now) + 20), // Additional
+					factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummarySplitType).WithValue(typedef.SplitTypeRunRest),
+					factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummaryNumSplits).WithValue(uint16(1)),
+				}},
+				{Num: mesgnum.Session, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Session, fieldnum.SessionSport).WithValue(typedef.SportCycling),
+					factory.CreateField(mesgnum.Session, fieldnum.SessionTimestamp).WithValue(datetime.ToUint32(now) + 20),
+					factory.CreateField(mesgnum.Session, fieldnum.SessionStartTime).WithValue(datetime.ToUint32(now)),
+					factory.CreateField(mesgnum.Session, fieldnum.SessionTotalDistance).WithValue(uint32(400)),
+					factory.CreateField(mesgnum.Session, fieldnum.SessionTotalMovingTime).WithValue(uint32(4000)),
+					factory.CreateField(mesgnum.Session, fieldnum.SessionTotalElapsedTime).WithValue(uint32(6000 + 7000)), // gap 7000
+					factory.CreateField(mesgnum.Session, fieldnum.SessionTotalTimerTime).WithValue(uint32(6000 + 7000)),   // gap 7000
+				}},
+				{Num: mesgnum.Activity, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Activity, fieldnum.ActivityType).WithValue(typedef.ActivityAutoMultiSport),
+					factory.CreateField(mesgnum.Activity, fieldnum.ActivityTotalTimerTime).WithValue(uint32(19000)), // 19s
+					factory.CreateField(mesgnum.Activity, fieldnum.ActivityTimestamp).WithValue(datetime.ToUint32(now) + 20),
+					factory.CreateField(mesgnum.Activity, fieldnum.ActivityLocalTimestamp).WithValue(
+						datetime.ToUint32(now.Add(7*time.Hour)) + 20,
+					),
+					factory.CreateField(mesgnum.Activity, fieldnum.ActivityNumSessions).WithValue(uint16(1)),
+				}},
+			}},
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
+			fit, err := Combine(tc.fits...)
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("expected error: %v, got: %v", tc.err, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(fit, tc.expected,
+				cmp.Transformer("Value", func(v proto.Value) interface{} { return v.Any() }),
+				cmp.Transformer("Fields", func(fields []proto.Field) []proto.Field {
+					slices.SortStableFunc(fields, func(f1, f2 proto.Field) int {
+						if f1.Num < f2.Num {
+							return -1
+						} else if f1.Num > f2.Num {
+							return 1
+						}
+						return 0
+					})
+					return fields
+				}),
+			); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestGetLastDistanceOrZero(t *testing.T) {
+	now := time.Now()
+	tt := []struct {
+		name  string
+		mesgs []proto.Message
+		dist  uint32
+	}{
+		{
+			name: "happy flow",
+			mesgs: []proto.Message{
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(uint32(datetime.ToUint32(now))),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(1)),
+				}},
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(uint32(datetime.ToUint32(now) + 1)),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(2)),
+				}},
+				{Num: mesgnum.Session, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Session, fieldnum.SessionTimestamp).WithValue(uint32(datetime.ToUint32(now) + 1)),
+				}},
+			},
+			dist: 2,
+		},
+		{
+			name: "return zero",
+			mesgs: []proto.Message{
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(uint32(datetime.ToUint32(now))),
+				}},
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(uint32(datetime.ToUint32(now) + 1)),
+				}},
+			},
+			dist: 0,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			d := getLastDistanceOrZero(tc.mesgs)
+			if d != tc.dist {
+				t.Fatalf("expected: %d, got: %d", tc.dist, d)
+			}
+		})
+	}
+}
+
+func TestGetFirstTimestamp(t *testing.T) {
+	now := time.Now()
+	tt := []struct {
+		name      string
+		mesgs     []proto.Message
+		timestamp uint32
+	}{
+		{
+			name: "happy flow",
+			mesgs: []proto.Message{
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(uint32(datetime.ToUint32(now))),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(1)),
+				}},
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(uint32(datetime.ToUint32(now) + 1)),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(2)),
+				}},
+				{Num: mesgnum.Session, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Session, fieldnum.SessionTimestamp).WithValue(uint32(datetime.ToUint32(now) + 1)),
+				}},
+			},
+			timestamp: datetime.ToUint32(now),
+		},
+		{
+			name: "return basetype.Uint32Invalid",
+			mesgs: []proto.Message{
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(1)),
+				}},
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(2)),
+				}},
+			},
+			timestamp: basetype.Uint32Invalid,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			d := getFirstTimestamp(tc.mesgs)
+			if d != tc.timestamp {
+				t.Fatalf("expected: %d, got: %d", tc.timestamp, d)
+			}
+		})
+	}
+}
+
+func TestGetLastTimestamp(t *testing.T) {
+	now := time.Now()
+	tt := []struct {
+		name      string
+		mesgs     []proto.Message
+		timestamp uint32
+	}{
+		{
+			name: "happy flow",
+			mesgs: []proto.Message{
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(uint32(datetime.ToUint32(now))),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(1)),
+				}},
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(uint32(datetime.ToUint32(now) + 1)),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(2)),
+				}},
+				{Num: mesgnum.Session, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Session, fieldnum.SessionTimestamp).WithValue(uint32(datetime.ToUint32(now) + 2)),
+				}},
+			},
+			timestamp: datetime.ToUint32(now) + 2,
+		},
+		{
+			name: "return basetype.Uint32Invalid",
+			mesgs: []proto.Message{
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(1)),
+				}},
+				{Num: mesgnum.Record, Fields: []proto.Field{
+					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(2)),
+				}},
+			},
+			timestamp: basetype.Uint32Invalid,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			d := getLastTimestamp(tc.mesgs)
+			if d != tc.timestamp {
+				t.Fatalf("expected: %d, got: %d", tc.timestamp, d)
+			}
+		})
+	}
+}
+
+func TestGetTimezone(t *testing.T) {
+	now := time.Now()
+	tt := []struct {
+		name       string
+		activities []*mesgdef.Activity
+		timezone   int
+	}{
+		{
+			name: "happy flow",
+			activities: []*mesgdef.Activity{
+				mesgdef.NewActivity(nil).
+					SetTimestamp(now).
+					SetLocalTimestamp(now.Add(7 * time.Hour)),
+				mesgdef.NewActivity(nil),
+			},
+			timezone: 7,
+		},
+		{
+			name: "return basetype.Uint32Invalid",
+			activities: []*mesgdef.Activity{
+				mesgdef.NewActivity(nil),
+				mesgdef.NewActivity(nil),
+			},
+			timezone: 0,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			tz := getTimezone(tc.activities)
+			if tz != tc.timezone {
+				t.Fatalf("expected: %d, got: %d", tc.timezone, tz)
+			}
+		})
+	}
+}

--- a/cmd/fitactivity/main.go
+++ b/cmd/fitactivity/main.go
@@ -5,222 +5,742 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/muktihari/fit/cmd/fitactivity/combiner"
 	"github.com/muktihari/fit/cmd/fitactivity/concealer"
 	"github.com/muktihari/fit/cmd/fitactivity/opener"
+	"github.com/muktihari/fit/cmd/fitactivity/reducer"
 	"github.com/muktihari/fit/decoder"
 	"github.com/muktihari/fit/encoder"
+	"github.com/muktihari/fit/profile"
 	"github.com/muktihari/fit/proto"
 )
 
-var version = "dev"
+type errorString string
 
-type options struct {
-	combineOutputPath string
+func (e errorString) Error() string { return string(e) }
 
-	// list of commands
-	concealStart uint32
-	concealEnd   uint32
-	combine      bool
+const (
+	errBadArgument       = errorString("bad argument")
+	errPrintUsageAndExit = errorString("print usage and exit")
+)
 
-	encoderHeaderOption encoder.Option
-}
+// NOTE: This variables can be changed during build using -ldflags.
+// e.g. go build -ldflags="-X 'main.version=$(git describe --tags)'" -o fitactivity main.go
+var (
+	cli     = "fitactivity"
+	version = "dev"
+)
+
+const (
+	combineDesc = "combine multiple activities into one continous activity"
+	concealDesc = "conceal first or last x meters GPS positions for privacy"
+	reduceDesc  = `reduce the size of record messages, available methods:
+             1. Based on GPS points using RDP [Ramer-Douglas-Peucker]
+             2. Based on distance interval in meters
+             3. Based on time interval in seconds`
+
+	perm = 0o644
+)
+
+var mainUsage = `About:
+  ` + cli + ` is a program to handle FIT files based on provided command.
+	
+Usage:
+  ` + cli + ` [command] 
+
+Available Commands:
+  combine    ` + combineDesc + `
+  conceal    ` + concealDesc + `
+  reduce     ` + reduceDesc + `
+
+Flags:
+  -h, --help       Print help
+  -v, --version    Print version
+`
 
 func main() {
-	var opts options
-	outputPathHelpText := "[option] Output of combined files: result.fit"
-	flag.StringVar(&opts.combineOutputPath, "o", "", outputPathHelpText)
-	flag.StringVar(&opts.combineOutputPath, "out", "", outputPathHelpText)
+	fs := flag.NewFlagSet("main", flag.ExitOnError)
+	fs.Usage = func() { fmt.Fprint(os.Stderr, mainUsage) }
 
-	flag.BoolVar(&opts.combine, "combine", false, "[command] Combine multiple fit activity files into one continoues fit activity. Example:\n"+
-		" 1. fitactivity --combine -o result.fit part1.fit part2.fit\n"+
-		" 2. fitactivity --combine part1.fit part2.fit > result.fit",
-	)
+	var v bool
+	fs.BoolVar(&v, "v", false, "Print version")
+	fs.BoolVar(&v, "version", false, "Print version")
+	fs.Parse(os.Args[1:])
 
-	var flagConcealStart uint
-	flag.UintVar(&flagConcealStart, "conceal-start", 0, "[command] Amount of distance to conceal from the start (in meters). Example:\n"+
-		" 1. fitactivity --conceal-start 1000 part1.fit part2.fit\n"+
-		" 2. fitactivity --conceal-start 1000 --conceal-end 1000 part1.fit part2.fit\n"+
-		" 3. fitactivity --combine --conceal-start 1000 part1.fit part2.fit > result.fit",
-	)
-
-	var flagConcealEnd uint
-	flag.UintVar(&flagConcealEnd, "conceal-end", 0, "[command] Amount of distance to conceal from the end (in meters). Example:\n"+
-		" 1. fitactivity --conceal-end 1000 part1.fit part2.fit\n"+
-		" 2. fitactivity --combine --conceal-end 1000 part1.fit part2.fit > result.fit\n"+
-		" 3. fitactivity --combine --conceal-start 1000 --conceal-end 1000 part1.fit part2.fit > result.fit",
-	)
-
-	var flagInterleave uint
-	flag.UintVar(&flagInterleave, "interleave", 15, "[option] Max interleave allowed to reduce writing the same message definition on encoding process. Valid value: 0-15. Example:\n"+
-		" 1. fitactivity --combine -o result.fit --interleave 0 part1.fit part2.fit\n *",
-	)
-
-	var flagCompress bool
-	flag.BoolVar(&flagCompress, "compress", false, "[option] Compress timestamp in message header. Save 7 bytes per message up for every message written in 31s interval. Example:\n"+
-		" 1. fitactivity --combine -o result.fit --compress part1.fit part2.fit",
-	)
-
-	var flagVersion bool
-	flagVersionHelpText := "[command] Show version"
-	flag.BoolVar(&flagVersion, "v", false, flagVersionHelpText)
-	flag.BoolVar(&flagVersion, "version", false, flagVersionHelpText)
-
-	flag.Parse()
-
-	if flagVersion {
+	if v {
 		fmt.Println(version)
 		return
 	}
 
-	if flagConcealStart > math.MaxUint32 {
-		fatalf("max conceal-start value is %d.", math.MaxUint32)
-	}
-	if flagConcealEnd > math.MaxUint32 {
-		fatalf("max conceal-end value is %d.", math.MaxUint32)
-	}
-	opts.concealStart = uint32(flagConcealStart)
-	opts.concealEnd = uint32(flagConcealEnd)
-
-	if !opts.combine && opts.concealStart == 0 && opts.concealEnd == 0 {
-		fatalf("no options selected. see --help\n")
-	}
-
-	if flagInterleave > 15 {
-		fatalf("max message definition interleave is 15, got: %d.", flagInterleave)
-	}
-
-	if flagCompress {
-		opts.encoderHeaderOption = encoder.WithCompressedTimestampHeader()
-	} else {
-		opts.encoderHeaderOption = encoder.WithNormalHeader(byte(flagInterleave))
-	}
-
-	// Convert meters into record's distance scaled value (scale: 100, offset: 0).
-	opts.concealStart, opts.concealEnd = opts.concealStart*100, opts.concealEnd*100
-
-	paths := flag.Args()
-
-	if opts.combine { // Combine (and Conceal Position if specified)
-		if err := combineAndConcealPosition(paths, &opts); err != nil {
-			fatalf("could not combine: %v\n", err)
-		}
+	args := fs.Args()
+	if len(args) == 0 {
+		fs.Usage()
 		return
 	}
 
-	// Conceal Position Only
-	for _, path := range paths {
-		if err := openAndConcealPosition(path, &opts); err != nil {
-			fatalf("could not openAndConcealPosition [path %q]: %v\n", path, err)
-		}
+	var begin = time.Now()
+
+	var command = args[0]
+	switch command {
+	case "combine":
+		fs := flag.NewFlagSet(command, flag.ExitOnError)
+		printerror(fs, command, combine(fs, args[1:]))
+	case "conceal":
+		fs := flag.NewFlagSet(command, flag.ExitOnError)
+		printerror(fs, command, conceal(fs, args[1:]))
+	case "reduce":
+		fs := flag.NewFlagSet(command, flag.ExitOnError)
+		printerror(fs, command, reduce(fs, args[1:]))
+	default:
+		printerror(fs, command, fmt.Errorf("command provided but not defined: %s", command))
 	}
+
+	fmt.Fprintf(os.Stderr, "~ DONE! in %s\n", time.Since(begin))
 }
 
-func combineAndConcealPosition(paths []string, opts *options) error {
-	fits, err := opener.Open(paths...)
-	if err != nil {
-		return fmt.Errorf("could not bulk open: %v", err)
+// printerror prints error and exit if err != nil.
+func printerror(fs *flag.FlagSet, command string, err error) {
+	if err == nil {
+		return
 	}
-
-	fit, err := combiner.Combine(fits...)
-	if err != nil {
-		return fmt.Errorf("could not combine: %v", err)
+	if errors.Is(err, errBadArgument) {
+		fmt.Fprintln(os.Stderr, strings.TrimSuffix(err.Error(), ": "+errBadArgument.Error()))
+		fs.Usage()
+	} else if errors.Is(err, errPrintUsageAndExit) {
+		fs.Usage()
+	} else {
+		fmt.Fprintf(os.Stderr, "~ %s: return with error: %v\n", command, err)
 	}
+	os.Exit(1)
+}
 
-	protocolVersion := latestProtocolVersion(fits)
+const (
+	defaultInterleave     = 15
+	interleaveDesc        = "max interleave for message definition [valid: 0-15, default: 15]"
+	compressDesc          = "compress timestamp into message header [default: false; this overrides interleave]"
+	combineOutDesc        = "combine output file"
+	concealFirstDesc      = "conceal distance: first x meters"
+	concealLastDesc       = "conceal distance: last x meters"
+	reduceByPointsRdpDesc = "reduce method: RDP [Ramer-Douglas-Peucker] based on GPS points, epsilon > 0"
+	reduceByDistanceDesc  = "reduce method: distance interval in meters"
+	reduceByTimeDesc      = "reduce method: time interval in seconds"
+)
 
-	if err := concealer.ConcealPosition(fit, opts.concealStart, opts.concealEnd); err != nil {
-		return fmt.Errorf("could not conceal: %v", err)
-	}
+var combineUsage = `About:
+  ` + combineDesc + `
 
-	concealer.ConcealLapStartAndEndPosition(fit)
+Usage:
+  ` + cli + ` combine [subcommands] [flags] [files]
 
-	var fout = os.Stdout // default output to stdout if not specified.
-	if opts.combineOutputPath != "" {
-		fout, err = os.OpenFile(opts.combineOutputPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o666)
-		if err != nil {
-			return fmt.Errorf("could not open output file: %v", err)
+Available Subcommands (optional):
+  conceal    ` + concealDesc + `
+  reduce     ` + reduceDesc + `
+
+Flags:
+  (required):
+  -o, --out  string    ` + combineOutDesc + `
+
+  (optional):
+  -i, --interleave  uint8    ` + interleaveDesc + `
+  -c, --compress    bool     ` + compressDesc + `
+
+Subcommand Flags (only if subcommand is provided):
+  conceal: (select at least one)
+   --first  uint32    ` + concealFirstDesc + `
+   --last   uint32    ` + concealLastDesc + `
+
+  reduce: (select only one)
+   --rdp       float64    ` + reduceByPointsRdpDesc + `
+   --distance  float64    ` + reduceByDistanceDesc + `
+   --time      uint32     ` + reduceByTimeDesc + `
+
+Examples:
+  ` + cli + ` combine -o result.fit part1.fit part2.fit
+  ` + cli + ` combine reduce -o result.fit --rdp 0.0001 part1.fit part2.fit
+  ` + cli + ` combine conceal -o result.fit --first 1000 part1.fit part2.fit
+  ` + cli + ` combine conceal reduce -o result.fit --last 1000 --time 5 part1.fit part2.fit
+`
+
+func combine(fs *flag.FlagSet, args []string) (err error) {
+	fs.Usage = func() { fmt.Fprint(os.Stderr, combineUsage) }
+
+	const subcommandConceal = "conceal"
+	const subcommandReduce = "reduce"
+
+	subcommands := make([]string, 0, 2)
+	var i int
+loop:
+	for i = range args {
+		switch args[i] { // Subcommands
+		case subcommandConceal:
+			subcommands = append(subcommands, subcommandConceal)
+		case subcommandReduce:
+			subcommands = append(subcommands, subcommandReduce)
+		default:
+			if !strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("subcommand provided but not defined: %s: %w", args[i], errBadArgument)
+			}
+			break loop
 		}
-		defer fout.Close()
 	}
 
-	enc := encoder.New(fout,
-		encoder.WithProtocolVersion(protocolVersion),
-		opts.encoderHeaderOption,
-	)
+	var out string
+	fs.StringVar(&out, "o", "", combineOutDesc)
+	fs.StringVar(&out, "out", "", combineOutDesc)
 
-	if err := enc.Encode(fit); err != nil {
-		return fmt.Errorf("could not encode: %v", err)
+	var interleave uint
+	fs.UintVar(&interleave, "i", defaultInterleave, interleaveDesc)
+	fs.UintVar(&interleave, "interleave", defaultInterleave, interleaveDesc)
+
+	var compress bool
+	fs.BoolVar(&compress, "c", false, compressDesc)
+	fs.BoolVar(&compress, "compress", false, compressDesc)
+
+	const flagNameRdp = "rdp"
+	var reduceByRdp float64
+	fs.Float64Var(&reduceByRdp, flagNameRdp, 0, reduceByPointsRdpDesc)
+
+	const flagNameDistance = "distance"
+	var reduceByDistance float64
+	fs.Float64Var(&reduceByDistance, flagNameDistance, 0, reduceByDistanceDesc)
+
+	const flagNameTime = "time"
+	var reduceByTime uint
+	fs.UintVar(&reduceByTime, flagNameTime, 0, reduceByTimeDesc)
+
+	const flagNameFirst = "first"
+	var concealFirst uint
+	fs.UintVar(&concealFirst, flagNameFirst, 0, concealFirstDesc)
+
+	const flagNameLast = "last"
+	var concealLast uint
+	fs.UintVar(&concealLast, flagNameLast, 0, concealLastDesc)
+
+	fs.Parse(args[i:])
+
+	var flagSpecified bool
+	fs.Visit(func(f *flag.Flag) { flagSpecified = true })
+	if !flagSpecified {
+		return errPrintUsageAndExit
+	}
+
+	if out == "" {
+		return fmt.Errorf("flag is required but not provided: -o or --out: %w", errBadArgument)
+	}
+
+	if interleave > 15 {
+		return fmt.Errorf("interleave: valid value is between 0 to 15, got: %d: %w", interleave, errBadArgument)
+	}
+
+	if subcommandProvided(subcommands, subcommandReduce) {
+		if count := countSelectedFlag(fs, flagNameRdp, flagNameDistance, flagNameTime); count == 0 || count > 1 {
+			return fmt.Errorf("reduce: please select (only) one method: %w", errBadArgument)
+		}
+		if reduceByRdp == 0 && reduceByDistance == 0 && reduceByTime == 0 {
+			return fmt.Errorf("reduce: input value could not be zero: %w", errBadArgument)
+		}
+	}
+	if subcommandProvided(subcommands, subcommandConceal) && countSelectedFlag(fs, flagNameFirst, flagNameLast) == 0 {
+		return fmt.Errorf("conceal: no distance is provided: %w", errBadArgument)
+	}
+
+	files := fs.Args()
+	if len(files) < 2 {
+		return fmt.Errorf("provide at least 2 valid FIT files to combine: %w", errBadArgument)
+	}
+
+	if err = expectdotfit(files); err != nil {
+		return err
+	}
+
+	var fits []*proto.FIT
+	verboserun(fmt.Sprintf("Decoding %d files", len(files)), func() {
+		fits, err = opener.Open(files)
+	})
+	if err != nil {
+		return err
+	}
+
+	var fit *proto.FIT
+	verboserun(fmt.Sprintf("Combining %d files", len(files)), func() {
+		fit, err = combiner.Combine(fits)
+	})
+	if err != nil {
+		return err
+	}
+
+	fit.FileHeader.ProtocolVersion = byte(latestProtocolVersion(fits))
+	fit.FileHeader.ProfileVersion = latestProfileVersion(fits)
+
+	for _, subcommand := range subcommands {
+		switch subcommand {
+		case subcommandConceal:
+			msg := fmt.Sprintf("Concealing [start: %sm, end: %sm]",
+				formatThousand(int(concealFirst)), formatThousand(int(concealLast)))
+
+			verboserun(msg, func() {
+				err = concealer.Conceal(fit, uint32(concealFirst)*100, uint32(concealLast)*100)
+			})
+			if err != nil {
+				return err
+			}
+		case subcommandReduce:
+			var option reducer.Option
+
+			var param string
+			switch {
+			case reduceByRdp > 0:
+				option = reducer.WithRDP(reduceByRdp)
+				param = fmt.Sprintf("rdp: %g ε", reduceByRdp)
+			case reduceByDistance > 0:
+				option = reducer.WithDistanceInterval(reduceByDistance)
+				param = fmt.Sprintf("distance: %.2fm", reduceByDistance)
+			case reduceByTime > 0:
+				option = reducer.WithTimeInterval(uint32(reduceByTime))
+				param = fmt.Sprintf("time: %ds", reduceByTime)
+			}
+			prevLen := len(fit.Messages)
+
+			msg := fmt.Sprintf("Reducing [%s]", param)
+			verboserun(msg, func() {
+				err = reducer.Reduce(fit, option)
+			})
+
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(os.Stderr, "  # messages are reduced from %s into %s\n",
+				formatThousand(prevLen), formatThousand(len(fit.Messages)))
+		}
+	}
+
+	headerInfo := fmt.Sprintf("interleave: %d", interleave)
+	headerOption := encoder.WithNormalHeader(byte(interleave))
+	if compress {
+		headerInfo = "compress"
+		headerOption = encoder.WithCompressedTimestampHeader()
+	}
+
+	msg := fmt.Sprintf("Encoding [%s]", headerInfo)
+	verboserun(msg, func() {
+		var f *os.File
+		f, err = os.OpenFile(out, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
+		if err != nil {
+			return
+		}
+		defer f.Close()
+		enc := encoder.New(f, headerOption)
+		err = enc.Encode(fit)
+	})
+
+	return err
+}
+
+var concealUsage = `About:
+  ` + concealDesc + `
+
+Usage:
+  ` + cli + ` conceal [flags] [files]
+
+Flags: 
+  (select at least one):
+    --start         uint32     ` + concealFirstDesc + `
+    --end           uint32     ` + concealLastDesc + `
+
+  (optional):
+  -i, --interleave  uint8      ` + interleaveDesc + `
+  -c, --compress    bool       ` + compressDesc + `
+
+Examples:
+  ` + cli + ` conceal --first 1000 a.fit b.fit
+  ` + cli + ` conceal --first 1000 --last 1000 a.fit b.fit
+`
+
+func conceal(fs *flag.FlagSet, args []string) (err error) {
+	fs.Usage = func() { fmt.Fprint(os.Stderr, concealUsage) }
+
+	var interleave int
+	fs.IntVar(&interleave, "i", defaultInterleave, interleaveDesc)
+	fs.IntVar(&interleave, "interleave", defaultInterleave, interleaveDesc)
+
+	var compress bool
+	fs.BoolVar(&compress, "c", false, compressDesc)
+	fs.BoolVar(&compress, "compress", false, compressDesc)
+
+	const flagNameFirst = "first"
+	var first uint
+	fs.UintVar(&first, flagNameFirst, 0, concealFirstDesc)
+
+	const flagNameLast = "last"
+	var last uint
+	fs.UintVar(&last, flagNameLast, 0, concealLastDesc)
+
+	fs.Parse(args)
+
+	var flagSpecified bool
+	fs.Visit(func(f *flag.Flag) { flagSpecified = true })
+	if !flagSpecified {
+		return errPrintUsageAndExit
+	}
+
+	if first == 0 && last == 0 {
+		return fmt.Errorf("conceal: no distance is specified: %w", errBadArgument)
+	}
+
+	if interleave < 0 || interleave > 15 {
+		return fmt.Errorf("interleave: valid value is between 0 to 15, got: %d: %w", interleave, errBadArgument)
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		return fmt.Errorf("provide at least 1 FIT files to conceal: %w", errBadArgument)
+	}
+
+	if err := expectdotfit(files); err != nil {
+		return err
+	}
+
+	headerInfo := fmt.Sprintf("interleave: %d", interleave)
+	headerOption := encoder.WithNormalHeader(byte(interleave))
+	if compress {
+		headerInfo = "compress"
+		headerOption = encoder.WithCompressedTimestampHeader()
+	}
+
+	fmt.Fprintf(os.Stderr, "- Concealing %d file(s) [first: %s m; last: %s m]\n",
+		len(files), formatThousand(int(first)), formatThousand(int(last)))
+
+	var dec = decoder.New(nil)
+	var enc = encoder.New(nil)
+	for i, path := range files {
+		var fits []*proto.FIT
+		verboserun(fmt.Sprintf("[%d] Decoding", i), func() {
+			var f *os.File
+			f, err = os.Open(path)
+			if err != nil {
+				return
+			}
+			defer f.Close()
+
+			dec.Reset(f)
+
+			var fit *proto.FIT
+			for dec.Next() {
+				fit, err = dec.Decode()
+				if err != nil {
+					return
+				}
+				fits = append(fits, fit)
+			}
+		})
+		if err != nil {
+			return err
+		}
+
+		verboserun(fmt.Sprintf("[%d] Concealing", i), func() {
+			for _, fit := range fits {
+				if err = concealer.Conceal(fit, uint32(first)*100, uint32(last)*100); err != nil {
+					return
+				}
+			}
+		})
+		if err != nil {
+			return err
+		}
+
+		verboserun(fmt.Sprintf("[%d] Encoding [%s]", i, headerInfo), func() {
+			name := fmt.Sprintf("%s_concealed_%d_%d.fit",
+				strings.TrimSuffix(path, filepath.Ext(path)), first, last)
+
+			var f *os.File
+			f, err = os.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
+			if err != nil {
+				return
+			}
+			defer f.Close()
+
+			enc.Reset(f, headerOption)
+
+			for _, fit := range fits {
+				if err = enc.Encode(fit); err != nil {
+					return
+				}
+			}
+		})
+		if err != nil {
+			return fmt.Errorf("could not conceal %q: %v", path, err)
+		}
+	}
+	return nil
+}
+
+func trimSpaceAddPaddingPerLine(s string, paddingLeft int) string {
+	var b strings.Builder
+	for _, v := range strings.Split(s, "\n") {
+		b.WriteString(strings.Repeat(" ", paddingLeft))
+		b.WriteString(strings.TrimSpace(v))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+var reduceUsage = `About:
+` + trimSpaceAddPaddingPerLine(reduceDesc, 2) + `
+
+Usage:
+  ` + cli + ` reduce [flags] [files]
+
+Flags:
+  (select only one):
+    --rdp           float64    ` + reduceByPointsRdpDesc + `
+    --distance      float64    ` + reduceByDistanceDesc + `
+    --time          uint32     ` + reduceByTimeDesc + `
+
+  (optional):
+  -i, --interleave  uint8      ` + interleaveDesc + `
+  -c, --compress    bool       ` + compressDesc + `
+
+
+Examples:
+  ` + cli + ` reduce --rdp 0.0001 a.fit b.fit
+  ` + cli + ` reduce --distance 0.5 a.fit b.fit
+  ` + cli + ` reduce --time 5 a.fit b.fit
+`
+
+func reduce(fs *flag.FlagSet, args []string) (err error) {
+	fs.Usage = func() { fmt.Fprint(os.Stderr, reduceUsage) }
+
+	var interleave int
+	fs.IntVar(&interleave, "i", defaultInterleave, interleaveDesc)
+	fs.IntVar(&interleave, "interleave", defaultInterleave, interleaveDesc)
+
+	var compress bool
+	fs.BoolVar(&compress, "c", false, compressDesc)
+	fs.BoolVar(&compress, "compress", false, compressDesc)
+
+	const flagNameRdp = "rdp"
+	var reduceByRdp float64
+	fs.Float64Var(&reduceByRdp, flagNameRdp, 0, reduceByPointsRdpDesc)
+
+	const flagNameDistance = "distance"
+	var reduceByDistance float64
+	fs.Float64Var(&reduceByDistance, flagNameDistance, 0, reduceByDistanceDesc)
+
+	const flagNameTime = "time"
+	var reduceByTime uint
+	fs.UintVar(&reduceByTime, flagNameTime, 0, reduceByTimeDesc)
+
+	fs.Parse(args)
+
+	var flagSpecified bool
+	fs.Visit(func(f *flag.Flag) { flagSpecified = true })
+	if !flagSpecified {
+		return errPrintUsageAndExit
+	}
+
+	if count := countSelectedFlag(fs, flagNameRdp, flagNameDistance, flagNameTime); count == 0 || count > 1 {
+		return fmt.Errorf("please select (only) one method: %w", errBadArgument)
+	}
+
+	if reduceByRdp == 0 && reduceByDistance == 0 && reduceByTime == 0 {
+		return fmt.Errorf("input value could not be zero: %w", errBadArgument)
+	}
+
+	if interleave < 0 || interleave > 15 {
+		return fmt.Errorf("interleave: valid value is between 0 to 15, got: %d: %w", interleave, errBadArgument)
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		return fmt.Errorf("provide at least 1 FIT files to conceal: %w", errBadArgument)
+	}
+
+	if err = expectdotfit(files); err != nil {
+		return err
+	}
+
+	var option reducer.Option
+	var nameSuffix string
+	var methodInfo string
+	switch {
+	case reduceByRdp > 0:
+		option = reducer.WithRDP(reduceByRdp)
+		methodInfo = fmt.Sprintf("rdp ε: %g", reduceByRdp)
+		nameSuffix = fmt.Sprintf("rdp_epsilon_%g", reduceByRdp)
+	case reduceByDistance > 0:
+		option = reducer.WithDistanceInterval(reduceByDistance)
+		methodInfo = fmt.Sprintf("distance interval: %sm", formatThousand(int(reduceByDistance)))
+		nameSuffix = fmt.Sprintf("distance_interval_%.2fm", reduceByDistance)
+	case reduceByTime > 0:
+		option = reducer.WithTimeInterval(uint32(reduceByTime))
+		methodInfo = fmt.Sprintf("time interval: %ss", formatThousand(int(reduceByTime)))
+		nameSuffix = fmt.Sprintf("time_interval_%ds", reduceByTime)
+	}
+
+	headerInfo := fmt.Sprintf("interleave: %d", interleave)
+	headerOption := encoder.WithNormalHeader(byte(interleave))
+	if compress {
+		headerInfo = "compress"
+		headerOption = encoder.WithCompressedTimestampHeader()
+	}
+
+	fmt.Fprintf(os.Stderr, "- Reducing %d file(s) [%s]\n",
+		len(files), methodInfo)
+
+	var dec = decoder.New(nil)
+	var enc = encoder.New(nil)
+	for i, path := range files {
+		var fits []*proto.FIT
+		verboserun(fmt.Sprintf("[%d] Decoding", i), func() {
+			var f *os.File
+			f, err = os.Open(path)
+			if err != nil {
+				return
+			}
+			defer f.Close()
+
+			dec.Reset(f)
+
+			var fit *proto.FIT
+			for dec.Next() {
+				fit, err = dec.Decode()
+				if err != nil {
+					return
+				}
+				fits = append(fits, fit)
+			}
+		})
+		if err != nil {
+			return err
+		}
+
+		var msgs []string
+		verboserun(fmt.Sprintf("[%d] Reducing", i), func() {
+			for _, fit := range fits {
+				prevLen := len(fit.Messages)
+				if err = reducer.Reduce(fit, option); err != nil {
+					return
+				}
+				msgs = append(msgs, fmt.Sprintf("# messages are reduced from %s into %s",
+					formatThousand(prevLen), formatThousand(len(fit.Messages))))
+			}
+		})
+		if err != nil {
+			return err
+		}
+		for _, msg := range msgs {
+			fmt.Fprintf(os.Stderr, "      %s\n", msg)
+		}
+
+		verboserun(fmt.Sprintf("[%d] Encoding [%s]", i, headerInfo), func() {
+			name := fmt.Sprintf("%s_reduced_%s.fit",
+				strings.TrimSuffix(path, filepath.Ext(path)), nameSuffix)
+
+			var f *os.File
+			f, err = os.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
+			if err != nil {
+				return
+			}
+			defer f.Close()
+
+			enc.Reset(f, headerOption)
+
+			for _, fit := range fits {
+				if err = enc.Encode(fit); err != nil {
+					return
+				}
+			}
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func latestProtocolVersion(fits []*proto.FIT) proto.Version {
+// verboserun wraps and runs fn with printing msg and elapsed time of the running process.
+func verboserun(msg string, fn func()) {
+	begin := time.Now()
+	fmt.Fprintf(os.Stderr, "- %-52s ", msg)
+	fn()
+	fmt.Fprintf(os.Stderr, "[took: %s]\n", time.Since(begin))
+}
+
+func countSelectedFlag(fs *flag.FlagSet, flagNames ...string) (count int) {
+	for _, name := range flagNames {
+		fs.Visit(func(f *flag.Flag) {
+			if f.Name == name {
+				count++
+			}
+		})
+	}
+	return
+}
+
+func subcommandProvided(subcommands []string, target string) bool {
+	for _, subcommand := range subcommands {
+		if target == subcommand {
+			return true
+		}
+	}
+	return false
+}
+
+func expectdotfit(paths []string) error {
+	for _, path := range paths {
+		ext := filepath.Ext(path)
+		if strings.ToLower(ext) != ".fit" {
+			return fmt.Errorf("%q expected file extension: .fit, got: %s: %w", path, ext, errBadArgument)
+		}
+	}
+	return nil
+}
+
+func formatThousand(v int) string {
+	s := strconv.Itoa(v)
+	var result strings.Builder
+
+	n := len(s)
+	for i, digit := range s {
+		if (n-i)%3 == 0 && i != 0 {
+			result.WriteRune('.')
+		}
+		result.WriteRune(digit)
+	}
+
+	return result.String()
+}
+
+func latestProtocolVersion(fits []*proto.FIT) byte {
 	var version = byte(proto.V1)
 	for i := range fits {
 		if fits[i].FileHeader.ProtocolVersion > version {
 			version = fits[i].FileHeader.ProtocolVersion
 		}
 	}
-	return proto.Version(version)
+	return byte(proto.Version(version))
 }
 
-func openAndConcealPosition(path string, opts *options) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return fmt.Errorf("could not open file: %v", err)
-	}
-	defer f.Close()
-
-	var fits []*proto.FIT
-	dec := decoder.New(f, decoder.WithNoComponentExpansion())
-
-	for dec.Next() {
-		fit, err := dec.Decode()
-		if err != nil {
-			return fmt.Errorf("could not decode: %v", err)
-		}
-		fits = append(fits, fit)
-	}
-
+func latestProfileVersion(fits []*proto.FIT) uint16 {
+	var version uint16
 	for i := range fits {
-		if err := concealer.ConcealPosition(fits[i], opts.concealStart, opts.concealEnd); err != nil {
-			return fmt.Errorf("could not conceal fits[%d of %d]: %v", i+1, len(fits), err)
-		}
-		concealer.ConcealLapStartAndEndPosition(fits[i])
-	}
-
-	ext := filepath.Ext(path)
-	name := fmt.Sprintf("%s_concealed_%d_%d", strings.TrimSuffix(path, ext), opts.concealStart, opts.concealEnd)
-
-	fout, err := os.OpenFile(name+ext, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o666)
-	if err != nil {
-		return fmt.Errorf("could not open output file: %v", err)
-	}
-	defer fout.Close()
-
-	enc := encoder.New(fout,
-		opts.encoderHeaderOption,
-	)
-
-	for _, fit := range fits {
-		if err := enc.Encode(fit); err != nil {
-			return fmt.Errorf("could not encode: %v", err)
+		if fits[i].FileHeader.ProfileVersion > version {
+			version = fits[i].FileHeader.ProfileVersion
 		}
 	}
-
-	return nil
-}
-
-func fatalf(format string, args ...any) {
-	fmt.Fprintf(os.Stderr, format, args...)
-	os.Exit(1)
+	if version == 0 {
+		return profile.Version
+	}
+	return version
 }

--- a/cmd/fitactivity/opener/opener.go
+++ b/cmd/fitactivity/opener/opener.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Open opens all given paths concurrently.
-func Open(paths ...string) ([]*proto.FIT, error) {
+func Open(paths []string) ([]*proto.FIT, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -59,7 +59,7 @@ func worker(ctx context.Context, path string, resultc chan<- result, wg *sync.Wa
 	}
 	defer f.Close()
 
-	dec := decoder.New(f, decoder.WithNoComponentExpansion())
+	dec := decoder.New(f)
 
 	for dec.Next() {
 		fileId, err := dec.PeekFileId()

--- a/cmd/fitactivity/reducer/reducer.go
+++ b/cmd/fitactivity/reducer/reducer.go
@@ -1,0 +1,258 @@
+// Copyright 2024 The FIT SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package reducer
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/muktihari/carto/rdp"
+	"github.com/muktihari/fit/kit/semicircles"
+	"github.com/muktihari/fit/profile/basetype"
+	"github.com/muktihari/fit/profile/untyped/fieldnum"
+	"github.com/muktihari/fit/profile/untyped/mesgnum"
+	"github.com/muktihari/fit/proto"
+)
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
+const (
+	errBadArgument = errorString("bad arguments")
+)
+
+type method byte
+
+const (
+	methodUnknown method = iota
+	methodRDP
+	methodDistanceInterval
+	methodTimeInterval
+)
+
+func (m method) String() string {
+	switch m {
+	case methodRDP:
+		return "method_rdp"
+	case methodDistanceInterval:
+		return "method_distance"
+	case methodTimeInterval:
+		return "method_time"
+	default:
+		return "unknown(" + strconv.Itoa(int(m)) + ")"
+	}
+}
+
+type options struct {
+	method     method  // reduce method
+	rdpEpsilon float64 // tolerance should be > 0
+	interval   uint32  // meters when by distance, seconds when by time.
+}
+
+// Options is reducer options.
+type Option func(*options)
+
+// WithRDP directs Reduce to use Ramer-Douglas-Peucker algorithm to simplify by GPS points.
+func WithRDP(epsilon float64) Option {
+	return func(o *options) {
+		o.method = methodRDP
+		o.rdpEpsilon = epsilon
+	}
+}
+
+// WithDistanceInterval directs Reduce to by specific distance interval.
+func WithDistanceInterval(interval float64) Option {
+	return func(o *options) {
+		o.method = methodDistanceInterval
+		o.interval = uint32(interval * 100)
+	}
+}
+
+// WithTimeInterval directs Reduce to by specific time interval.
+func WithTimeInterval(interval uint32) Option {
+	return func(o *options) {
+		o.method = methodTimeInterval
+		o.interval = interval
+	}
+}
+
+// Reduce reduces message size by simplifying a curve of points using Ramer-Douglas-Peucker
+// algorithm to a similar curve with fewer points, then only keep messages having those points.
+func Reduce(fit *proto.FIT, opts ...Option) error {
+	var o options
+	for i := range opts {
+		opts[i](&o)
+	}
+
+	switch o.method {
+	case methodRDP:
+		if o.rdpEpsilon == 0 {
+			return fmt.Errorf("epsilon should be > 0, got: %f: %v", o.rdpEpsilon, errBadArgument)
+		}
+		return reduceByRDP(fit, o.rdpEpsilon)
+	case methodDistanceInterval:
+		if o.interval == 0 {
+			return fmt.Errorf("interval should be > 0, got: %d: %v", o.interval, errBadArgument)
+		}
+		return reduceByDistanceInterval(fit, o.interval)
+	case methodTimeInterval:
+		if o.interval == 0 {
+			return fmt.Errorf("interval should be > 0, got: %d: %v", o.interval, errBadArgument)
+		}
+		return reduceByTimeInterval(fit, o.interval)
+	default:
+		return fmt.Errorf("method is undefined: %s: %v", o.method, errBadArgument)
+	}
+}
+
+func reduceByRDP(fit *proto.FIT, epsilon float64) error {
+	epsilon /= 1000
+
+	var n int
+	for _, mesg := range fit.Messages {
+		if mesg.Num == mesgnum.Record {
+			n++
+		}
+	}
+
+	recordIndexes := make([]int, 0, n)
+	points := make([]rdp.Point, 0, n)
+	for i, mesg := range fit.Messages {
+		if mesg.Num != mesgnum.Record {
+			continue
+		}
+
+		recordIndexes = append(recordIndexes, i)
+
+		x := semicircles.ToDegrees(mesg.FieldValueByNum(fieldnum.RecordPositionLat).Int32())
+		y := semicircles.ToDegrees(mesg.FieldValueByNum(fieldnum.RecordPositionLong).Int32())
+		if math.IsNaN(x) || math.IsNaN(y) {
+			continue
+		}
+
+		points = append(points, rdp.Point{X: x, Y: y, Index: i})
+	}
+
+	if len(points) == 0 {
+		return fmt.Errorf("zero valid points")
+	}
+
+	points = rdp.Simplify(points, epsilon)
+
+	fragments := findFragments(recordIndexes, points)
+	fit.Messages = defragment(fit.Messages, fragments)
+
+	return nil
+}
+
+// findFragments finds ommited records based on RDP result and returning the index as fragments.
+func findFragments(recordIndexes []int, points []rdp.Point) (fragments []int) {
+	var i, j int
+	// Reslicing is safe as index will always move forward
+	fragments = recordIndexes[:0]
+	for i < len(recordIndexes) && j < len(points) {
+		if recordIndexes[i] < points[j].Index {
+			fragments = append(fragments, recordIndexes[i])
+			i++
+		} else if recordIndexes[i] == points[j].Index {
+			i, j = i+1, j+1
+		} else {
+			j++
+		}
+	}
+	fragments = append(fragments, recordIndexes[i:]...)
+	return fragments
+}
+
+// defragment defrags mesgs by filling every index occupied by the fragmented data.
+func defragment(mesgs []proto.Message, fragments []int) []proto.Message {
+	var i, valid, cur int
+	for i = 0; i < len(mesgs); i++ {
+		if cur == len(fragments) {
+			break
+		}
+		if i == fragments[cur] {
+			cur++
+			continue
+		}
+		if i != valid {
+			mesgs[i], mesgs[valid] = mesgs[valid], mesgs[i]
+		}
+		valid++
+	}
+	return append(mesgs[:valid], mesgs[i:]...)
+}
+
+func reduceByDistanceInterval(fit *proto.FIT, threshold uint32) error {
+	var (
+		last               uint32
+		valid              int
+		firstRecordReached bool
+	)
+	for i := 0; i < len(fit.Messages); i++ {
+		mesg := &fit.Messages[i]
+		if mesg.Num == mesgnum.Record {
+			d := mesg.FieldValueByNum(fieldnum.RecordDistance).Uint32()
+			if !firstRecordReached {
+				firstRecordReached = true
+				if d != basetype.Uint32Invalid {
+					last = d
+				}
+				valid++ // Perserve first record
+				continue
+			}
+			if d == basetype.Uint32Invalid {
+				continue
+			}
+			if d-last < threshold {
+				continue
+			}
+			last = d
+		}
+		if i != valid {
+			fit.Messages[i], fit.Messages[valid] = fit.Messages[valid], fit.Messages[i]
+		}
+		valid++
+	}
+	fit.Messages = fit.Messages[:valid]
+	return nil
+}
+
+func reduceByTimeInterval(fit *proto.FIT, threshold uint32) error {
+	var (
+		last               uint32
+		valid              int
+		firstRecordReached bool
+	)
+	for i := 0; i < len(fit.Messages); i++ {
+		mesg := &fit.Messages[i]
+		if mesg.Num == mesgnum.Record {
+			t := mesg.FieldValueByNum(fieldnum.RecordTimestamp).Uint32()
+			if !firstRecordReached {
+				firstRecordReached = true
+				if t != basetype.Uint32Invalid {
+					last = t
+				}
+				valid++ // Perserve first record
+				continue
+			}
+			if t == basetype.Uint32Invalid {
+				continue
+			}
+			if t-last < threshold {
+				continue
+			}
+			last = t
+		}
+		if i != valid {
+			fit.Messages[i], fit.Messages[valid] = fit.Messages[valid], fit.Messages[i]
+		}
+		valid++
+	}
+	fit.Messages = fit.Messages[:valid]
+	return nil
+}

--- a/cmd/fitactivity/reducer/reducer_test.go
+++ b/cmd/fitactivity/reducer/reducer_test.go
@@ -1,0 +1,133 @@
+// Copyright 2024 The FIT SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package reducer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/muktihari/carto/rdp"
+	"github.com/muktihari/fit/decoder"
+	"github.com/muktihari/fit/profile/typedef"
+	"github.com/muktihari/fit/proto"
+)
+
+var (
+	_, filename, _, _ = runtime.Caller(0)
+	cd                = filepath.Dir(filename)
+	testdata          = filepath.Join(cd, "..", "..", "..", "testdata")
+	fromGarminForums  = filepath.Join(testdata, "from_garmin_forums")
+)
+
+func TestReduceRDP(t *testing.T) {
+	f, err := os.Open(filepath.Join(fromGarminForums, "triathlon_summary_last.fit"))
+	if err != nil {
+		t.Fatalf("could not open file: %v", err)
+	}
+	defer f.Close()
+
+	dec := decoder.New(f, decoder.WithNoComponentExpansion())
+	fit, err := dec.Decode()
+	if err != nil {
+		t.Fatalf("could not decode: %v", err)
+	}
+
+	prev := float64(len(fit.Messages))
+	if err := Reduce(fit, WithRDP(0.001)); err != nil {
+		t.Fatalf("could not reduce: %v", err)
+	}
+	current := float64(len(fit.Messages))
+
+	// NOTE: Creating proper test for this requires dedication; this can be done later.
+	// For now, let's just have this guard that will fail our test when we make incorrect implementation.
+	// This threshold is just an estimation, at least we don't get lower value than this.
+	// If we do, then implementation may be incorrect.
+	const threshold = 80.0
+	if percent := current / prev * 100; percent < threshold || percent > 100 {
+		t.Fatalf("expected size after reduce >%g%% && <= 100%%, got: %g%%", threshold, percent)
+	}
+}
+
+func TestFindFragment(t *testing.T) {
+	tt := []struct {
+		name      string
+		records   []int
+		points    []rdp.Point
+		fragments []int
+	}{
+		{
+			name:      "valid middle",
+			records:   []int{1, 2, 3, 4, 5, 6},
+			points:    []rdp.Point{{Index: 2}, {Index: 4}, {Index: 5}},
+			fragments: []int{1, 3, 6},
+		},
+		{
+			name:      "valid middle-end",
+			records:   []int{1, 2, 3, 4, 5, 6},
+			points:    []rdp.Point{{Index: 2}, {Index: 3}, {Index: 6}},
+			fragments: []int{1, 4, 5},
+		},
+		{
+			name:      "valid begin-middle",
+			records:   []int{1, 2, 3, 4, 5, 6},
+			points:    []rdp.Point{{Index: 1}, {Index: 3}, {Index: 5}},
+			fragments: []int{2, 4, 6},
+		},
+		{
+			name:      "valid begin-middle-end",
+			records:   []int{2, 3, 4, 5, 6},
+			points:    []rdp.Point{{Index: 2}, {Index: 3}, {Index: 6}},
+			fragments: []int{4, 5},
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
+			fragments := findFragments(tc.records, tc.points)
+			if diff := cmp.Diff(fragments, tc.fragments); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestDefragment(t *testing.T) {
+	makeSeq := func(n uint16) []proto.Message {
+		ms := make([]proto.Message, n)
+		for i := uint16(0); i < n; i++ {
+			ms[i].Num = typedef.MesgNum(i)
+		}
+		return ms
+	}
+
+	tt := []struct {
+		name      string
+		mesgs     []proto.Message
+		fragments []int
+		expect    []proto.Message
+	}{
+		{
+			name:      "",
+			mesgs:     makeSeq(5), // 0, 1, 2, 3, 4
+			fragments: []int{0, 2},
+			expect:    []proto.Message{{Num: 1}, {Num: 3}, {Num: 4}},
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
+			mesgs := defragment(tc.mesgs, tc.fragments)
+			if diff := cmp.Diff(mesgs, tc.expect,
+				cmp.Transformer("printAsInteger", func(v typedef.MesgNum) uint16 { return uint16(v) }),
+			); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/google/go-cmp v0.6.0
+	github.com/muktihari/carto v0.1.1
 	github.com/thedatashed/xlsxreader v1.2.8
 	golang.org/x/exp v0.0.0-20240531132922-fd00a4e0eefc
 	golang.org/x/text v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/muktihari/carto v0.1.1 h1:2onp1tC7uYLBQy5WuIJyP5A6oQq3duRkcO3kf6+hzR0=
+github.com/muktihari/carto v0.1.1/go.mod h1:bqfBZ6Ghuz7wTfy90/TT0Wy9Ry9B8+XctvwhaakkScU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
### New Feature
This PR adds new feature "**reduce**" to reduce record messages in a FIT file to answer this issue #394 . 

This has 3 method to choose:
1. Based on GPS points using RDP [Ramer-Douglas-Peucker](https://w.wiki/B6U3).
2. Based on distance interval in meters
3. Based on time interval in seconds`

### Refactor
How we can interact with **fitactivity** CLI is also refactored for more structured commands (arguably easier to access and maintain). Some commands may differ, but they should be simple to follow. `cmd/fitactivity/README.md` file has been updated accordingly regarding the changes.