### PR TITLE
fix: encoder dynamic protocol version validator

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -215,7 +215,6 @@ func (e *Encoder) Reset(w io.Writer, opts ...Option) {
 	}
 
 	e.reset()
-	e.protocolValidator.SetProtocolVersion(e.options.protocolVersion)
 
 	var lruSize byte = 1
 	if e.options.headerOption == headerOptionNormal && e.options.multipleLocalMessageType > 0 {
@@ -319,6 +318,7 @@ func (e *Encoder) encodeFileHeader(header *proto.FileHeader) error {
 	} else if header.ProtocolVersion == 0 { // Default when not specified in FileHeader.
 		header.ProtocolVersion = byte(proto.V1)
 	}
+	e.protocolValidator.SetProtocolVersion(proto.Version(header.ProtocolVersion))
 
 	header.DataType = proto.DataTypeFIT
 	header.CRC = 0 // recalculated


### PR DESCRIPTION
After allowing dynamic protocol version, we didn't set the validator to validate based on the current protocol version that being used. When users use default protocol version 1 but the messages contains developer data or basetype that is not supported by version 1, the resulting file will not be correct even if maybe it can still be decoded. This PR fix that bug.