### PR TITLE
refactor: set minimal go version to v1.21

### DIFF
--- a/cmd/fitactivity/combiner/combiner.go
+++ b/cmd/fitactivity/combiner/combiner.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"time"
 
+	"slices"
+
 	"github.com/muktihari/fit/cmd/fitactivity/aggregator"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
@@ -17,7 +19,6 @@ import (
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 type errorString string

--- a/cmd/fitactivity/combiner/combiner_test.go
+++ b/cmd/fitactivity/combiner/combiner_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"slices"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
@@ -19,7 +21,6 @@ import (
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 func TestCombine(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/muktihari/carto v0.1.1
 	github.com/thedatashed/xlsxreader v1.2.8
-	golang.org/x/exp v0.0.0-20240531132922-fd00a4e0eefc
 	golang.org/x/text v0.18.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/muktihari/fit
 
-go 1.20
+go 1.21
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/thedatashed/xlsxreader v1.2.8 h1:8aGbkXIPEThQbA8KzUZqIa4v4oqFrJFKLQ36vWePI5U=
 github.com/thedatashed/xlsxreader v1.2.8/go.mod h1:wZyb/2xF1+rkZ2ujhC72tuuOWBY574QvcXHFls+5AXc=
-golang.org/x/exp v0.0.0-20240531132922-fd00a4e0eefc h1:O9NuF4s+E/PvMIy+9IUZB9znFwUIXEWSstNjek6VpVg=
-golang.org/x/exp v0.0.0-20240531132922-fd00a4e0eefc/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
 golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJ
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/muktihari/carto v0.1.1 h1:2onp1tC7uYLBQy5WuIJyP5A6oQq3duRkcO3kf6+hzR0=
@@ -19,3 +20,4 @@ golang.org/x/exp v0.0.0-20240531132922-fd00a4e0eefc/go.mod h1:XtvwrStGgqGPLc4cjQ
 golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
 golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cmd/benchfit/go.mod
+++ b/internal/cmd/benchfit/go.mod
@@ -1,6 +1,6 @@
 module benchfit
 
-go 1.20
+go 1.21
 
 require (
 	github.com/muktihari/fit v0.0.0

--- a/internal/cmd/fitgen/pkg/flagutil/flagutil.go
+++ b/internal/cmd/fitgen/pkg/flagutil/flagutil.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 func Usage() {

--- a/internal/cmd/fitgen/pkg/strutil/strutil_test.go
+++ b/internal/cmd/fitgen/pkg/strutil/strutil_test.go
@@ -5,10 +5,46 @@
 package strutil_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/muktihari/fit/internal/cmd/fitgen/pkg/strutil"
 )
+
+func BenchmarkToTitle(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = strutil.ToTitle("avg_speed")
+	}
+}
+
+func TestToTitle(t *testing.T) {
+	tt := []struct {
+		input  string
+		output string
+	}{
+		{
+			input:  "avg_speed",
+			output: "AvgSpeed",
+		},
+		{
+			input:  "avg speed",
+			output: "AvgSpeed",
+		},
+		{
+			input:  "timestamp_32k",
+			output: "Timestamp32K",
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.input), func(t *testing.T) {
+			out := strutil.ToTitle(tc.input)
+			if out != tc.output {
+				t.Fatalf("expected: %q, got: %q", tc.output, out)
+			}
+		})
+	}
+}
 
 func TestTrimRepeatedChar(t *testing.T) {
 	tt := []struct {

--- a/internal/cmd/fitgen/profile/mesgdef/builder.go
+++ b/internal/cmd/fitgen/profile/mesgdef/builder.go
@@ -12,12 +12,13 @@ import (
 	"strings"
 	"text/template"
 
+	"slices"
+
 	"github.com/muktihari/fit/internal/cmd/fitgen/generator"
 	"github.com/muktihari/fit/internal/cmd/fitgen/lookup"
 	"github.com/muktihari/fit/internal/cmd/fitgen/parser"
 	"github.com/muktihari/fit/internal/cmd/fitgen/pkg/strutil"
 	"github.com/muktihari/fit/profile/basetype"
-	"golang.org/x/exp/slices"
 )
 
 type Builder struct {

--- a/internal/cmd/fitgen/profile/untyped/fieldnum/builder.go
+++ b/internal/cmd/fitgen/profile/untyped/fieldnum/builder.go
@@ -12,12 +12,13 @@ import (
 	"strings"
 	"text/template"
 
+	"slices"
+
 	"github.com/muktihari/fit/internal/cmd/fitgen/generator"
 	"github.com/muktihari/fit/internal/cmd/fitgen/lookup"
 	"github.com/muktihari/fit/internal/cmd/fitgen/parser"
 	"github.com/muktihari/fit/internal/cmd/fitgen/pkg/strutil"
 	"github.com/muktihari/fit/internal/cmd/fitgen/shared"
-	"golang.org/x/exp/slices"
 )
 
 type Builder struct {

--- a/kit/scaleoffset/scaleoffset.go
+++ b/kit/scaleoffset/scaleoffset.go
@@ -7,11 +7,10 @@ package scaleoffset
 import (
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/constraints"
 )
 
 type Numeric interface {
-	constraints.Integer | constraints.Float
+	~int8 | ~int16 | ~int32 | ~int64 | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~float32 | ~float64
 }
 
 // Apply applies scale and offset on value.

--- a/profile/filedef/activity_test.go
+++ b/profile/filedef/activity_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"slices"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
@@ -18,7 +20,6 @@ import (
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 func sortFields(mesgs []proto.Message) {

--- a/profile/filedef/filedef.go
+++ b/profile/filedef/filedef.go
@@ -5,11 +5,12 @@
 package filedef
 
 import (
+	"slices"
+
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
-	"golang.org/x/exp/slices"
 )
 
 // File is an interface for defining common type file, any defined common file type should implement


### PR DESCRIPTION
- Set minimal Go version to **v1.21** and drop _golang.org/x/exp_ dependency as `slices` package is available in v1.21 and we can define our own _constaints_ for numeric values without depend on that package. 
- Can not drop _golang.org/x/test_ since we still don't have replacement  to make Title Case (we use this package since strings.Title has been deprecated). Unit test for strutil.ToTitle is added in case in the future we want to create our own simplified implementation, we should pass the test.