### PR TITLE
fix: decoder should expand component only from a valid value

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -786,6 +786,10 @@ func (d *Decoder) expandComponents(mesg *proto.Message, containingField *proto.F
 		return
 	}
 
+	if !containingField.Value.Valid(containingField.BaseType) {
+		return
+	}
+
 	bitVal, ok := bitsFromValue(containingField.Value)
 	if !ok {
 		return

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -1876,10 +1876,19 @@ func TestExpandComponents(t *testing.T) {
 			components:           factory.CreateField(mesgnum.Hr, fieldnum.HrEventTimestamp12).Components,
 			nFieldAfterExpansion: 2,
 		},
+		{
+			name: "expand components do not expand when containing field's value is invalid",
+			mesg: factory.CreateMesgOnly(mesgnum.Session).WithFields(
+				factory.CreateField(mesgnum.Session, fieldnum.SessionAvgSpeed).WithValue(uint16(basetype.Uint16Invalid)),
+			),
+			containingField:      factory.CreateField(mesgnum.Session, fieldnum.SessionAvgSpeed).WithValue(uint16(basetype.Uint16Invalid)),
+			components:           factory.CreateField(mesgnum.Session, fieldnum.SessionAvgSpeed).Components,
+			nFieldAfterExpansion: 1,
+		},
 	}
 
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
 			dec := New(nil)
 			dec.expandComponents(&tc.mesg, &tc.containingField, tc.components)
 			if len(tc.mesg.Fields) != tc.nFieldAfterExpansion {


### PR DESCRIPTION
Related issue: #397 

The background of the problem that it solves declared here: https://github.com/muktihari/fit/issues/397#issuecomment-2337086333