### PR TITLE
refactor!: change primitive bool to typedef.Bool

### DIFF
--- a/cmd/fitconv/fitcsv/csv_to_fit.go
+++ b/cmd/fitconv/fitcsv/csv_to_fit.go
@@ -413,11 +413,11 @@ func parseValue(strValue string, baseType basetype.BaseType, profileType profile
 	}
 
 	if profileType == profile.Bool {
-		v, err := strconv.ParseBool(strValue)
+		v, err := strconv.ParseUint(strValue, 0, 8)
 		if err != nil {
 			return value, err
 		}
-		return proto.Bool(v), nil
+		return proto.Bool(typedef.Bool(v)), nil
 	}
 
 	var scaledValue float64
@@ -545,7 +545,7 @@ func packValues(vals []proto.Value) proto.Value {
 	}
 	switch vals[0].Type() {
 	case proto.TypeBool:
-		values := make([]bool, len(vals))
+		values := make([]typedef.Bool, len(vals))
 		for i := range vals {
 			values[i] = vals[i].Bool()
 		}

--- a/cmd/fitconv/fitcsv/formatter.go
+++ b/cmd/fitconv/fitcsv/formatter.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
 
@@ -22,7 +23,7 @@ import (
 func format(val proto.Value) string {
 	switch val.Type() { // fast path
 	case proto.TypeBool:
-		return strconv.FormatBool(val.Bool())
+		return strconv.FormatUint(uint64(val.Bool()), 10)
 	case proto.TypeInt8:
 		return strconv.FormatInt(int64(val.Int8()), 10)
 	case proto.TypeUint8:
@@ -54,8 +55,8 @@ func format(val proto.Value) string {
 	case proto.TypeString:
 		return val.String()
 	case proto.TypeSliceBool:
-		return concat(val.SliceBool(), func(v bool) string {
-			return strconv.FormatBool(v)
+		return concat(val.SliceBool(), func(v typedef.Bool) string {
+			return strconv.FormatUint(uint64(v), 10)
 		})
 	case proto.TypeSliceInt8:
 		return concat(val.SliceInt8(), func(v int8) string {

--- a/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
+++ b/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
@@ -94,37 +94,29 @@ func (m *{{ .Name }}) ToMesg(options *Options) proto.Message {
 
 	arr := pool.Get().(*[poolsize]proto.Field)
 	fields := arr[:0]
-	
+
 	mesg := proto.Message{ Num: typedef.MesgNum{{ .Name }} }
-	
+
 	{{ range .Fields -}}
-		{{ if and (eq .Type "bool") (eq .FixedArraySize 0) -}} 
-		{
-			field := fac.CreateField(mesg.Num, {{ .Num }})
-			field.Value = {{ .ProtoValue }}
-			fields = append(fields, field)
-		}
+	if {{ .IsValidValue -}} {
+		{{- if eq .CanExpand true -}} if expanded := m.IsExpandedField({{ .Num }}); !expanded || (expanded && options.IncludeExpandedFields) { {{ end }}
+		field := fac.CreateField(mesg.Num, {{ .Num }})
+		{{ if gt .FixedArraySize 0 -}}
+		{{- /* DO NOT reslice directly from the struct (e.g. m.Velocity[:]), otherwise, we will keep referencing
+			the struct since we promote the array from the same memory block as the struct. We must copy the array
+			to local variable, so it will be promoted instead (we only need the local variable to escape to the heap),
+			only then the struct can be garbage-collected on next GC's cycle. */ -}}
+		copied := m.{{ .Name }}
+		field.Value = {{ stringReplace .ProtoValue (printf "m.%s" .Name) "copied[:]" -1 }}
 		{{ else -}}
-		if {{ .IsValidValue -}} {
-			{{- if eq .CanExpand true -}} if expanded := m.IsExpandedField({{ .Num }}); !expanded || (expanded && options.IncludeExpandedFields) { {{ end }}
-			field := fac.CreateField(mesg.Num, {{ .Num }})
-			{{ if gt .FixedArraySize 0 -}}
-			{{- /* DO NOT reslice directly from the struct (e.g. m.Velocity[:]), otherwise, we will keep referencing
-				the struct since we promote the array from the same memory block as the struct. We must copy the array
-				to local variable, so it will be promoted instead (we only need the local variable to escape to the heap),
-				only then the struct can be garbage-collected on next GC's cycle. */ -}}
-			copied := m.{{ .Name }}
-			field.Value = {{ stringReplace .ProtoValue (printf "m.%s" .Name) "copied[:]" -1 }}
-			{{ else -}}
-			field.Value = {{ .ProtoValue }}
-			{{ end -}}
-			{{ if eq .CanExpand true -}}
-				field.IsExpandedField = expanded
-			{{ end -}}
-			fields = append(fields, field)
-			{{ if eq .CanExpand true -}} } {{ end -}}
-		}
+		field.Value = {{ .ProtoValue }}
 		{{ end -}}
+		{{ if eq .CanExpand true -}}
+			field.IsExpandedField = expanded
+		{{ end -}}
+		fields = append(fields, field)
+		{{ if eq .CanExpand true -}} } {{ end -}}
+	}
 	{{ end }}
 
 	mesg.Fields = make([]proto.Field, len(fields))

--- a/profile/mesgdef/activity_gen.go
+++ b/profile/mesgdef/activity_gen.go
@@ -95,17 +95,17 @@ func (m *Activity) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.NumSessions)
 		fields = append(fields, field)
 	}
-	if byte(m.Type) != basetype.EnumInvalid {
+	if m.Type != typedef.ActivityInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint8(byte(m.Type))
 		fields = append(fields, field)
 	}
-	if byte(m.Event) != basetype.EnumInvalid {
+	if m.Event != typedef.EventInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = proto.Uint8(byte(m.Event))
 		fields = append(fields, field)
 	}
-	if byte(m.EventType) != basetype.EnumInvalid {
+	if m.EventType != typedef.EventTypeInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Uint8(byte(m.EventType))
 		fields = append(fields, field)

--- a/profile/mesgdef/ant_channel_id_gen.go
+++ b/profile/mesgdef/ant_channel_id_gen.go
@@ -91,7 +91,7 @@ func (m *AntChannelId) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.TransmissionType)
 		fields = append(fields, field)
 	}
-	if uint8(m.DeviceIndex) != basetype.Uint8Invalid {
+	if m.DeviceIndex != typedef.DeviceIndexInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Uint8(uint8(m.DeviceIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/bike_profile_gen.go
+++ b/profile/mesgdef/bike_profile_gen.go
@@ -34,15 +34,15 @@ type BikeProfile struct {
 	PowerCalFactor           uint16 // Scale: 10; Units: %
 	Sport                    typedef.Sport
 	SubSport                 typedef.SubSport
-	AutoWheelCal             bool
-	AutoPowerZero            bool
+	AutoWheelCal             typedef.Bool
+	AutoPowerZero            typedef.Bool
 	Id                       uint8
-	SpdEnabled               bool
-	CadEnabled               bool
-	SpdcadEnabled            bool
-	PowerEnabled             bool
+	SpdEnabled               typedef.Bool
+	CadEnabled               typedef.Bool
+	SpdcadEnabled            typedef.Bool
+	PowerEnabled             typedef.Bool
 	CrankLength              uint8 // Scale: 2; Offset: -110; Units: mm
-	Enabled                  bool
+	Enabled                  typedef.Bool
 	BikeSpdAntIdTransType    uint8
 	BikeCadAntIdTransType    uint8
 	BikeSpdcadAntIdTransType uint8
@@ -50,7 +50,7 @@ type BikeProfile struct {
 	OdometerRollover         uint8 // Rollover counter that can be used to extend the odometer
 	FrontGearNum             uint8 // Number of front gears
 	RearGearNum              uint8 // Number of rear gears
-	ShimanoDi2Enabled        bool
+	ShimanoDi2Enabled        typedef.Bool
 
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
@@ -126,7 +126,7 @@ func (m *BikeProfile) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumBikeProfile}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -136,12 +136,12 @@ func (m *BikeProfile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.Name)
 		fields = append(fields, field)
 	}
-	if byte(m.Sport) != basetype.EnumInvalid {
+	if m.Sport != typedef.SportInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.Sport))
 		fields = append(fields, field)
 	}
-	if byte(m.SubSport) != basetype.EnumInvalid {
+	if m.SubSport != typedef.SubSportInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint8(byte(m.SubSport))
 		fields = append(fields, field)
@@ -191,12 +191,12 @@ func (m *BikeProfile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.PowerCalFactor)
 		fields = append(fields, field)
 	}
-	{
+	if m.AutoWheelCal < 2 {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = proto.Bool(m.AutoWheelCal)
 		fields = append(fields, field)
 	}
-	{
+	if m.AutoPowerZero < 2 {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = proto.Bool(m.AutoPowerZero)
 		fields = append(fields, field)
@@ -206,22 +206,22 @@ func (m *BikeProfile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.Id)
 		fields = append(fields, field)
 	}
-	{
+	if m.SpdEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = proto.Bool(m.SpdEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.CadEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 16)
 		field.Value = proto.Bool(m.CadEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.SpdcadEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 17)
 		field.Value = proto.Bool(m.SpdcadEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.PowerEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 18)
 		field.Value = proto.Bool(m.PowerEnabled)
 		fields = append(fields, field)
@@ -231,7 +231,7 @@ func (m *BikeProfile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.CrankLength)
 		fields = append(fields, field)
 	}
-	{
+	if m.Enabled < 2 {
 		field := fac.CreateField(mesg.Num, 20)
 		field.Value = proto.Bool(m.Enabled)
 		fields = append(fields, field)
@@ -281,7 +281,7 @@ func (m *BikeProfile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.SliceUint8(m.RearGear)
 		fields = append(fields, field)
 	}
-	{
+	if m.ShimanoDi2Enabled < 2 {
 		field := fac.CreateField(mesg.Num, 44)
 		field.Value = proto.Bool(m.ShimanoDi2Enabled)
 		fields = append(fields, field)
@@ -521,13 +521,13 @@ func (m *BikeProfile) SetPowerCalFactorScaled(v float64) *BikeProfile {
 }
 
 // SetAutoWheelCal sets AutoWheelCal value.
-func (m *BikeProfile) SetAutoWheelCal(v bool) *BikeProfile {
+func (m *BikeProfile) SetAutoWheelCal(v typedef.Bool) *BikeProfile {
 	m.AutoWheelCal = v
 	return m
 }
 
 // SetAutoPowerZero sets AutoPowerZero value.
-func (m *BikeProfile) SetAutoPowerZero(v bool) *BikeProfile {
+func (m *BikeProfile) SetAutoPowerZero(v typedef.Bool) *BikeProfile {
 	m.AutoPowerZero = v
 	return m
 }
@@ -539,25 +539,25 @@ func (m *BikeProfile) SetId(v uint8) *BikeProfile {
 }
 
 // SetSpdEnabled sets SpdEnabled value.
-func (m *BikeProfile) SetSpdEnabled(v bool) *BikeProfile {
+func (m *BikeProfile) SetSpdEnabled(v typedef.Bool) *BikeProfile {
 	m.SpdEnabled = v
 	return m
 }
 
 // SetCadEnabled sets CadEnabled value.
-func (m *BikeProfile) SetCadEnabled(v bool) *BikeProfile {
+func (m *BikeProfile) SetCadEnabled(v typedef.Bool) *BikeProfile {
 	m.CadEnabled = v
 	return m
 }
 
 // SetSpdcadEnabled sets SpdcadEnabled value.
-func (m *BikeProfile) SetSpdcadEnabled(v bool) *BikeProfile {
+func (m *BikeProfile) SetSpdcadEnabled(v typedef.Bool) *BikeProfile {
 	m.SpdcadEnabled = v
 	return m
 }
 
 // SetPowerEnabled sets PowerEnabled value.
-func (m *BikeProfile) SetPowerEnabled(v bool) *BikeProfile {
+func (m *BikeProfile) SetPowerEnabled(v typedef.Bool) *BikeProfile {
 	m.PowerEnabled = v
 	return m
 }
@@ -585,7 +585,7 @@ func (m *BikeProfile) SetCrankLengthScaled(v float64) *BikeProfile {
 }
 
 // SetEnabled sets Enabled value.
-func (m *BikeProfile) SetEnabled(v bool) *BikeProfile {
+func (m *BikeProfile) SetEnabled(v typedef.Bool) *BikeProfile {
 	m.Enabled = v
 	return m
 }
@@ -655,7 +655,7 @@ func (m *BikeProfile) SetRearGear(v []uint8) *BikeProfile {
 }
 
 // SetShimanoDi2Enabled sets ShimanoDi2Enabled value.
-func (m *BikeProfile) SetShimanoDi2Enabled(v bool) *BikeProfile {
+func (m *BikeProfile) SetShimanoDi2Enabled(v typedef.Bool) *BikeProfile {
 	m.ShimanoDi2Enabled = v
 	return m
 }

--- a/profile/mesgdef/blood_pressure_gen.go
+++ b/profile/mesgdef/blood_pressure_gen.go
@@ -125,17 +125,17 @@ func (m *BloodPressure) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.HeartRate)
 		fields = append(fields, field)
 	}
-	if byte(m.HeartRateType) != basetype.EnumInvalid {
+	if m.HeartRateType != typedef.HrTypeInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = proto.Uint8(byte(m.HeartRateType))
 		fields = append(fields, field)
 	}
-	if byte(m.Status) != basetype.EnumInvalid {
+	if m.Status != typedef.BpStatusInvalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = proto.Uint8(byte(m.Status))
 		fields = append(fields, field)
 	}
-	if uint16(m.UserProfileIndex) != basetype.Uint16Invalid {
+	if m.UserProfileIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = proto.Uint16(uint16(m.UserProfileIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/cadence_zone_gen.go
+++ b/profile/mesgdef/cadence_zone_gen.go
@@ -67,7 +67,7 @@ func (m *CadenceZone) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumCadenceZone}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/camera_event_gen.go
+++ b/profile/mesgdef/camera_event_gen.go
@@ -83,7 +83,7 @@ func (m *CameraEvent) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.TimestampMs)
 		fields = append(fields, field)
 	}
-	if byte(m.CameraEventType) != basetype.EnumInvalid {
+	if m.CameraEventType != typedef.CameraEventTypeInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.CameraEventType))
 		fields = append(fields, field)
@@ -93,7 +93,7 @@ func (m *CameraEvent) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.CameraFileUuid)
 		fields = append(fields, field)
 	}
-	if byte(m.CameraOrientation) != basetype.EnumInvalid {
+	if m.CameraOrientation != typedef.CameraOrientationTypeInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = proto.Uint8(byte(m.CameraOrientation))
 		fields = append(fields, field)

--- a/profile/mesgdef/capabilities_gen.go
+++ b/profile/mesgdef/capabilities_gen.go
@@ -8,7 +8,6 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 	"unsafe"
@@ -84,12 +83,12 @@ func (m *Capabilities) ToMesg(options *Options) proto.Message {
 		field.Value = proto.SliceUint8(m.Sports)
 		fields = append(fields, field)
 	}
-	if uint32(m.WorkoutsSupported) != basetype.Uint32zInvalid {
+	if m.WorkoutsSupported != typedef.WorkoutCapabilitiesInvalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = proto.Uint32(uint32(m.WorkoutsSupported))
 		fields = append(fields, field)
 	}
-	if uint32(m.ConnectivitySupported) != basetype.Uint32zInvalid {
+	if m.ConnectivitySupported != typedef.ConnectivityCapabilitiesInvalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = proto.Uint32(uint32(m.ConnectivitySupported))
 		fields = append(fields, field)

--- a/profile/mesgdef/chrono_shot_session_gen.go
+++ b/profile/mesgdef/chrono_shot_session_gen.go
@@ -103,7 +103,7 @@ func (m *ChronoShotSession) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.ShotCount)
 		fields = append(fields, field)
 	}
-	if byte(m.ProjectileType) != basetype.EnumInvalid {
+	if m.ProjectileType != typedef.ProjectileTypeInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Uint8(byte(m.ProjectileType))
 		fields = append(fields, field)

--- a/profile/mesgdef/climb_pro_gen.go
+++ b/profile/mesgdef/climb_pro_gen.go
@@ -94,7 +94,7 @@ func (m *ClimbPro) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Int32(m.PositionLong)
 		fields = append(fields, field)
 	}
-	if byte(m.ClimbProEvent) != basetype.EnumInvalid {
+	if m.ClimbProEvent != typedef.ClimbProEventInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint8(byte(m.ClimbProEvent))
 		fields = append(fields, field)

--- a/profile/mesgdef/connectivity_gen.go
+++ b/profile/mesgdef/connectivity_gen.go
@@ -19,18 +19,18 @@ import (
 // Do not rely on field indices, such as when using reflection.
 type Connectivity struct {
 	Name                        string
-	BluetoothEnabled            bool // Use Bluetooth for connectivity features
-	BluetoothLeEnabled          bool // Use Bluetooth Low Energy for connectivity features
-	AntEnabled                  bool // Use ANT for connectivity features
-	LiveTrackingEnabled         bool
-	WeatherConditionsEnabled    bool
-	WeatherAlertsEnabled        bool
-	AutoActivityUploadEnabled   bool
-	CourseDownloadEnabled       bool
-	WorkoutDownloadEnabled      bool
-	GpsEphemerisDownloadEnabled bool
-	IncidentDetectionEnabled    bool
-	GrouptrackEnabled           bool
+	BluetoothEnabled            typedef.Bool // Use Bluetooth for connectivity features
+	BluetoothLeEnabled          typedef.Bool // Use Bluetooth Low Energy for connectivity features
+	AntEnabled                  typedef.Bool // Use ANT for connectivity features
+	LiveTrackingEnabled         typedef.Bool
+	WeatherConditionsEnabled    typedef.Bool
+	WeatherAlertsEnabled        typedef.Bool
+	AutoActivityUploadEnabled   typedef.Bool
+	CourseDownloadEnabled       typedef.Bool
+	WorkoutDownloadEnabled      typedef.Bool
+	GpsEphemerisDownloadEnabled typedef.Bool
+	IncidentDetectionEnabled    typedef.Bool
+	GrouptrackEnabled           typedef.Bool
 
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
@@ -87,17 +87,17 @@ func (m *Connectivity) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumConnectivity}
 
-	{
+	if m.BluetoothEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Bool(m.BluetoothEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.BluetoothLeEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Bool(m.BluetoothLeEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.AntEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Bool(m.AntEnabled)
 		fields = append(fields, field)
@@ -107,47 +107,47 @@ func (m *Connectivity) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.Name)
 		fields = append(fields, field)
 	}
-	{
+	if m.LiveTrackingEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Bool(m.LiveTrackingEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.WeatherConditionsEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = proto.Bool(m.WeatherConditionsEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.WeatherAlertsEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = proto.Bool(m.WeatherAlertsEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.AutoActivityUploadEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = proto.Bool(m.AutoActivityUploadEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.CourseDownloadEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = proto.Bool(m.CourseDownloadEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.WorkoutDownloadEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = proto.Bool(m.WorkoutDownloadEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.GpsEphemerisDownloadEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = proto.Bool(m.GpsEphemerisDownloadEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.IncidentDetectionEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = proto.Bool(m.IncidentDetectionEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.GrouptrackEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = proto.Bool(m.GrouptrackEnabled)
 		fields = append(fields, field)
@@ -165,7 +165,7 @@ func (m *Connectivity) ToMesg(options *Options) proto.Message {
 // SetBluetoothEnabled sets BluetoothEnabled value.
 //
 // Use Bluetooth for connectivity features
-func (m *Connectivity) SetBluetoothEnabled(v bool) *Connectivity {
+func (m *Connectivity) SetBluetoothEnabled(v typedef.Bool) *Connectivity {
 	m.BluetoothEnabled = v
 	return m
 }
@@ -173,7 +173,7 @@ func (m *Connectivity) SetBluetoothEnabled(v bool) *Connectivity {
 // SetBluetoothLeEnabled sets BluetoothLeEnabled value.
 //
 // Use Bluetooth Low Energy for connectivity features
-func (m *Connectivity) SetBluetoothLeEnabled(v bool) *Connectivity {
+func (m *Connectivity) SetBluetoothLeEnabled(v typedef.Bool) *Connectivity {
 	m.BluetoothLeEnabled = v
 	return m
 }
@@ -181,7 +181,7 @@ func (m *Connectivity) SetBluetoothLeEnabled(v bool) *Connectivity {
 // SetAntEnabled sets AntEnabled value.
 //
 // Use ANT for connectivity features
-func (m *Connectivity) SetAntEnabled(v bool) *Connectivity {
+func (m *Connectivity) SetAntEnabled(v typedef.Bool) *Connectivity {
 	m.AntEnabled = v
 	return m
 }
@@ -193,55 +193,55 @@ func (m *Connectivity) SetName(v string) *Connectivity {
 }
 
 // SetLiveTrackingEnabled sets LiveTrackingEnabled value.
-func (m *Connectivity) SetLiveTrackingEnabled(v bool) *Connectivity {
+func (m *Connectivity) SetLiveTrackingEnabled(v typedef.Bool) *Connectivity {
 	m.LiveTrackingEnabled = v
 	return m
 }
 
 // SetWeatherConditionsEnabled sets WeatherConditionsEnabled value.
-func (m *Connectivity) SetWeatherConditionsEnabled(v bool) *Connectivity {
+func (m *Connectivity) SetWeatherConditionsEnabled(v typedef.Bool) *Connectivity {
 	m.WeatherConditionsEnabled = v
 	return m
 }
 
 // SetWeatherAlertsEnabled sets WeatherAlertsEnabled value.
-func (m *Connectivity) SetWeatherAlertsEnabled(v bool) *Connectivity {
+func (m *Connectivity) SetWeatherAlertsEnabled(v typedef.Bool) *Connectivity {
 	m.WeatherAlertsEnabled = v
 	return m
 }
 
 // SetAutoActivityUploadEnabled sets AutoActivityUploadEnabled value.
-func (m *Connectivity) SetAutoActivityUploadEnabled(v bool) *Connectivity {
+func (m *Connectivity) SetAutoActivityUploadEnabled(v typedef.Bool) *Connectivity {
 	m.AutoActivityUploadEnabled = v
 	return m
 }
 
 // SetCourseDownloadEnabled sets CourseDownloadEnabled value.
-func (m *Connectivity) SetCourseDownloadEnabled(v bool) *Connectivity {
+func (m *Connectivity) SetCourseDownloadEnabled(v typedef.Bool) *Connectivity {
 	m.CourseDownloadEnabled = v
 	return m
 }
 
 // SetWorkoutDownloadEnabled sets WorkoutDownloadEnabled value.
-func (m *Connectivity) SetWorkoutDownloadEnabled(v bool) *Connectivity {
+func (m *Connectivity) SetWorkoutDownloadEnabled(v typedef.Bool) *Connectivity {
 	m.WorkoutDownloadEnabled = v
 	return m
 }
 
 // SetGpsEphemerisDownloadEnabled sets GpsEphemerisDownloadEnabled value.
-func (m *Connectivity) SetGpsEphemerisDownloadEnabled(v bool) *Connectivity {
+func (m *Connectivity) SetGpsEphemerisDownloadEnabled(v typedef.Bool) *Connectivity {
 	m.GpsEphemerisDownloadEnabled = v
 	return m
 }
 
 // SetIncidentDetectionEnabled sets IncidentDetectionEnabled value.
-func (m *Connectivity) SetIncidentDetectionEnabled(v bool) *Connectivity {
+func (m *Connectivity) SetIncidentDetectionEnabled(v typedef.Bool) *Connectivity {
 	m.IncidentDetectionEnabled = v
 	return m
 }
 
 // SetGrouptrackEnabled sets GrouptrackEnabled value.
-func (m *Connectivity) SetGrouptrackEnabled(v bool) *Connectivity {
+func (m *Connectivity) SetGrouptrackEnabled(v typedef.Bool) *Connectivity {
 	m.GrouptrackEnabled = v
 	return m
 }

--- a/profile/mesgdef/course_gen.go
+++ b/profile/mesgdef/course_gen.go
@@ -69,7 +69,7 @@ func (m *Course) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumCourse}
 
-	if byte(m.Sport) != basetype.EnumInvalid {
+	if m.Sport != typedef.SportInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Uint8(byte(m.Sport))
 		fields = append(fields, field)
@@ -79,12 +79,12 @@ func (m *Course) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.Name)
 		fields = append(fields, field)
 	}
-	if uint32(m.Capabilities) != basetype.Uint32zInvalid {
+	if m.Capabilities != typedef.CourseCapabilitiesInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = proto.Uint32(uint32(m.Capabilities))
 		fields = append(fields, field)
 	}
-	if byte(m.SubSport) != basetype.EnumInvalid {
+	if m.SubSport != typedef.SubSportInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = proto.Uint8(byte(m.SubSport))
 		fields = append(fields, field)

--- a/profile/mesgdef/course_point_gen.go
+++ b/profile/mesgdef/course_point_gen.go
@@ -29,7 +29,7 @@ type CoursePoint struct {
 	Distance     uint32 // Scale: 100; Units: m
 	MessageIndex typedef.MessageIndex
 	Type         typedef.CoursePoint
-	Favorite     bool
+	Favorite     typedef.Bool
 
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
@@ -81,7 +81,7 @@ func (m *CoursePoint) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumCoursePoint}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -106,7 +106,7 @@ func (m *CoursePoint) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.Distance)
 		fields = append(fields, field)
 	}
-	if byte(m.Type) != basetype.EnumInvalid {
+	if m.Type != typedef.CoursePointInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = proto.Uint8(byte(m.Type))
 		fields = append(fields, field)
@@ -116,7 +116,7 @@ func (m *CoursePoint) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.Name)
 		fields = append(fields, field)
 	}
-	{
+	if m.Favorite < 2 {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = proto.Bool(m.Favorite)
 		fields = append(fields, field)
@@ -234,7 +234,7 @@ func (m *CoursePoint) SetName(v string) *CoursePoint {
 }
 
 // SetFavorite sets Favorite value.
-func (m *CoursePoint) SetFavorite(v bool) *CoursePoint {
+func (m *CoursePoint) SetFavorite(v typedef.Bool) *CoursePoint {
 	m.Favorite = v
 	return m
 }

--- a/profile/mesgdef/developer_data_id_gen.go
+++ b/profile/mesgdef/developer_data_id_gen.go
@@ -73,7 +73,7 @@ func (m *DeveloperDataId) ToMesg(options *Options) proto.Message {
 		field.Value = proto.SliceUint8(m.ApplicationId)
 		fields = append(fields, field)
 	}
-	if uint16(m.ManufacturerId) != basetype.Uint16Invalid {
+	if m.ManufacturerId != typedef.ManufacturerInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint16(uint16(m.ManufacturerId))
 		fields = append(fields, field)

--- a/profile/mesgdef/device_aux_battery_info_gen.go
+++ b/profile/mesgdef/device_aux_battery_info_gen.go
@@ -79,7 +79,7 @@ func (m *DeviceAuxBatteryInfo) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if uint8(m.DeviceIndex) != basetype.Uint8Invalid {
+	if m.DeviceIndex != typedef.DeviceIndexInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(uint8(m.DeviceIndex))
 		fields = append(fields, field)
@@ -89,7 +89,7 @@ func (m *DeviceAuxBatteryInfo) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.BatteryVoltage)
 		fields = append(fields, field)
 	}
-	if uint8(m.BatteryStatus) != basetype.Uint8Invalid {
+	if m.BatteryStatus != typedef.BatteryStatusInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint8(uint8(m.BatteryStatus))
 		fields = append(fields, field)

--- a/profile/mesgdef/device_info_gen.go
+++ b/profile/mesgdef/device_info_gen.go
@@ -107,7 +107,7 @@ func (m *DeviceInfo) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if uint8(m.DeviceIndex) != basetype.Uint8Invalid {
+	if m.DeviceIndex != typedef.DeviceIndexInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(uint8(m.DeviceIndex))
 		fields = append(fields, field)
@@ -117,7 +117,7 @@ func (m *DeviceInfo) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.DeviceType)
 		fields = append(fields, field)
 	}
-	if uint16(m.Manufacturer) != basetype.Uint16Invalid {
+	if m.Manufacturer != typedef.ManufacturerInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint16(uint16(m.Manufacturer))
 		fields = append(fields, field)
@@ -152,12 +152,12 @@ func (m *DeviceInfo) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.BatteryVoltage)
 		fields = append(fields, field)
 	}
-	if uint8(m.BatteryStatus) != basetype.Uint8Invalid {
+	if m.BatteryStatus != typedef.BatteryStatusInvalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = proto.Uint8(uint8(m.BatteryStatus))
 		fields = append(fields, field)
 	}
-	if byte(m.SensorPosition) != basetype.EnumInvalid {
+	if m.SensorPosition != typedef.BodyLocationInvalid {
 		field := fac.CreateField(mesg.Num, 18)
 		field.Value = proto.Uint8(byte(m.SensorPosition))
 		fields = append(fields, field)
@@ -177,12 +177,12 @@ func (m *DeviceInfo) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.AntDeviceNumber)
 		fields = append(fields, field)
 	}
-	if byte(m.AntNetwork) != basetype.EnumInvalid {
+	if m.AntNetwork != typedef.AntNetworkInvalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = proto.Uint8(byte(m.AntNetwork))
 		fields = append(fields, field)
 	}
-	if byte(m.SourceType) != basetype.EnumInvalid {
+	if m.SourceType != typedef.SourceTypeInvalid {
 		field := fac.CreateField(mesg.Num, 25)
 		field.Value = proto.Uint8(byte(m.SourceType))
 		fields = append(fields, field)

--- a/profile/mesgdef/device_settings_gen.go
+++ b/profile/mesgdef/device_settings_gen.go
@@ -34,13 +34,13 @@ type DeviceSettings struct {
 	AutosyncMinTime                     uint16                     // Units: minutes; Minimum minutes before an autosync can occur
 	ActiveTimeZone                      uint8                      // Index into time zone arrays.
 	BacklightMode                       typedef.BacklightMode      // Mode for backlight
-	ActivityTrackerEnabled              bool                       // Enabled state of the activity tracker functionality
-	MoveAlertEnabled                    bool                       // Enabled state of the move alert
+	ActivityTrackerEnabled              typedef.Bool               // Enabled state of the activity tracker functionality
+	MoveAlertEnabled                    typedef.Bool               // Enabled state of the move alert
 	DateMode                            typedef.DateMode           // Display mode for the date
 	DisplayOrientation                  typedef.DisplayOrientation
 	MountingSide                        typedef.Side
-	LactateThresholdAutodetectEnabled   bool                       // Enable auto-detect setting for the lactate threshold feature.
-	BleAutoUploadEnabled                bool                       // Automatically upload using BLE
+	LactateThresholdAutodetectEnabled   typedef.Bool               // Enable auto-detect setting for the lactate threshold feature.
+	BleAutoUploadEnabled                typedef.Bool               // Automatically upload using BLE
 	AutoSyncFrequency                   typedef.AutoSyncFrequency  // Helps to conserve battery by changing modes
 	NumberOfScreens                     uint8                      // Number of screens configured to display
 	SmartNotificationDisplayOrientation typedef.DisplayOrientation // Smart Notification display orientation
@@ -142,12 +142,12 @@ func (m *DeviceSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.SliceInt8(m.TimeZoneOffset)
 		fields = append(fields, field)
 	}
-	if byte(m.BacklightMode) != basetype.EnumInvalid {
+	if m.BacklightMode != typedef.BacklightModeInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = proto.Uint8(byte(m.BacklightMode))
 		fields = append(fields, field)
 	}
-	{
+	if m.ActivityTrackerEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 36)
 		field.Value = proto.Bool(m.ActivityTrackerEnabled)
 		fields = append(fields, field)
@@ -162,22 +162,22 @@ func (m *DeviceSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.SliceUint16(m.PagesEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.MoveAlertEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 46)
 		field.Value = proto.Bool(m.MoveAlertEnabled)
 		fields = append(fields, field)
 	}
-	if byte(m.DateMode) != basetype.EnumInvalid {
+	if m.DateMode != typedef.DateModeInvalid {
 		field := fac.CreateField(mesg.Num, 47)
 		field.Value = proto.Uint8(byte(m.DateMode))
 		fields = append(fields, field)
 	}
-	if byte(m.DisplayOrientation) != basetype.EnumInvalid {
+	if m.DisplayOrientation != typedef.DisplayOrientationInvalid {
 		field := fac.CreateField(mesg.Num, 55)
 		field.Value = proto.Uint8(byte(m.DisplayOrientation))
 		fields = append(fields, field)
 	}
-	if byte(m.MountingSide) != basetype.EnumInvalid {
+	if m.MountingSide != typedef.SideInvalid {
 		field := fac.CreateField(mesg.Num, 56)
 		field.Value = proto.Uint8(byte(m.MountingSide))
 		fields = append(fields, field)
@@ -197,22 +197,22 @@ func (m *DeviceSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.AutosyncMinTime)
 		fields = append(fields, field)
 	}
-	{
+	if m.LactateThresholdAutodetectEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 80)
 		field.Value = proto.Bool(m.LactateThresholdAutodetectEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.BleAutoUploadEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 86)
 		field.Value = proto.Bool(m.BleAutoUploadEnabled)
 		fields = append(fields, field)
 	}
-	if byte(m.AutoSyncFrequency) != basetype.EnumInvalid {
+	if m.AutoSyncFrequency != typedef.AutoSyncFrequencyInvalid {
 		field := fac.CreateField(mesg.Num, 89)
 		field.Value = proto.Uint8(byte(m.AutoSyncFrequency))
 		fields = append(fields, field)
 	}
-	if uint32(m.AutoActivityDetect) != basetype.Uint32Invalid {
+	if m.AutoActivityDetect != typedef.AutoActivityDetectInvalid {
 		field := fac.CreateField(mesg.Num, 90)
 		field.Value = proto.Uint32(uint32(m.AutoActivityDetect))
 		fields = append(fields, field)
@@ -222,17 +222,17 @@ func (m *DeviceSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.NumberOfScreens)
 		fields = append(fields, field)
 	}
-	if byte(m.SmartNotificationDisplayOrientation) != basetype.EnumInvalid {
+	if m.SmartNotificationDisplayOrientation != typedef.DisplayOrientationInvalid {
 		field := fac.CreateField(mesg.Num, 95)
 		field.Value = proto.Uint8(byte(m.SmartNotificationDisplayOrientation))
 		fields = append(fields, field)
 	}
-	if byte(m.TapInterface) != basetype.EnumInvalid {
+	if m.TapInterface != typedef.SwitchInvalid {
 		field := fac.CreateField(mesg.Num, 134)
 		field.Value = proto.Uint8(byte(m.TapInterface))
 		fields = append(fields, field)
 	}
-	if byte(m.TapSensitivity) != basetype.EnumInvalid {
+	if m.TapSensitivity != typedef.TapSensitivityInvalid {
 		field := fac.CreateField(mesg.Num, 174)
 		field.Value = proto.Uint8(byte(m.TapSensitivity))
 		fields = append(fields, field)
@@ -341,7 +341,7 @@ func (m *DeviceSettings) SetBacklightMode(v typedef.BacklightMode) *DeviceSettin
 // SetActivityTrackerEnabled sets ActivityTrackerEnabled value.
 //
 // Enabled state of the activity tracker functionality
-func (m *DeviceSettings) SetActivityTrackerEnabled(v bool) *DeviceSettings {
+func (m *DeviceSettings) SetActivityTrackerEnabled(v typedef.Bool) *DeviceSettings {
 	m.ActivityTrackerEnabled = v
 	return m
 }
@@ -365,7 +365,7 @@ func (m *DeviceSettings) SetPagesEnabled(v []uint16) *DeviceSettings {
 // SetMoveAlertEnabled sets MoveAlertEnabled value.
 //
 // Enabled state of the move alert
-func (m *DeviceSettings) SetMoveAlertEnabled(v bool) *DeviceSettings {
+func (m *DeviceSettings) SetMoveAlertEnabled(v typedef.Bool) *DeviceSettings {
 	m.MoveAlertEnabled = v
 	return m
 }
@@ -417,7 +417,7 @@ func (m *DeviceSettings) SetAutosyncMinTime(v uint16) *DeviceSettings {
 // SetLactateThresholdAutodetectEnabled sets LactateThresholdAutodetectEnabled value.
 //
 // Enable auto-detect setting for the lactate threshold feature.
-func (m *DeviceSettings) SetLactateThresholdAutodetectEnabled(v bool) *DeviceSettings {
+func (m *DeviceSettings) SetLactateThresholdAutodetectEnabled(v typedef.Bool) *DeviceSettings {
 	m.LactateThresholdAutodetectEnabled = v
 	return m
 }
@@ -425,7 +425,7 @@ func (m *DeviceSettings) SetLactateThresholdAutodetectEnabled(v bool) *DeviceSet
 // SetBleAutoUploadEnabled sets BleAutoUploadEnabled value.
 //
 // Automatically upload using BLE
-func (m *DeviceSettings) SetBleAutoUploadEnabled(v bool) *DeviceSettings {
+func (m *DeviceSettings) SetBleAutoUploadEnabled(v typedef.Bool) *DeviceSettings {
 	m.BleAutoUploadEnabled = v
 	return m
 }

--- a/profile/mesgdef/dive_alarm_gen.go
+++ b/profile/mesgdef/dive_alarm_gen.go
@@ -26,13 +26,13 @@ type DiveAlarm struct {
 	Id               uint32                // Alarm ID
 	Speed            int32                 // Scale: 1000; Units: mps; Ascent/descent rate (mps) setting for speed type alarms
 	MessageIndex     typedef.MessageIndex  // Index of the alarm
-	Enabled          bool                  // Enablement flag
+	Enabled          typedef.Bool          // Enablement flag
 	AlarmType        typedef.DiveAlarmType // Alarm type setting
 	Sound            typedef.Tone          // Tone and Vibe setting for the alarm
-	PopupEnabled     bool                  // Show a visible pop-up for this alarm
-	TriggerOnDescent bool                  // Trigger the alarm on descent
-	TriggerOnAscent  bool                  // Trigger the alarm on ascent
-	Repeating        bool                  // Repeat alarm each time threshold is crossed?
+	PopupEnabled     typedef.Bool          // Show a visible pop-up for this alarm
+	TriggerOnDescent typedef.Bool          // Trigger the alarm on descent
+	TriggerOnAscent  typedef.Bool          // Trigger the alarm on ascent
+	Repeating        typedef.Bool          // Repeat alarm each time threshold is crossed?
 
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
@@ -93,7 +93,7 @@ func (m *DiveAlarm) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumDiveAlarm}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -108,17 +108,17 @@ func (m *DiveAlarm) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Int32(m.Time)
 		fields = append(fields, field)
 	}
-	{
+	if m.Enabled < 2 {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Bool(m.Enabled)
 		fields = append(fields, field)
 	}
-	if byte(m.AlarmType) != basetype.EnumInvalid {
+	if m.AlarmType != typedef.DiveAlarmTypeInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = proto.Uint8(byte(m.AlarmType))
 		fields = append(fields, field)
 	}
-	if byte(m.Sound) != basetype.EnumInvalid {
+	if m.Sound != typedef.ToneInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Uint8(byte(m.Sound))
 		fields = append(fields, field)
@@ -133,22 +133,22 @@ func (m *DiveAlarm) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.Id)
 		fields = append(fields, field)
 	}
-	{
+	if m.PopupEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = proto.Bool(m.PopupEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.TriggerOnDescent < 2 {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = proto.Bool(m.TriggerOnDescent)
 		fields = append(fields, field)
 	}
-	{
+	if m.TriggerOnAscent < 2 {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = proto.Bool(m.TriggerOnAscent)
 		fields = append(fields, field)
 	}
-	{
+	if m.Repeating < 2 {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = proto.Bool(m.Repeating)
 		fields = append(fields, field)
@@ -231,7 +231,7 @@ func (m *DiveAlarm) SetTime(v int32) *DiveAlarm {
 // SetEnabled sets Enabled value.
 //
 // Enablement flag
-func (m *DiveAlarm) SetEnabled(v bool) *DiveAlarm {
+func (m *DiveAlarm) SetEnabled(v typedef.Bool) *DiveAlarm {
 	m.Enabled = v
 	return m
 }
@@ -271,7 +271,7 @@ func (m *DiveAlarm) SetId(v uint32) *DiveAlarm {
 // SetPopupEnabled sets PopupEnabled value.
 //
 // Show a visible pop-up for this alarm
-func (m *DiveAlarm) SetPopupEnabled(v bool) *DiveAlarm {
+func (m *DiveAlarm) SetPopupEnabled(v typedef.Bool) *DiveAlarm {
 	m.PopupEnabled = v
 	return m
 }
@@ -279,7 +279,7 @@ func (m *DiveAlarm) SetPopupEnabled(v bool) *DiveAlarm {
 // SetTriggerOnDescent sets TriggerOnDescent value.
 //
 // Trigger the alarm on descent
-func (m *DiveAlarm) SetTriggerOnDescent(v bool) *DiveAlarm {
+func (m *DiveAlarm) SetTriggerOnDescent(v typedef.Bool) *DiveAlarm {
 	m.TriggerOnDescent = v
 	return m
 }
@@ -287,7 +287,7 @@ func (m *DiveAlarm) SetTriggerOnDescent(v bool) *DiveAlarm {
 // SetTriggerOnAscent sets TriggerOnAscent value.
 //
 // Trigger the alarm on ascent
-func (m *DiveAlarm) SetTriggerOnAscent(v bool) *DiveAlarm {
+func (m *DiveAlarm) SetTriggerOnAscent(v typedef.Bool) *DiveAlarm {
 	m.TriggerOnAscent = v
 	return m
 }
@@ -295,7 +295,7 @@ func (m *DiveAlarm) SetTriggerOnAscent(v bool) *DiveAlarm {
 // SetRepeating sets Repeating value.
 //
 // Repeat alarm each time threshold is crossed?
-func (m *DiveAlarm) SetRepeating(v bool) *DiveAlarm {
+func (m *DiveAlarm) SetRepeating(v typedef.Bool) *DiveAlarm {
 	m.Repeating = v
 	return m
 }

--- a/profile/mesgdef/dive_apnea_alarm_gen.go
+++ b/profile/mesgdef/dive_apnea_alarm_gen.go
@@ -26,13 +26,13 @@ type DiveApneaAlarm struct {
 	Id               uint32                // Alarm ID
 	Speed            int32                 // Scale: 1000; Units: mps; Ascent/descent rate (mps) setting for speed type alarms
 	MessageIndex     typedef.MessageIndex  // Index of the alarm
-	Enabled          bool                  // Enablement flag
+	Enabled          typedef.Bool          // Enablement flag
 	AlarmType        typedef.DiveAlarmType // Alarm type setting
 	Sound            typedef.Tone          // Tone and Vibe setting for the alarm.
-	PopupEnabled     bool                  // Show a visible pop-up for this alarm
-	TriggerOnDescent bool                  // Trigger the alarm on descent
-	TriggerOnAscent  bool                  // Trigger the alarm on ascent
-	Repeating        bool                  // Repeat alarm each time threshold is crossed?
+	PopupEnabled     typedef.Bool          // Show a visible pop-up for this alarm
+	TriggerOnDescent typedef.Bool          // Trigger the alarm on descent
+	TriggerOnAscent  typedef.Bool          // Trigger the alarm on ascent
+	Repeating        typedef.Bool          // Repeat alarm each time threshold is crossed?
 
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
@@ -93,7 +93,7 @@ func (m *DiveApneaAlarm) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumDiveApneaAlarm}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -108,17 +108,17 @@ func (m *DiveApneaAlarm) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Int32(m.Time)
 		fields = append(fields, field)
 	}
-	{
+	if m.Enabled < 2 {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Bool(m.Enabled)
 		fields = append(fields, field)
 	}
-	if byte(m.AlarmType) != basetype.EnumInvalid {
+	if m.AlarmType != typedef.DiveAlarmTypeInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = proto.Uint8(byte(m.AlarmType))
 		fields = append(fields, field)
 	}
-	if byte(m.Sound) != basetype.EnumInvalid {
+	if m.Sound != typedef.ToneInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Uint8(byte(m.Sound))
 		fields = append(fields, field)
@@ -133,22 +133,22 @@ func (m *DiveApneaAlarm) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.Id)
 		fields = append(fields, field)
 	}
-	{
+	if m.PopupEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = proto.Bool(m.PopupEnabled)
 		fields = append(fields, field)
 	}
-	{
+	if m.TriggerOnDescent < 2 {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = proto.Bool(m.TriggerOnDescent)
 		fields = append(fields, field)
 	}
-	{
+	if m.TriggerOnAscent < 2 {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = proto.Bool(m.TriggerOnAscent)
 		fields = append(fields, field)
 	}
-	{
+	if m.Repeating < 2 {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = proto.Bool(m.Repeating)
 		fields = append(fields, field)
@@ -231,7 +231,7 @@ func (m *DiveApneaAlarm) SetTime(v int32) *DiveApneaAlarm {
 // SetEnabled sets Enabled value.
 //
 // Enablement flag
-func (m *DiveApneaAlarm) SetEnabled(v bool) *DiveApneaAlarm {
+func (m *DiveApneaAlarm) SetEnabled(v typedef.Bool) *DiveApneaAlarm {
 	m.Enabled = v
 	return m
 }
@@ -271,7 +271,7 @@ func (m *DiveApneaAlarm) SetId(v uint32) *DiveApneaAlarm {
 // SetPopupEnabled sets PopupEnabled value.
 //
 // Show a visible pop-up for this alarm
-func (m *DiveApneaAlarm) SetPopupEnabled(v bool) *DiveApneaAlarm {
+func (m *DiveApneaAlarm) SetPopupEnabled(v typedef.Bool) *DiveApneaAlarm {
 	m.PopupEnabled = v
 	return m
 }
@@ -279,7 +279,7 @@ func (m *DiveApneaAlarm) SetPopupEnabled(v bool) *DiveApneaAlarm {
 // SetTriggerOnDescent sets TriggerOnDescent value.
 //
 // Trigger the alarm on descent
-func (m *DiveApneaAlarm) SetTriggerOnDescent(v bool) *DiveApneaAlarm {
+func (m *DiveApneaAlarm) SetTriggerOnDescent(v typedef.Bool) *DiveApneaAlarm {
 	m.TriggerOnDescent = v
 	return m
 }
@@ -287,7 +287,7 @@ func (m *DiveApneaAlarm) SetTriggerOnDescent(v bool) *DiveApneaAlarm {
 // SetTriggerOnAscent sets TriggerOnAscent value.
 //
 // Trigger the alarm on ascent
-func (m *DiveApneaAlarm) SetTriggerOnAscent(v bool) *DiveApneaAlarm {
+func (m *DiveApneaAlarm) SetTriggerOnAscent(v typedef.Bool) *DiveApneaAlarm {
 	m.TriggerOnAscent = v
 	return m
 }
@@ -295,7 +295,7 @@ func (m *DiveApneaAlarm) SetTriggerOnAscent(v bool) *DiveApneaAlarm {
 // SetRepeating sets Repeating value.
 //
 // Repeat alarm each time threshold is crossed?
-func (m *DiveApneaAlarm) SetRepeating(v bool) *DiveApneaAlarm {
+func (m *DiveApneaAlarm) SetRepeating(v typedef.Bool) *DiveApneaAlarm {
 	m.Repeating = v
 	return m
 }

--- a/profile/mesgdef/dive_gas_gen.go
+++ b/profile/mesgdef/dive_gas_gen.go
@@ -71,7 +71,7 @@ func (m *DiveGas) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumDiveGas}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -86,12 +86,12 @@ func (m *DiveGas) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.OxygenContent)
 		fields = append(fields, field)
 	}
-	if byte(m.Status) != basetype.EnumInvalid {
+	if m.Status != typedef.DiveGasStatusInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint8(byte(m.Status))
 		fields = append(fields, field)
 	}
-	if byte(m.Mode) != basetype.EnumInvalid {
+	if m.Mode != typedef.DiveGasModeInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = proto.Uint8(byte(m.Mode))
 		fields = append(fields, field)

--- a/profile/mesgdef/dive_settings_gen.go
+++ b/profile/mesgdef/dive_settings_gen.go
@@ -40,8 +40,8 @@ type DiveSettings struct {
 	Po2Warn                   uint8 // Scale: 100; Units: percent; Typically 1.40
 	Po2Critical               uint8 // Scale: 100; Units: percent; Typically 1.60
 	Po2Deco                   uint8 // Scale: 100; Units: percent
-	SafetyStopEnabled         bool
-	ApneaCountdownEnabled     bool
+	SafetyStopEnabled         typedef.Bool
+	ApneaCountdownEnabled     typedef.Bool
 	BacklightMode             typedef.DiveBacklightMode
 	BacklightBrightness       uint8
 	BacklightTimeout          typedef.BacklightTimeout
@@ -52,7 +52,7 @@ type DiveSettings struct {
 	CcrHighSetpointSwitchMode typedef.CcrSetpointSwitchMode  // If high PO2 should be switched to automatically
 	CcrHighSetpoint           uint8                          // Scale: 100; Units: percent; Target PO2 when using high setpoint
 	GasConsumptionDisplay     typedef.GasConsumptionRateType // Type of gas consumption rate to display. Some values are only valid if tank volume is known.
-	UpKeyEnabled              bool                           // Indicates whether the up key is enabled during dives
+	UpKeyEnabled              typedef.Bool                   // Indicates whether the up key is enabled during dives
 	DiveSounds                typedef.Tone                   // Sounds and vibration enabled or disabled in-dive
 	LastStopMultiple          uint8                          // Scale: 10; Usually 1.0/1.5/2.0 representing 3/4.5/6m or 10/15/20ft
 	NoFlyTimeMode             typedef.NoFlyTimeMode          // Indicates which guidelines to use for no-fly surface interval.
@@ -139,7 +139,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -149,7 +149,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.Name)
 		fields = append(fields, field)
 	}
-	if byte(m.Model) != basetype.EnumInvalid {
+	if m.Model != typedef.TissueModelTypeInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.Model))
 		fields = append(fields, field)
@@ -164,7 +164,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.GfHigh)
 		fields = append(fields, field)
 	}
-	if byte(m.WaterType) != basetype.EnumInvalid {
+	if m.WaterType != typedef.WaterTypeInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Uint8(byte(m.WaterType))
 		fields = append(fields, field)
@@ -189,7 +189,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.Po2Deco)
 		fields = append(fields, field)
 	}
-	{
+	if m.SafetyStopEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = proto.Bool(m.SafetyStopEnabled)
 		fields = append(fields, field)
@@ -204,7 +204,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.BottomTime)
 		fields = append(fields, field)
 	}
-	{
+	if m.ApneaCountdownEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = proto.Bool(m.ApneaCountdownEnabled)
 		fields = append(fields, field)
@@ -214,7 +214,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.ApneaCountdownTime)
 		fields = append(fields, field)
 	}
-	if byte(m.BacklightMode) != basetype.EnumInvalid {
+	if m.BacklightMode != typedef.DiveBacklightModeInvalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = proto.Uint8(byte(m.BacklightMode))
 		fields = append(fields, field)
@@ -224,7 +224,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.BacklightBrightness)
 		fields = append(fields, field)
 	}
-	if uint8(m.BacklightTimeout) != basetype.Uint8Invalid {
+	if m.BacklightTimeout != typedef.BacklightTimeoutInvalid {
 		field := fac.CreateField(mesg.Num, 16)
 		field.Value = proto.Uint8(uint8(m.BacklightTimeout))
 		fields = append(fields, field)
@@ -239,7 +239,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.SafetyStopTime)
 		fields = append(fields, field)
 	}
-	if byte(m.HeartRateSourceType) != basetype.EnumInvalid {
+	if m.HeartRateSourceType != typedef.SourceTypeInvalid {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = proto.Uint8(byte(m.HeartRateSourceType))
 		fields = append(fields, field)
@@ -249,12 +249,12 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.HeartRateSource)
 		fields = append(fields, field)
 	}
-	if uint16(m.TravelGas) != basetype.Uint16Invalid {
+	if m.TravelGas != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = proto.Uint16(uint16(m.TravelGas))
 		fields = append(fields, field)
 	}
-	if byte(m.CcrLowSetpointSwitchMode) != basetype.EnumInvalid {
+	if m.CcrLowSetpointSwitchMode != typedef.CcrSetpointSwitchModeInvalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = proto.Uint8(byte(m.CcrLowSetpointSwitchMode))
 		fields = append(fields, field)
@@ -269,7 +269,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.CcrLowSetpointDepth)
 		fields = append(fields, field)
 	}
-	if byte(m.CcrHighSetpointSwitchMode) != basetype.EnumInvalid {
+	if m.CcrHighSetpointSwitchMode != typedef.CcrSetpointSwitchModeInvalid {
 		field := fac.CreateField(mesg.Num, 25)
 		field.Value = proto.Uint8(byte(m.CcrHighSetpointSwitchMode))
 		fields = append(fields, field)
@@ -284,17 +284,17 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.CcrHighSetpointDepth)
 		fields = append(fields, field)
 	}
-	if byte(m.GasConsumptionDisplay) != basetype.EnumInvalid {
+	if m.GasConsumptionDisplay != typedef.GasConsumptionRateTypeInvalid {
 		field := fac.CreateField(mesg.Num, 29)
 		field.Value = proto.Uint8(byte(m.GasConsumptionDisplay))
 		fields = append(fields, field)
 	}
-	{
+	if m.UpKeyEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 30)
 		field.Value = proto.Bool(m.UpKeyEnabled)
 		fields = append(fields, field)
 	}
-	if byte(m.DiveSounds) != basetype.EnumInvalid {
+	if m.DiveSounds != typedef.ToneInvalid {
 		field := fac.CreateField(mesg.Num, 35)
 		field.Value = proto.Uint8(byte(m.DiveSounds))
 		fields = append(fields, field)
@@ -304,7 +304,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.LastStopMultiple)
 		fields = append(fields, field)
 	}
-	if byte(m.NoFlyTimeMode) != basetype.EnumInvalid {
+	if m.NoFlyTimeMode != typedef.NoFlyTimeModeInvalid {
 		field := fac.CreateField(mesg.Num, 37)
 		field.Value = proto.Uint8(byte(m.NoFlyTimeMode))
 		fields = append(fields, field)
@@ -549,7 +549,7 @@ func (m *DiveSettings) SetPo2DecoScaled(v float64) *DiveSettings {
 }
 
 // SetSafetyStopEnabled sets SafetyStopEnabled value.
-func (m *DiveSettings) SetSafetyStopEnabled(v bool) *DiveSettings {
+func (m *DiveSettings) SetSafetyStopEnabled(v typedef.Bool) *DiveSettings {
 	m.SafetyStopEnabled = v
 	return m
 }
@@ -567,7 +567,7 @@ func (m *DiveSettings) SetBottomTime(v uint32) *DiveSettings {
 }
 
 // SetApneaCountdownEnabled sets ApneaCountdownEnabled value.
-func (m *DiveSettings) SetApneaCountdownEnabled(v bool) *DiveSettings {
+func (m *DiveSettings) SetApneaCountdownEnabled(v typedef.Bool) *DiveSettings {
 	m.ApneaCountdownEnabled = v
 	return m
 }
@@ -747,7 +747,7 @@ func (m *DiveSettings) SetGasConsumptionDisplay(v typedef.GasConsumptionRateType
 // SetUpKeyEnabled sets UpKeyEnabled value.
 //
 // Indicates whether the up key is enabled during dives
-func (m *DiveSettings) SetUpKeyEnabled(v bool) *DiveSettings {
+func (m *DiveSettings) SetUpKeyEnabled(v typedef.Bool) *DiveSettings {
 	m.UpKeyEnabled = v
 	return m
 }

--- a/profile/mesgdef/dive_summary_gen.go
+++ b/profile/mesgdef/dive_summary_gen.go
@@ -115,12 +115,12 @@ func (m *DiveSummary) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if uint16(m.ReferenceMesg) != basetype.Uint16Invalid {
+	if m.ReferenceMesg != typedef.MesgNumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint16(uint16(m.ReferenceMesg))
 		fields = append(fields, field)
 	}
-	if uint16(m.ReferenceIndex) != basetype.Uint16Invalid {
+	if m.ReferenceIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint16(uint16(m.ReferenceIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/event_gen.go
+++ b/profile/mesgdef/event_gen.go
@@ -116,12 +116,12 @@ func (m *Event) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.Event) != basetype.EnumInvalid {
+	if m.Event != typedef.EventInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Event))
 		fields = append(fields, field)
 	}
-	if byte(m.EventType) != basetype.EnumInvalid {
+	if m.EventType != typedef.EventTypeInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.EventType))
 		fields = append(fields, field)
@@ -192,12 +192,12 @@ func (m *Event) ToMesg(options *Options) proto.Message {
 			fields = append(fields, field)
 		}
 	}
-	if uint8(m.DeviceIndex) != basetype.Uint8Invalid {
+	if m.DeviceIndex != typedef.DeviceIndexInvalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = proto.Uint8(uint8(m.DeviceIndex))
 		fields = append(fields, field)
 	}
-	if byte(m.ActivityType) != basetype.EnumInvalid {
+	if m.ActivityType != typedef.ActivityTypeInvalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = proto.Uint8(byte(m.ActivityType))
 		fields = append(fields, field)
@@ -207,7 +207,7 @@ func (m *Event) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.StartTimestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.RadarThreatLevelMax) != basetype.EnumInvalid {
+	if m.RadarThreatLevelMax != typedef.RadarThreatLevelTypeInvalid {
 		if expanded := m.IsExpandedField(21); !expanded || (expanded && options.IncludeExpandedFields) {
 			field := fac.CreateField(mesg.Num, 21)
 			field.Value = proto.Uint8(byte(m.RadarThreatLevelMax))

--- a/profile/mesgdef/exd_data_concept_configuration_gen.go
+++ b/profile/mesgdef/exd_data_concept_configuration_gen.go
@@ -28,7 +28,7 @@ type ExdDataConceptConfiguration struct {
 	DataUnits    typedef.ExdDataUnits
 	Qualifier    typedef.ExdQualifiers
 	Descriptor   typedef.ExdDescriptors
-	IsSigned     bool
+	IsSigned     typedef.Bool
 
 	state [1]uint8 // Used for tracking expanded fields.
 
@@ -133,22 +133,22 @@ func (m *ExdDataConceptConfiguration) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.Scaling)
 		fields = append(fields, field)
 	}
-	if byte(m.DataUnits) != basetype.EnumInvalid {
+	if m.DataUnits != typedef.ExdDataUnitsInvalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = proto.Uint8(byte(m.DataUnits))
 		fields = append(fields, field)
 	}
-	if byte(m.Qualifier) != basetype.EnumInvalid {
+	if m.Qualifier != typedef.ExdQualifiersInvalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = proto.Uint8(byte(m.Qualifier))
 		fields = append(fields, field)
 	}
-	if byte(m.Descriptor) != basetype.EnumInvalid {
+	if m.Descriptor != typedef.ExdDescriptorsInvalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = proto.Uint8(byte(m.Descriptor))
 		fields = append(fields, field)
 	}
-	{
+	if m.IsSigned < 2 {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = proto.Bool(m.IsSigned)
 		fields = append(fields, field)
@@ -224,7 +224,7 @@ func (m *ExdDataConceptConfiguration) SetDescriptor(v typedef.ExdDescriptors) *E
 }
 
 // SetIsSigned sets IsSigned value.
-func (m *ExdDataConceptConfiguration) SetIsSigned(v bool) *ExdDataConceptConfiguration {
+func (m *ExdDataConceptConfiguration) SetIsSigned(v typedef.Bool) *ExdDataConceptConfiguration {
 	m.IsSigned = v
 	return m
 }

--- a/profile/mesgdef/exd_data_field_configuration_gen.go
+++ b/profile/mesgdef/exd_data_field_configuration_gen.go
@@ -145,7 +145,7 @@ func (m *ExdDataFieldConfiguration) ToMesg(options *Options) proto.Message {
 			fields = append(fields, field)
 		}
 	}
-	if byte(m.DisplayType) != basetype.EnumInvalid {
+	if m.DisplayType != typedef.ExdDisplayTypeInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Uint8(byte(m.DisplayType))
 		fields = append(fields, field)

--- a/profile/mesgdef/exd_screen_configuration_gen.go
+++ b/profile/mesgdef/exd_screen_configuration_gen.go
@@ -21,7 +21,7 @@ type ExdScreenConfiguration struct {
 	ScreenIndex   uint8
 	FieldCount    uint8 // number of fields in screen
 	Layout        typedef.ExdLayout
-	ScreenEnabled bool
+	ScreenEnabled typedef.Bool
 
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
@@ -79,12 +79,12 @@ func (m *ExdScreenConfiguration) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.FieldCount)
 		fields = append(fields, field)
 	}
-	if byte(m.Layout) != basetype.EnumInvalid {
+	if m.Layout != typedef.ExdLayoutInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint8(byte(m.Layout))
 		fields = append(fields, field)
 	}
-	{
+	if m.ScreenEnabled < 2 {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = proto.Bool(m.ScreenEnabled)
 		fields = append(fields, field)
@@ -120,7 +120,7 @@ func (m *ExdScreenConfiguration) SetLayout(v typedef.ExdLayout) *ExdScreenConfig
 }
 
 // SetScreenEnabled sets ScreenEnabled value.
-func (m *ExdScreenConfiguration) SetScreenEnabled(v bool) *ExdScreenConfiguration {
+func (m *ExdScreenConfiguration) SetScreenEnabled(v typedef.Bool) *ExdScreenConfiguration {
 	m.ScreenEnabled = v
 	return m
 }

--- a/profile/mesgdef/exercise_title_gen.go
+++ b/profile/mesgdef/exercise_title_gen.go
@@ -69,12 +69,12 @@ func (m *ExerciseTitle) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumExerciseTitle}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	if uint16(m.ExerciseCategory) != basetype.Uint16Invalid {
+	if m.ExerciseCategory != typedef.ExerciseCategoryInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint16(uint16(m.ExerciseCategory))
 		fields = append(fields, field)

--- a/profile/mesgdef/field_capabilities_gen.go
+++ b/profile/mesgdef/field_capabilities_gen.go
@@ -71,17 +71,17 @@ func (m *FieldCapabilities) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumFieldCapabilities}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	if byte(m.File) != basetype.EnumInvalid {
+	if m.File != typedef.FileInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.File))
 		fields = append(fields, field)
 	}
-	if uint16(m.MesgNum) != basetype.Uint16Invalid {
+	if m.MesgNum != typedef.MesgNumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint16(uint16(m.MesgNum))
 		fields = append(fields, field)

--- a/profile/mesgdef/field_description_gen.go
+++ b/profile/mesgdef/field_description_gen.go
@@ -91,7 +91,7 @@ func (m *FieldDescription) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.FieldDefinitionNumber)
 		fields = append(fields, field)
 	}
-	if uint8(m.FitBaseTypeId) != basetype.Uint8Invalid {
+	if m.FitBaseTypeId != 255 {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint8(uint8(m.FitBaseTypeId))
 		fields = append(fields, field)
@@ -136,12 +136,12 @@ func (m *FieldDescription) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.Accumulate)
 		fields = append(fields, field)
 	}
-	if uint16(m.FitBaseUnitId) != basetype.Uint16Invalid {
+	if m.FitBaseUnitId != typedef.FitBaseUnitInvalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = proto.Uint16(uint16(m.FitBaseUnitId))
 		fields = append(fields, field)
 	}
-	if uint16(m.NativeMesgNum) != basetype.Uint16Invalid {
+	if m.NativeMesgNum != typedef.MesgNumInvalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = proto.Uint16(uint16(m.NativeMesgNum))
 		fields = append(fields, field)

--- a/profile/mesgdef/file_capabilities_gen.go
+++ b/profile/mesgdef/file_capabilities_gen.go
@@ -73,17 +73,17 @@ func (m *FileCapabilities) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumFileCapabilities}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	if byte(m.Type) != basetype.EnumInvalid {
+	if m.Type != typedef.FileInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Type))
 		fields = append(fields, field)
 	}
-	if uint8(m.Flags) != basetype.Uint8zInvalid {
+	if m.Flags != typedef.FileFlagsInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(uint8(m.Flags))
 		fields = append(fields, field)

--- a/profile/mesgdef/file_id_gen.go
+++ b/profile/mesgdef/file_id_gen.go
@@ -69,12 +69,12 @@ func (m *FileId) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumFileId}
 
-	if byte(m.Type) != basetype.EnumInvalid {
+	if m.Type != typedef.FileInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Type))
 		fields = append(fields, field)
 	}
-	if uint16(m.Manufacturer) != basetype.Uint16Invalid {
+	if m.Manufacturer != typedef.ManufacturerInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint16(uint16(m.Manufacturer))
 		fields = append(fields, field)

--- a/profile/mesgdef/goal_gen.go
+++ b/profile/mesgdef/goal_gen.go
@@ -29,9 +29,9 @@ type Goal struct {
 	Sport           typedef.Sport
 	SubSport        typedef.SubSport
 	Type            typedef.Goal
-	Repeat          bool
+	Repeat          typedef.Bool
 	Recurrence      typedef.GoalRecurrence
-	Enabled         bool
+	Enabled         typedef.Bool
 	Source          typedef.GoalSource
 
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
@@ -89,17 +89,17 @@ func (m *Goal) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumGoal}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	if byte(m.Sport) != basetype.EnumInvalid {
+	if m.Sport != typedef.SportInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Sport))
 		fields = append(fields, field)
 	}
-	if byte(m.SubSport) != basetype.EnumInvalid {
+	if m.SubSport != typedef.SubSportInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.SubSport))
 		fields = append(fields, field)
@@ -114,7 +114,7 @@ func (m *Goal) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.EndDate.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.Type) != basetype.EnumInvalid {
+	if m.Type != typedef.GoalInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Uint8(byte(m.Type))
 		fields = append(fields, field)
@@ -124,7 +124,7 @@ func (m *Goal) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.Value)
 		fields = append(fields, field)
 	}
-	{
+	if m.Repeat < 2 {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = proto.Bool(m.Repeat)
 		fields = append(fields, field)
@@ -134,7 +134,7 @@ func (m *Goal) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.TargetValue)
 		fields = append(fields, field)
 	}
-	if byte(m.Recurrence) != basetype.EnumInvalid {
+	if m.Recurrence != typedef.GoalRecurrenceInvalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = proto.Uint8(byte(m.Recurrence))
 		fields = append(fields, field)
@@ -144,12 +144,12 @@ func (m *Goal) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.RecurrenceValue)
 		fields = append(fields, field)
 	}
-	{
+	if m.Enabled < 2 {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = proto.Bool(m.Enabled)
 		fields = append(fields, field)
 	}
-	if byte(m.Source) != basetype.EnumInvalid {
+	if m.Source != typedef.GoalSourceInvalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = proto.Uint8(byte(m.Source))
 		fields = append(fields, field)
@@ -213,7 +213,7 @@ func (m *Goal) SetValue(v uint32) *Goal {
 }
 
 // SetRepeat sets Repeat value.
-func (m *Goal) SetRepeat(v bool) *Goal {
+func (m *Goal) SetRepeat(v typedef.Bool) *Goal {
 	m.Repeat = v
 	return m
 }
@@ -237,7 +237,7 @@ func (m *Goal) SetRecurrenceValue(v uint16) *Goal {
 }
 
 // SetEnabled sets Enabled value.
-func (m *Goal) SetEnabled(v bool) *Goal {
+func (m *Goal) SetEnabled(v typedef.Bool) *Goal {
 	m.Enabled = v
 	return m
 }

--- a/profile/mesgdef/hr_zone_gen.go
+++ b/profile/mesgdef/hr_zone_gen.go
@@ -67,7 +67,7 @@ func (m *HrZone) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumHrZone}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/hrm_profile_gen.go
+++ b/profile/mesgdef/hrm_profile_gen.go
@@ -20,8 +20,8 @@ import (
 type HrmProfile struct {
 	MessageIndex      typedef.MessageIndex
 	HrmAntId          uint16
-	Enabled           bool
-	LogHrv            bool
+	Enabled           typedef.Bool
+	LogHrv            typedef.Bool
 	HrmAntIdTransType uint8
 
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
@@ -71,12 +71,12 @@ func (m *HrmProfile) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumHrmProfile}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	{
+	if m.Enabled < 2 {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Bool(m.Enabled)
 		fields = append(fields, field)
@@ -86,7 +86,7 @@ func (m *HrmProfile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.HrmAntId)
 		fields = append(fields, field)
 	}
-	{
+	if m.LogHrv < 2 {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Bool(m.LogHrv)
 		fields = append(fields, field)
@@ -113,7 +113,7 @@ func (m *HrmProfile) SetMessageIndex(v typedef.MessageIndex) *HrmProfile {
 }
 
 // SetEnabled sets Enabled value.
-func (m *HrmProfile) SetEnabled(v bool) *HrmProfile {
+func (m *HrmProfile) SetEnabled(v typedef.Bool) *HrmProfile {
 	m.Enabled = v
 	return m
 }
@@ -125,7 +125,7 @@ func (m *HrmProfile) SetHrmAntId(v uint16) *HrmProfile {
 }
 
 // SetLogHrv sets LogHrv value.
-func (m *HrmProfile) SetLogHrv(v bool) *HrmProfile {
+func (m *HrmProfile) SetLogHrv(v typedef.Bool) *HrmProfile {
 	m.LogHrv = v
 	return m
 }

--- a/profile/mesgdef/hrv_status_summary_gen.go
+++ b/profile/mesgdef/hrv_status_summary_gen.go
@@ -115,7 +115,7 @@ func (m *HrvStatusSummary) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.BaselineBalancedUpper)
 		fields = append(fields, field)
 	}
-	if byte(m.Status) != basetype.EnumInvalid {
+	if m.Status != typedef.HrvStatusInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = proto.Uint8(byte(m.Status))
 		fields = append(fields, field)

--- a/profile/mesgdef/lap_gen.go
+++ b/profile/mesgdef/lap_gen.go
@@ -320,7 +320,7 @@ func (m *Lap) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumLap}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -330,12 +330,12 @@ func (m *Lap) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.Event) != basetype.EnumInvalid {
+	if m.Event != typedef.EventInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Event))
 		fields = append(fields, field)
 	}
-	if byte(m.EventType) != basetype.EnumInvalid {
+	if m.EventType != typedef.EventTypeInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.EventType))
 		fields = append(fields, field)
@@ -445,17 +445,17 @@ func (m *Lap) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.TotalDescent)
 		fields = append(fields, field)
 	}
-	if byte(m.Intensity) != basetype.EnumInvalid {
+	if m.Intensity != typedef.IntensityInvalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = proto.Uint8(byte(m.Intensity))
 		fields = append(fields, field)
 	}
-	if byte(m.LapTrigger) != basetype.EnumInvalid {
+	if m.LapTrigger != typedef.LapTriggerInvalid {
 		field := fac.CreateField(mesg.Num, 24)
 		field.Value = proto.Uint8(byte(m.LapTrigger))
 		fields = append(fields, field)
 	}
-	if byte(m.Sport) != basetype.EnumInvalid {
+	if m.Sport != typedef.SportInvalid {
 		field := fac.CreateField(mesg.Num, 25)
 		field.Value = proto.Uint8(byte(m.Sport))
 		fields = append(fields, field)
@@ -475,7 +475,7 @@ func (m *Lap) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.NormalizedPower)
 		fields = append(fields, field)
 	}
-	if uint16(m.LeftRightBalance) != basetype.Uint16Invalid {
+	if m.LeftRightBalance != typedef.LeftRightBalance100Invalid {
 		field := fac.CreateField(mesg.Num, 34)
 		field.Value = proto.Uint16(uint16(m.LeftRightBalance))
 		fields = append(fields, field)
@@ -490,12 +490,12 @@ func (m *Lap) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.AvgStrokeDistance)
 		fields = append(fields, field)
 	}
-	if byte(m.SwimStroke) != basetype.EnumInvalid {
+	if m.SwimStroke != typedef.SwimStrokeInvalid {
 		field := fac.CreateField(mesg.Num, 38)
 		field.Value = proto.Uint8(byte(m.SwimStroke))
 		fields = append(fields, field)
 	}
-	if byte(m.SubSport) != basetype.EnumInvalid {
+	if m.SubSport != typedef.SubSportInvalid {
 		field := fac.CreateField(mesg.Num, 39)
 		field.Value = proto.Uint8(byte(m.SubSport))
 		fields = append(fields, field)
@@ -620,7 +620,7 @@ func (m *Lap) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.MinHeartRate)
 		fields = append(fields, field)
 	}
-	if uint16(m.WktStepIndex) != basetype.Uint16Invalid {
+	if m.WktStepIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 71)
 		field.Value = proto.Uint16(uint16(m.WktStepIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/length_gen.go
+++ b/profile/mesgdef/length_gen.go
@@ -117,7 +117,7 @@ func (m *Length) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumLength}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -127,12 +127,12 @@ func (m *Length) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.Event) != basetype.EnumInvalid {
+	if m.Event != typedef.EventInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Event))
 		fields = append(fields, field)
 	}
-	if byte(m.EventType) != basetype.EnumInvalid {
+	if m.EventType != typedef.EventTypeInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.EventType))
 		fields = append(fields, field)
@@ -162,7 +162,7 @@ func (m *Length) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.AvgSpeed)
 		fields = append(fields, field)
 	}
-	if byte(m.SwimStroke) != basetype.EnumInvalid {
+	if m.SwimStroke != typedef.SwimStrokeInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = proto.Uint8(byte(m.SwimStroke))
 		fields = append(fields, field)
@@ -182,7 +182,7 @@ func (m *Length) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.TotalCalories)
 		fields = append(fields, field)
 	}
-	if byte(m.LengthType) != basetype.EnumInvalid {
+	if m.LengthType != typedef.LengthTypeInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = proto.Uint8(byte(m.LengthType))
 		fields = append(fields, field)

--- a/profile/mesgdef/max_met_data_gen.go
+++ b/profile/mesgdef/max_met_data_gen.go
@@ -26,7 +26,7 @@ type MaxMetData struct {
 	Sport          typedef.Sport
 	SubSport       typedef.SubSport
 	MaxMetCategory typedef.MaxMetCategory
-	CalibratedData bool                          // Indicates if calibrated data was used in the calculation
+	CalibratedData typedef.Bool                  // Indicates if calibrated data was used in the calculation
 	HrSource       typedef.MaxMetHeartRateSource // Indicates if the estimate was obtained using a chest strap or wrist heart rate
 	SpeedSource    typedef.MaxMetSpeedSource     // Indidcates if the estimate was obtained using onboard GPS or connected GPS
 
@@ -90,32 +90,32 @@ func (m *MaxMetData) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.Vo2Max)
 		fields = append(fields, field)
 	}
-	if byte(m.Sport) != basetype.EnumInvalid {
+	if m.Sport != typedef.SportInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = proto.Uint8(byte(m.Sport))
 		fields = append(fields, field)
 	}
-	if byte(m.SubSport) != basetype.EnumInvalid {
+	if m.SubSport != typedef.SubSportInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = proto.Uint8(byte(m.SubSport))
 		fields = append(fields, field)
 	}
-	if byte(m.MaxMetCategory) != basetype.EnumInvalid {
+	if m.MaxMetCategory != typedef.MaxMetCategoryInvalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = proto.Uint8(byte(m.MaxMetCategory))
 		fields = append(fields, field)
 	}
-	{
+	if m.CalibratedData < 2 {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = proto.Bool(m.CalibratedData)
 		fields = append(fields, field)
 	}
-	if byte(m.HrSource) != basetype.EnumInvalid {
+	if m.HrSource != typedef.MaxMetHeartRateSourceInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = proto.Uint8(byte(m.HrSource))
 		fields = append(fields, field)
 	}
-	if byte(m.SpeedSource) != basetype.EnumInvalid {
+	if m.SpeedSource != typedef.MaxMetSpeedSourceInvalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = proto.Uint8(byte(m.SpeedSource))
 		fields = append(fields, field)
@@ -195,7 +195,7 @@ func (m *MaxMetData) SetMaxMetCategory(v typedef.MaxMetCategory) *MaxMetData {
 // SetCalibratedData sets CalibratedData value.
 //
 // Indicates if calibrated data was used in the calculation
-func (m *MaxMetData) SetCalibratedData(v bool) *MaxMetData {
+func (m *MaxMetData) SetCalibratedData(v typedef.Bool) *MaxMetData {
 	m.CalibratedData = v
 	return m
 }

--- a/profile/mesgdef/memo_glob_gen.go
+++ b/profile/mesgdef/memo_glob_gen.go
@@ -83,12 +83,12 @@ func (m *MemoGlob) ToMesg(options *Options) proto.Message {
 		field.Value = proto.SliceUint8(m.Memo)
 		fields = append(fields, field)
 	}
-	if uint16(m.MesgNum) != basetype.Uint16Invalid {
+	if m.MesgNum != typedef.MesgNumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint16(uint16(m.MesgNum))
 		fields = append(fields, field)
 	}
-	if uint16(m.ParentIndex) != basetype.Uint16Invalid {
+	if m.ParentIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint16(uint16(m.ParentIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/mesg_capabilities_gen.go
+++ b/profile/mesgdef/mesg_capabilities_gen.go
@@ -71,22 +71,22 @@ func (m *MesgCapabilities) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumMesgCapabilities}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	if byte(m.File) != basetype.EnumInvalid {
+	if m.File != typedef.FileInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.File))
 		fields = append(fields, field)
 	}
-	if uint16(m.MesgNum) != basetype.Uint16Invalid {
+	if m.MesgNum != typedef.MesgNumInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint16(uint16(m.MesgNum))
 		fields = append(fields, field)
 	}
-	if byte(m.CountType) != basetype.EnumInvalid {
+	if m.CountType != typedef.MesgCountInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint8(byte(m.CountType))
 		fields = append(fields, field)

--- a/profile/mesgdef/met_zone_gen.go
+++ b/profile/mesgdef/met_zone_gen.go
@@ -70,7 +70,7 @@ func (m *MetZone) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumMetZone}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/monitoring_gen.go
+++ b/profile/mesgdef/monitoring_gen.go
@@ -149,7 +149,7 @@ func (m *Monitoring) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if uint8(m.DeviceIndex) != basetype.Uint8Invalid {
+	if m.DeviceIndex != typedef.DeviceIndexInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(uint8(m.DeviceIndex))
 		fields = append(fields, field)
@@ -174,7 +174,7 @@ func (m *Monitoring) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.ActiveTime)
 		fields = append(fields, field)
 	}
-	if byte(m.ActivityType) != basetype.EnumInvalid {
+	if m.ActivityType != typedef.ActivityTypeInvalid {
 		if expanded := m.IsExpandedField(5); !expanded || (expanded && options.IncludeExpandedFields) {
 			field := fac.CreateField(mesg.Num, 5)
 			field.Value = proto.Uint8(byte(m.ActivityType))
@@ -182,12 +182,12 @@ func (m *Monitoring) ToMesg(options *Options) proto.Message {
 			fields = append(fields, field)
 		}
 	}
-	if byte(m.ActivitySubtype) != basetype.EnumInvalid {
+	if m.ActivitySubtype != typedef.ActivitySubtypeInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = proto.Uint8(byte(m.ActivitySubtype))
 		fields = append(fields, field)
 	}
-	if byte(m.ActivityLevel) != basetype.EnumInvalid {
+	if m.ActivityLevel != typedef.ActivityLevelInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = proto.Uint8(byte(m.ActivityLevel))
 		fields = append(fields, field)

--- a/profile/mesgdef/ohr_settings_gen.go
+++ b/profile/mesgdef/ohr_settings_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 import (
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 	"time"
@@ -72,7 +71,7 @@ func (m *OhrSettings) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.Enabled) != basetype.EnumInvalid {
+	if m.Enabled != typedef.SwitchInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Enabled))
 		fields = append(fields, field)

--- a/profile/mesgdef/one_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/one_d_sensor_calibration_gen.go
@@ -80,7 +80,7 @@ func (m *OneDSensorCalibration) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.SensorType) != basetype.EnumInvalid {
+	if m.SensorType != typedef.SensorTypeInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.SensorType))
 		fields = append(fields, field)

--- a/profile/mesgdef/power_zone_gen.go
+++ b/profile/mesgdef/power_zone_gen.go
@@ -67,7 +67,7 @@ func (m *PowerZone) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumPowerZone}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/record_gen.go
+++ b/profile/mesgdef/record_gen.go
@@ -367,7 +367,7 @@ func (m *Record) ToMesg(options *Options) proto.Message {
 			fields = append(fields, field)
 		}
 	}
-	if uint8(m.LeftRightBalance) != basetype.Uint8Invalid {
+	if m.LeftRightBalance != typedef.LeftRightBalanceInvalid {
 		field := fac.CreateField(mesg.Num, 30)
 		field.Value = proto.Uint8(uint8(m.LeftRightBalance))
 		fields = append(fields, field)
@@ -402,7 +402,7 @@ func (m *Record) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.StanceTime)
 		fields = append(fields, field)
 	}
-	if byte(m.ActivityType) != basetype.EnumInvalid {
+	if m.ActivityType != typedef.ActivityTypeInvalid {
 		field := fac.CreateField(mesg.Num, 42)
 		field.Value = proto.Uint8(byte(m.ActivityType))
 		fields = append(fields, field)
@@ -437,7 +437,7 @@ func (m *Record) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.Time128)
 		fields = append(fields, field)
 	}
-	if byte(m.StrokeType) != basetype.EnumInvalid {
+	if m.StrokeType != typedef.StrokeTypeInvalid {
 		field := fac.CreateField(mesg.Num, 49)
 		field.Value = proto.Uint8(byte(m.StrokeType))
 		fields = append(fields, field)
@@ -492,7 +492,7 @@ func (m *Record) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.SaturatedHemoglobinPercentMax)
 		fields = append(fields, field)
 	}
-	if uint8(m.DeviceIndex) != basetype.Uint8Invalid {
+	if m.DeviceIndex != typedef.DeviceIndexInvalid {
 		field := fac.CreateField(mesg.Num, 62)
 		field.Value = proto.Uint8(uint8(m.DeviceIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/schedule_gen.go
+++ b/profile/mesgdef/schedule_gen.go
@@ -25,7 +25,7 @@ type Schedule struct {
 	SerialNumber  uint32               // Corresponds to file_id of scheduled workout / course.
 	Manufacturer  typedef.Manufacturer // Corresponds to file_id of scheduled workout / course.
 	Product       uint16               // Corresponds to file_id of scheduled workout / course.
-	Completed     bool                 // TRUE if this activity has been started
+	Completed     typedef.Bool         // TRUE if this activity has been started
 	Type          typedef.Schedule
 
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
@@ -77,7 +77,7 @@ func (m *Schedule) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSchedule}
 
-	if uint16(m.Manufacturer) != basetype.Uint16Invalid {
+	if m.Manufacturer != typedef.ManufacturerInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint16(uint16(m.Manufacturer))
 		fields = append(fields, field)
@@ -97,12 +97,12 @@ func (m *Schedule) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.TimeCreated.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	{
+	if m.Completed < 2 {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Bool(m.Completed)
 		fields = append(fields, field)
 	}
-	if byte(m.Type) != basetype.EnumInvalid {
+	if m.Type != typedef.ScheduleInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = proto.Uint8(byte(m.Type))
 		fields = append(fields, field)
@@ -181,7 +181,7 @@ func (m *Schedule) SetTimeCreated(v time.Time) *Schedule {
 // SetCompleted sets Completed value.
 //
 // TRUE if this activity has been started
-func (m *Schedule) SetCompleted(v bool) *Schedule {
+func (m *Schedule) SetCompleted(v typedef.Bool) *Schedule {
 	m.Completed = v
 	return m
 }

--- a/profile/mesgdef/sdm_profile_gen.go
+++ b/profile/mesgdef/sdm_profile_gen.go
@@ -23,8 +23,8 @@ type SdmProfile struct {
 	MessageIndex      typedef.MessageIndex
 	SdmAntId          uint16
 	SdmCalFactor      uint16 // Scale: 10; Units: %
-	Enabled           bool
-	SpeedSource       bool // Use footpod for speed source instead of GPS
+	Enabled           typedef.Bool
+	SpeedSource       typedef.Bool // Use footpod for speed source instead of GPS
 	SdmAntIdTransType uint8
 	OdometerRollover  uint8 // Rollover counter that can be used to extend the odometer
 
@@ -78,12 +78,12 @@ func (m *SdmProfile) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSdmProfile}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	{
+	if m.Enabled < 2 {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Bool(m.Enabled)
 		fields = append(fields, field)
@@ -103,7 +103,7 @@ func (m *SdmProfile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.Odometer)
 		fields = append(fields, field)
 	}
-	{
+	if m.SpeedSource < 2 {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Bool(m.SpeedSource)
 		fields = append(fields, field)
@@ -157,7 +157,7 @@ func (m *SdmProfile) SetMessageIndex(v typedef.MessageIndex) *SdmProfile {
 }
 
 // SetEnabled sets Enabled value.
-func (m *SdmProfile) SetEnabled(v bool) *SdmProfile {
+func (m *SdmProfile) SetEnabled(v typedef.Bool) *SdmProfile {
 	m.Enabled = v
 	return m
 }
@@ -215,7 +215,7 @@ func (m *SdmProfile) SetOdometerScaled(v float64) *SdmProfile {
 // SetSpeedSource sets SpeedSource value.
 //
 // Use footpod for speed source instead of GPS
-func (m *SdmProfile) SetSpeedSource(v bool) *SdmProfile {
+func (m *SdmProfile) SetSpeedSource(v typedef.Bool) *SdmProfile {
 	m.SpeedSource = v
 	return m
 }

--- a/profile/mesgdef/segment_file_gen.go
+++ b/profile/mesgdef/segment_file_gen.go
@@ -26,8 +26,8 @@ type SegmentFile struct {
 	LeaderActivityIdString []string                         // Array: [N]; String version of the activity ID of each leader in the segment file. 21 characters long for each ID, express in decimal
 	UserProfilePrimaryKey  uint32                           // Primary key of the user that created the segment file
 	MessageIndex           typedef.MessageIndex
-	Enabled                bool  // Enabled state of the segment file
-	DefaultRaceLeader      uint8 // Index for the Leader Board entry selected as the default race participant
+	Enabled                typedef.Bool // Enabled state of the segment file
+	DefaultRaceLeader      uint8        // Index for the Leader Board entry selected as the default race participant
 
 	// Developer Fields are dynamic, can't be mapped as struct's fields.
 	// [Added since protocol version 2.0]
@@ -84,7 +84,7 @@ func (m *SegmentFile) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSegmentFile}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -94,7 +94,7 @@ func (m *SegmentFile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.FileUuid)
 		fields = append(fields, field)
 	}
-	{
+	if m.Enabled < 2 {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = proto.Bool(m.Enabled)
 		fields = append(fields, field)
@@ -156,7 +156,7 @@ func (m *SegmentFile) SetFileUuid(v string) *SegmentFile {
 // SetEnabled sets Enabled value.
 //
 // Enabled state of the segment file
-func (m *SegmentFile) SetEnabled(v bool) *SegmentFile {
+func (m *SegmentFile) SetEnabled(v typedef.Bool) *SegmentFile {
 	m.Enabled = v
 	return m
 }

--- a/profile/mesgdef/segment_id_gen.go
+++ b/profile/mesgdef/segment_id_gen.go
@@ -23,7 +23,7 @@ type SegmentId struct {
 	UserProfilePrimaryKey uint32                       // Primary key of the user that created the segment
 	DeviceId              uint32                       // ID of the device that created the segment
 	Sport                 typedef.Sport                // Sport associated with the segment
-	Enabled               bool                         // Segment enabled for evaluation
+	Enabled               typedef.Bool                 // Segment enabled for evaluation
 	DefaultRaceLeader     uint8                        // Index for the Leader Board entry selected as the default race participant
 	DeleteStatus          typedef.SegmentDeleteStatus  // Indicates if any segments should be deleted
 	SelectionType         typedef.SegmentSelectionType // Indicates how the segment was selected to be sent to the device
@@ -89,12 +89,12 @@ func (m *SegmentId) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.Uuid)
 		fields = append(fields, field)
 	}
-	if byte(m.Sport) != basetype.EnumInvalid {
+	if m.Sport != typedef.SportInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint8(byte(m.Sport))
 		fields = append(fields, field)
 	}
-	{
+	if m.Enabled < 2 {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = proto.Bool(m.Enabled)
 		fields = append(fields, field)
@@ -114,12 +114,12 @@ func (m *SegmentId) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.DefaultRaceLeader)
 		fields = append(fields, field)
 	}
-	if byte(m.DeleteStatus) != basetype.EnumInvalid {
+	if m.DeleteStatus != typedef.SegmentDeleteStatusInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = proto.Uint8(byte(m.DeleteStatus))
 		fields = append(fields, field)
 	}
-	if byte(m.SelectionType) != basetype.EnumInvalid {
+	if m.SelectionType != typedef.SegmentSelectionTypeInvalid {
 		field := fac.CreateField(mesg.Num, 8)
 		field.Value = proto.Uint8(byte(m.SelectionType))
 		fields = append(fields, field)
@@ -161,7 +161,7 @@ func (m *SegmentId) SetSport(v typedef.Sport) *SegmentId {
 // SetEnabled sets Enabled value.
 //
 // Segment enabled for evaluation
-func (m *SegmentId) SetEnabled(v bool) *SegmentId {
+func (m *SegmentId) SetEnabled(v typedef.Bool) *SegmentId {
 	m.Enabled = v
 	return m
 }

--- a/profile/mesgdef/segment_lap_gen.go
+++ b/profile/mesgdef/segment_lap_gen.go
@@ -264,7 +264,7 @@ func (m *SegmentLap) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSegmentLap}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -274,12 +274,12 @@ func (m *SegmentLap) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.Event) != basetype.EnumInvalid {
+	if m.Event != typedef.EventInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Event))
 		fields = append(fields, field)
 	}
-	if byte(m.EventType) != basetype.EnumInvalid {
+	if m.EventType != typedef.EventTypeInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.EventType))
 		fields = append(fields, field)
@@ -389,7 +389,7 @@ func (m *SegmentLap) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.TotalDescent)
 		fields = append(fields, field)
 	}
-	if byte(m.Sport) != basetype.EnumInvalid {
+	if m.Sport != typedef.SportInvalid {
 		field := fac.CreateField(mesg.Num, 23)
 		field.Value = proto.Uint8(byte(m.Sport))
 		fields = append(fields, field)
@@ -429,12 +429,12 @@ func (m *SegmentLap) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.NormalizedPower)
 		fields = append(fields, field)
 	}
-	if uint16(m.LeftRightBalance) != basetype.Uint16Invalid {
+	if m.LeftRightBalance != typedef.LeftRightBalance100Invalid {
 		field := fac.CreateField(mesg.Num, 31)
 		field.Value = proto.Uint16(uint16(m.LeftRightBalance))
 		fields = append(fields, field)
 	}
-	if byte(m.SubSport) != basetype.EnumInvalid {
+	if m.SubSport != typedef.SubSportInvalid {
 		field := fac.CreateField(mesg.Num, 32)
 		field.Value = proto.Uint8(byte(m.SubSport))
 		fields = append(fields, field)
@@ -559,12 +559,12 @@ func (m *SegmentLap) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.ActiveTime)
 		fields = append(fields, field)
 	}
-	if uint16(m.WktStepIndex) != basetype.Uint16Invalid {
+	if m.WktStepIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 57)
 		field.Value = proto.Uint16(uint16(m.WktStepIndex))
 		fields = append(fields, field)
 	}
-	if byte(m.SportEvent) != basetype.EnumInvalid {
+	if m.SportEvent != typedef.SportEventInvalid {
 		field := fac.CreateField(mesg.Num, 58)
 		field.Value = proto.Uint8(byte(m.SportEvent))
 		fields = append(fields, field)
@@ -594,7 +594,7 @@ func (m *SegmentLap) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.AvgCombinedPedalSmoothness)
 		fields = append(fields, field)
 	}
-	if byte(m.Status) != basetype.EnumInvalid {
+	if m.Status != typedef.SegmentLapStatusInvalid {
 		field := fac.CreateField(mesg.Num, 64)
 		field.Value = proto.Uint8(byte(m.Status))
 		fields = append(fields, field)
@@ -689,7 +689,7 @@ func (m *SegmentLap) ToMesg(options *Options) proto.Message {
 		field.Value = proto.SliceUint8(m.MaxCadencePosition)
 		fields = append(fields, field)
 	}
-	if uint16(m.Manufacturer) != basetype.Uint16Invalid {
+	if m.Manufacturer != typedef.ManufacturerInvalid {
 		field := fac.CreateField(mesg.Num, 83)
 		field.Value = proto.Uint16(uint16(m.Manufacturer))
 		fields = append(fields, field)

--- a/profile/mesgdef/segment_leaderboard_entry_gen.go
+++ b/profile/mesgdef/segment_leaderboard_entry_gen.go
@@ -76,7 +76,7 @@ func (m *SegmentLeaderboardEntry) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSegmentLeaderboardEntry}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -86,7 +86,7 @@ func (m *SegmentLeaderboardEntry) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.Name)
 		fields = append(fields, field)
 	}
-	if byte(m.Type) != basetype.EnumInvalid {
+	if m.Type != typedef.SegmentLeaderboardTypeInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.Type))
 		fields = append(fields, field)

--- a/profile/mesgdef/segment_point_gen.go
+++ b/profile/mesgdef/segment_point_gen.go
@@ -86,7 +86,7 @@ func (m *SegmentPoint) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSegmentPoint}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/session_gen.go
+++ b/profile/mesgdef/session_gen.go
@@ -386,7 +386,7 @@ func (m *Session) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSession}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -396,12 +396,12 @@ func (m *Session) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.Event) != basetype.EnumInvalid {
+	if m.Event != typedef.EventInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Event))
 		fields = append(fields, field)
 	}
-	if byte(m.EventType) != basetype.EnumInvalid {
+	if m.EventType != typedef.EventTypeInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.EventType))
 		fields = append(fields, field)
@@ -421,12 +421,12 @@ func (m *Session) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Int32(m.StartPositionLong)
 		fields = append(fields, field)
 	}
-	if byte(m.Sport) != basetype.EnumInvalid {
+	if m.Sport != typedef.SportInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = proto.Uint8(byte(m.Sport))
 		fields = append(fields, field)
 	}
-	if byte(m.SubSport) != basetype.EnumInvalid {
+	if m.SubSport != typedef.SubSportInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = proto.Uint8(byte(m.SubSport))
 		fields = append(fields, field)
@@ -531,7 +531,7 @@ func (m *Session) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.EventGroup)
 		fields = append(fields, field)
 	}
-	if byte(m.Trigger) != basetype.EnumInvalid {
+	if m.Trigger != typedef.SessionTriggerInvalid {
 		field := fac.CreateField(mesg.Num, 28)
 		field.Value = proto.Uint8(byte(m.Trigger))
 		fields = append(fields, field)
@@ -576,7 +576,7 @@ func (m *Session) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.IntensityFactor)
 		fields = append(fields, field)
 	}
-	if uint16(m.LeftRightBalance) != basetype.Uint16Invalid {
+	if m.LeftRightBalance != typedef.LeftRightBalance100Invalid {
 		field := fac.CreateField(mesg.Num, 37)
 		field.Value = proto.Uint16(uint16(m.LeftRightBalance))
 		fields = append(fields, field)
@@ -601,7 +601,7 @@ func (m *Session) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.AvgStrokeDistance)
 		fields = append(fields, field)
 	}
-	if byte(m.SwimStroke) != basetype.EnumInvalid {
+	if m.SwimStroke != typedef.SwimStrokeInvalid {
 		field := fac.CreateField(mesg.Num, 43)
 		field.Value = proto.Uint8(byte(m.SwimStroke))
 		fields = append(fields, field)
@@ -616,7 +616,7 @@ func (m *Session) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.ThresholdPower)
 		fields = append(fields, field)
 	}
-	if byte(m.PoolLengthUnit) != basetype.EnumInvalid {
+	if m.PoolLengthUnit != typedef.DisplayMeasureInvalid {
 		field := fac.CreateField(mesg.Num, 46)
 		field.Value = proto.Uint8(byte(m.PoolLengthUnit))
 		fields = append(fields, field)

--- a/profile/mesgdef/set_gen.go
+++ b/profile/mesgdef/set_gen.go
@@ -111,7 +111,7 @@ func (m *Set) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.Weight)
 		fields = append(fields, field)
 	}
-	if uint8(m.SetType) != basetype.Uint8Invalid {
+	if m.SetType != typedef.SetTypeInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = proto.Uint8(uint8(m.SetType))
 		fields = append(fields, field)
@@ -131,17 +131,17 @@ func (m *Set) ToMesg(options *Options) proto.Message {
 		field.Value = proto.SliceUint16(m.CategorySubtype)
 		fields = append(fields, field)
 	}
-	if uint16(m.WeightDisplayUnit) != basetype.Uint16Invalid {
+	if m.WeightDisplayUnit != typedef.FitBaseUnitInvalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = proto.Uint16(uint16(m.WeightDisplayUnit))
 		fields = append(fields, field)
 	}
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	if uint16(m.WktStepIndex) != basetype.Uint16Invalid {
+	if m.WktStepIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = proto.Uint16(uint16(m.WktStepIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/slave_device_gen.go
+++ b/profile/mesgdef/slave_device_gen.go
@@ -65,7 +65,7 @@ func (m *SlaveDevice) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSlaveDevice}
 
-	if uint16(m.Manufacturer) != basetype.Uint16Invalid {
+	if m.Manufacturer != typedef.ManufacturerInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint16(uint16(m.Manufacturer))
 		fields = append(fields, field)

--- a/profile/mesgdef/sleep_level_gen.go
+++ b/profile/mesgdef/sleep_level_gen.go
@@ -9,7 +9,6 @@ package mesgdef
 import (
 	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 	"time"
@@ -72,7 +71,7 @@ func (m *SleepLevel) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.SleepLevel) != basetype.EnumInvalid {
+	if m.SleepLevel != typedef.SleepLevelInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.SleepLevel))
 		fields = append(fields, field)

--- a/profile/mesgdef/software_gen.go
+++ b/profile/mesgdef/software_gen.go
@@ -68,7 +68,7 @@ func (m *Software) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSoftware}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/speed_zone_gen.go
+++ b/profile/mesgdef/speed_zone_gen.go
@@ -68,7 +68,7 @@ func (m *SpeedZone) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSpeedZone}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/split_gen.go
+++ b/profile/mesgdef/split_gen.go
@@ -103,12 +103,12 @@ func (m *Split) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSplit}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	if byte(m.SplitType) != basetype.EnumInvalid {
+	if m.SplitType != typedef.SplitTypeInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.SplitType))
 		fields = append(fields, field)

--- a/profile/mesgdef/split_summary_gen.go
+++ b/profile/mesgdef/split_summary_gen.go
@@ -90,12 +90,12 @@ func (m *SplitSummary) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSplitSummary}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	if byte(m.SplitType) != basetype.EnumInvalid {
+	if m.SplitType != typedef.SplitTypeInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.SplitType))
 		fields = append(fields, field)

--- a/profile/mesgdef/spo2_data_gen.go
+++ b/profile/mesgdef/spo2_data_gen.go
@@ -86,7 +86,7 @@ func (m *Spo2Data) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.ReadingConfidence)
 		fields = append(fields, field)
 	}
-	if byte(m.Mode) != basetype.EnumInvalid {
+	if m.Mode != typedef.Spo2MeasurementTypeInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint8(byte(m.Mode))
 		fields = append(fields, field)

--- a/profile/mesgdef/sport_gen.go
+++ b/profile/mesgdef/sport_gen.go
@@ -67,12 +67,12 @@ func (m *Sport) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumSport}
 
-	if byte(m.Sport) != basetype.EnumInvalid {
+	if m.Sport != typedef.SportInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Sport))
 		fields = append(fields, field)
 	}
-	if byte(m.SubSport) != basetype.EnumInvalid {
+	if m.SubSport != typedef.SubSportInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.SubSport))
 		fields = append(fields, field)

--- a/profile/mesgdef/tank_summary_gen.go
+++ b/profile/mesgdef/tank_summary_gen.go
@@ -79,7 +79,7 @@ func (m *TankSummary) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if uint32(m.Sensor) != basetype.Uint32zInvalid {
+	if m.Sensor != typedef.AntChannelIdInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint32(uint32(m.Sensor))
 		fields = append(fields, field)

--- a/profile/mesgdef/tank_update_gen.go
+++ b/profile/mesgdef/tank_update_gen.go
@@ -75,7 +75,7 @@ func (m *TankUpdate) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if uint32(m.Sensor) != basetype.Uint32zInvalid {
+	if m.Sensor != typedef.AntChannelIdInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint32(uint32(m.Sensor))
 		fields = append(fields, field)

--- a/profile/mesgdef/three_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/three_d_sensor_calibration_gen.go
@@ -105,7 +105,7 @@ func (m *ThreeDSensorCalibration) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.SensorType) != basetype.EnumInvalid {
+	if m.SensorType != typedef.SensorTypeInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.SensorType))
 		fields = append(fields, field)

--- a/profile/mesgdef/time_in_zone_gen.go
+++ b/profile/mesgdef/time_in_zone_gen.go
@@ -103,12 +103,12 @@ func (m *TimeInZone) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if uint16(m.ReferenceMesg) != basetype.Uint16Invalid {
+	if m.ReferenceMesg != typedef.MesgNumInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint16(uint16(m.ReferenceMesg))
 		fields = append(fields, field)
 	}
-	if uint16(m.ReferenceIndex) != basetype.Uint16Invalid {
+	if m.ReferenceIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint16(uint16(m.ReferenceIndex))
 		fields = append(fields, field)
@@ -153,7 +153,7 @@ func (m *TimeInZone) ToMesg(options *Options) proto.Message {
 		field.Value = proto.SliceUint16(m.PowerZoneHighBoundary)
 		fields = append(fields, field)
 	}
-	if byte(m.HrCalcType) != basetype.EnumInvalid {
+	if m.HrCalcType != typedef.HrZoneCalcInvalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = proto.Uint8(byte(m.HrCalcType))
 		fields = append(fields, field)
@@ -173,7 +173,7 @@ func (m *TimeInZone) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.ThresholdHeartRate)
 		fields = append(fields, field)
 	}
-	if byte(m.PwrCalcType) != basetype.EnumInvalid {
+	if m.PwrCalcType != typedef.PwrZoneCalcInvalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = proto.Uint8(byte(m.PwrCalcType))
 		fields = append(fields, field)

--- a/profile/mesgdef/totals_gen.go
+++ b/profile/mesgdef/totals_gen.go
@@ -83,7 +83,7 @@ func (m *Totals) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumTotals}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -108,7 +108,7 @@ func (m *Totals) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.Calories)
 		fields = append(fields, field)
 	}
-	if byte(m.Sport) != basetype.EnumInvalid {
+	if m.Sport != typedef.SportInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = proto.Uint8(byte(m.Sport))
 		fields = append(fields, field)

--- a/profile/mesgdef/training_file_gen.go
+++ b/profile/mesgdef/training_file_gen.go
@@ -80,12 +80,12 @@ func (m *TrainingFile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.Type) != basetype.EnumInvalid {
+	if m.Type != typedef.FileInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Type))
 		fields = append(fields, field)
 	}
-	if uint16(m.Manufacturer) != basetype.Uint16Invalid {
+	if m.Manufacturer != typedef.ManufacturerInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint16(uint16(m.Manufacturer))
 		fields = append(fields, field)

--- a/profile/mesgdef/user_profile_gen.go
+++ b/profile/mesgdef/user_profile_gen.go
@@ -131,7 +131,7 @@ func (m *UserProfile) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumUserProfile}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -141,7 +141,7 @@ func (m *UserProfile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.FriendlyName)
 		fields = append(fields, field)
 	}
-	if byte(m.Gender) != basetype.EnumInvalid {
+	if m.Gender != typedef.GenderInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.Gender))
 		fields = append(fields, field)
@@ -161,17 +161,17 @@ func (m *UserProfile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.Weight)
 		fields = append(fields, field)
 	}
-	if byte(m.Language) != basetype.EnumInvalid {
+	if m.Language != typedef.LanguageInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = proto.Uint8(byte(m.Language))
 		fields = append(fields, field)
 	}
-	if byte(m.ElevSetting) != basetype.EnumInvalid {
+	if m.ElevSetting != typedef.DisplayMeasureInvalid {
 		field := fac.CreateField(mesg.Num, 6)
 		field.Value = proto.Uint8(byte(m.ElevSetting))
 		fields = append(fields, field)
 	}
-	if byte(m.WeightSetting) != basetype.EnumInvalid {
+	if m.WeightSetting != typedef.DisplayMeasureInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = proto.Uint8(byte(m.WeightSetting))
 		fields = append(fields, field)
@@ -196,42 +196,42 @@ func (m *UserProfile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.DefaultMaxHeartRate)
 		fields = append(fields, field)
 	}
-	if byte(m.HrSetting) != basetype.EnumInvalid {
+	if m.HrSetting != typedef.DisplayHeartInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = proto.Uint8(byte(m.HrSetting))
 		fields = append(fields, field)
 	}
-	if byte(m.SpeedSetting) != basetype.EnumInvalid {
+	if m.SpeedSetting != typedef.DisplayMeasureInvalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = proto.Uint8(byte(m.SpeedSetting))
 		fields = append(fields, field)
 	}
-	if byte(m.DistSetting) != basetype.EnumInvalid {
+	if m.DistSetting != typedef.DisplayMeasureInvalid {
 		field := fac.CreateField(mesg.Num, 14)
 		field.Value = proto.Uint8(byte(m.DistSetting))
 		fields = append(fields, field)
 	}
-	if byte(m.PowerSetting) != basetype.EnumInvalid {
+	if m.PowerSetting != typedef.DisplayPowerInvalid {
 		field := fac.CreateField(mesg.Num, 16)
 		field.Value = proto.Uint8(byte(m.PowerSetting))
 		fields = append(fields, field)
 	}
-	if byte(m.ActivityClass) != basetype.EnumInvalid {
+	if m.ActivityClass != typedef.ActivityClassInvalid {
 		field := fac.CreateField(mesg.Num, 17)
 		field.Value = proto.Uint8(byte(m.ActivityClass))
 		fields = append(fields, field)
 	}
-	if byte(m.PositionSetting) != basetype.EnumInvalid {
+	if m.PositionSetting != typedef.DisplayPositionInvalid {
 		field := fac.CreateField(mesg.Num, 18)
 		field.Value = proto.Uint8(byte(m.PositionSetting))
 		fields = append(fields, field)
 	}
-	if byte(m.TemperatureSetting) != basetype.EnumInvalid {
+	if m.TemperatureSetting != typedef.DisplayMeasureInvalid {
 		field := fac.CreateField(mesg.Num, 21)
 		field.Value = proto.Uint8(byte(m.TemperatureSetting))
 		fields = append(fields, field)
 	}
-	if uint16(m.LocalId) != basetype.Uint16Invalid {
+	if m.LocalId != typedef.UserLocalIdInvalid {
 		field := fac.CreateField(mesg.Num, 22)
 		field.Value = proto.Uint16(uint16(m.LocalId))
 		fields = append(fields, field)
@@ -249,17 +249,17 @@ func (m *UserProfile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.SliceUint8(copied[:])
 		fields = append(fields, field)
 	}
-	if uint32(m.WakeTime) != basetype.Uint32Invalid {
+	if m.WakeTime != typedef.LocaltimeIntoDayInvalid {
 		field := fac.CreateField(mesg.Num, 28)
 		field.Value = proto.Uint32(uint32(m.WakeTime))
 		fields = append(fields, field)
 	}
-	if uint32(m.SleepTime) != basetype.Uint32Invalid {
+	if m.SleepTime != typedef.LocaltimeIntoDayInvalid {
 		field := fac.CreateField(mesg.Num, 29)
 		field.Value = proto.Uint32(uint32(m.SleepTime))
 		fields = append(fields, field)
 	}
-	if byte(m.HeightSetting) != basetype.EnumInvalid {
+	if m.HeightSetting != typedef.DisplayMeasureInvalid {
 		field := fac.CreateField(mesg.Num, 30)
 		field.Value = proto.Uint8(byte(m.HeightSetting))
 		fields = append(fields, field)
@@ -274,7 +274,7 @@ func (m *UserProfile) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.UserWalkingStepLength)
 		fields = append(fields, field)
 	}
-	if byte(m.DepthSetting) != basetype.EnumInvalid {
+	if m.DepthSetting != typedef.DisplayMeasureInvalid {
 		field := fac.CreateField(mesg.Num, 47)
 		field.Value = proto.Uint8(byte(m.DepthSetting))
 		fields = append(fields, field)

--- a/profile/mesgdef/video_description_gen.go
+++ b/profile/mesgdef/video_description_gen.go
@@ -67,7 +67,7 @@ func (m *VideoDescription) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumVideoDescription}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/video_title_gen.go
+++ b/profile/mesgdef/video_title_gen.go
@@ -67,7 +67,7 @@ func (m *VideoTitle) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumVideoTitle}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)

--- a/profile/mesgdef/watchface_settings_gen.go
+++ b/profile/mesgdef/watchface_settings_gen.go
@@ -67,12 +67,12 @@ func (m *WatchfaceSettings) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumWatchfaceSettings}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	if byte(m.Mode) != basetype.EnumInvalid {
+	if m.Mode != typedef.WatchfaceModeInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Mode))
 		fields = append(fields, field)

--- a/profile/mesgdef/weather_alert_gen.go
+++ b/profile/mesgdef/weather_alert_gen.go
@@ -95,12 +95,12 @@ func (m *WeatherAlert) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.ExpireTime.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.Severity) != basetype.EnumInvalid {
+	if m.Severity != typedef.WeatherSeverityInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = proto.Uint8(byte(m.Severity))
 		fields = append(fields, field)
 	}
-	if byte(m.Type) != basetype.EnumInvalid {
+	if m.Type != typedef.WeatherSevereTypeInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Uint8(byte(m.Type))
 		fields = append(fields, field)

--- a/profile/mesgdef/weather_conditions_gen.go
+++ b/profile/mesgdef/weather_conditions_gen.go
@@ -102,7 +102,7 @@ func (m *WeatherConditions) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if byte(m.WeatherReport) != basetype.EnumInvalid {
+	if m.WeatherReport != typedef.WeatherReportInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.WeatherReport))
 		fields = append(fields, field)
@@ -112,7 +112,7 @@ func (m *WeatherConditions) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Int8(m.Temperature)
 		fields = append(fields, field)
 	}
-	if byte(m.Condition) != basetype.EnumInvalid {
+	if m.Condition != typedef.WeatherStatusInvalid {
 		field := fac.CreateField(mesg.Num, 2)
 		field.Value = proto.Uint8(byte(m.Condition))
 		fields = append(fields, field)
@@ -162,7 +162,7 @@ func (m *WeatherConditions) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Int32(m.ObservedLocationLong)
 		fields = append(fields, field)
 	}
-	if byte(m.DayOfWeek) != basetype.EnumInvalid {
+	if m.DayOfWeek != typedef.DayOfWeekInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = proto.Uint8(byte(m.DayOfWeek))
 		fields = append(fields, field)

--- a/profile/mesgdef/weight_scale_gen.go
+++ b/profile/mesgdef/weight_scale_gen.go
@@ -97,7 +97,7 @@ func (m *WeightScale) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(uint32(m.Timestamp.Sub(datetime.Epoch()).Seconds()))
 		fields = append(fields, field)
 	}
-	if uint16(m.Weight) != basetype.Uint16Invalid {
+	if m.Weight != typedef.WeightInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint16(uint16(m.Weight))
 		fields = append(fields, field)
@@ -152,7 +152,7 @@ func (m *WeightScale) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint8(m.VisceralFatRating)
 		fields = append(fields, field)
 	}
-	if uint16(m.UserProfileIndex) != basetype.Uint16Invalid {
+	if m.UserProfileIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 12)
 		field.Value = proto.Uint16(uint16(m.UserProfileIndex))
 		fields = append(fields, field)
@@ -180,7 +180,7 @@ func (m *WeightScale) TimestampUint32() uint32 { return datetime.ToUint32(m.Time
 //
 // Scale: 100; Units: kg
 func (m *WeightScale) WeightScaled() float64 {
-	if uint16(m.Weight) == basetype.Uint16Invalid {
+	if m.Weight == typedef.WeightInvalid {
 		return math.Float64frombits(basetype.Float64Invalid)
 	}
 	return float64(m.Weight)/100 - 0

--- a/profile/mesgdef/workout_gen.go
+++ b/profile/mesgdef/workout_gen.go
@@ -78,17 +78,17 @@ func (m *Workout) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumWorkout}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	if byte(m.Sport) != basetype.EnumInvalid {
+	if m.Sport != typedef.SportInvalid {
 		field := fac.CreateField(mesg.Num, 4)
 		field.Value = proto.Uint8(byte(m.Sport))
 		fields = append(fields, field)
 	}
-	if uint32(m.Capabilities) != basetype.Uint32zInvalid {
+	if m.Capabilities != typedef.WorkoutCapabilitiesInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = proto.Uint32(uint32(m.Capabilities))
 		fields = append(fields, field)
@@ -103,7 +103,7 @@ func (m *Workout) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.WktName)
 		fields = append(fields, field)
 	}
-	if byte(m.SubSport) != basetype.EnumInvalid {
+	if m.SubSport != typedef.SubSportInvalid {
 		field := fac.CreateField(mesg.Num, 11)
 		field.Value = proto.Uint8(byte(m.SubSport))
 		fields = append(fields, field)
@@ -113,7 +113,7 @@ func (m *Workout) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.PoolLength)
 		fields = append(fields, field)
 	}
-	if byte(m.PoolLengthUnit) != basetype.EnumInvalid {
+	if m.PoolLengthUnit != typedef.DisplayMeasureInvalid {
 		field := fac.CreateField(mesg.Num, 15)
 		field.Value = proto.Uint8(byte(m.PoolLengthUnit))
 		fields = append(fields, field)

--- a/profile/mesgdef/workout_session_gen.go
+++ b/profile/mesgdef/workout_session_gen.go
@@ -76,17 +76,17 @@ func (m *WorkoutSession) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumWorkoutSession}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
 	}
-	if byte(m.Sport) != basetype.EnumInvalid {
+	if m.Sport != typedef.SportInvalid {
 		field := fac.CreateField(mesg.Num, 0)
 		field.Value = proto.Uint8(byte(m.Sport))
 		fields = append(fields, field)
 	}
-	if byte(m.SubSport) != basetype.EnumInvalid {
+	if m.SubSport != typedef.SubSportInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.SubSport))
 		fields = append(fields, field)
@@ -106,7 +106,7 @@ func (m *WorkoutSession) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.PoolLength)
 		fields = append(fields, field)
 	}
-	if byte(m.PoolLengthUnit) != basetype.EnumInvalid {
+	if m.PoolLengthUnit != typedef.DisplayMeasureInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = proto.Uint8(byte(m.PoolLengthUnit))
 		fields = append(fields, field)

--- a/profile/mesgdef/workout_step_gen.go
+++ b/profile/mesgdef/workout_step_gen.go
@@ -100,7 +100,7 @@ func (m *WorkoutStep) ToMesg(options *Options) proto.Message {
 
 	mesg := proto.Message{Num: typedef.MesgNumWorkoutStep}
 
-	if uint16(m.MessageIndex) != basetype.Uint16Invalid {
+	if m.MessageIndex != typedef.MessageIndexInvalid {
 		field := fac.CreateField(mesg.Num, 254)
 		field.Value = proto.Uint16(uint16(m.MessageIndex))
 		fields = append(fields, field)
@@ -110,7 +110,7 @@ func (m *WorkoutStep) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.WktStepName)
 		fields = append(fields, field)
 	}
-	if byte(m.DurationType) != basetype.EnumInvalid {
+	if m.DurationType != typedef.WktStepDurationInvalid {
 		field := fac.CreateField(mesg.Num, 1)
 		field.Value = proto.Uint8(byte(m.DurationType))
 		fields = append(fields, field)
@@ -120,7 +120,7 @@ func (m *WorkoutStep) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.DurationValue)
 		fields = append(fields, field)
 	}
-	if byte(m.TargetType) != basetype.EnumInvalid {
+	if m.TargetType != typedef.WktStepTargetInvalid {
 		field := fac.CreateField(mesg.Num, 3)
 		field.Value = proto.Uint8(byte(m.TargetType))
 		fields = append(fields, field)
@@ -140,7 +140,7 @@ func (m *WorkoutStep) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint32(m.CustomTargetValueHigh)
 		fields = append(fields, field)
 	}
-	if byte(m.Intensity) != basetype.EnumInvalid {
+	if m.Intensity != typedef.IntensityInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = proto.Uint8(byte(m.Intensity))
 		fields = append(fields, field)
@@ -150,12 +150,12 @@ func (m *WorkoutStep) ToMesg(options *Options) proto.Message {
 		field.Value = proto.String(m.Notes)
 		fields = append(fields, field)
 	}
-	if byte(m.Equipment) != basetype.EnumInvalid {
+	if m.Equipment != typedef.WorkoutEquipmentInvalid {
 		field := fac.CreateField(mesg.Num, 9)
 		field.Value = proto.Uint8(byte(m.Equipment))
 		fields = append(fields, field)
 	}
-	if uint16(m.ExerciseCategory) != basetype.Uint16Invalid {
+	if m.ExerciseCategory != typedef.ExerciseCategoryInvalid {
 		field := fac.CreateField(mesg.Num, 10)
 		field.Value = proto.Uint16(uint16(m.ExerciseCategory))
 		fields = append(fields, field)
@@ -170,12 +170,12 @@ func (m *WorkoutStep) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.ExerciseWeight)
 		fields = append(fields, field)
 	}
-	if uint16(m.WeightDisplayUnit) != basetype.Uint16Invalid {
+	if m.WeightDisplayUnit != typedef.FitBaseUnitInvalid {
 		field := fac.CreateField(mesg.Num, 13)
 		field.Value = proto.Uint16(uint16(m.WeightDisplayUnit))
 		fields = append(fields, field)
 	}
-	if byte(m.SecondaryTargetType) != basetype.EnumInvalid {
+	if m.SecondaryTargetType != typedef.WktStepTargetInvalid {
 		field := fac.CreateField(mesg.Num, 19)
 		field.Value = proto.Uint8(byte(m.SecondaryTargetType))
 		fields = append(fields, field)

--- a/profile/mesgdef/zones_target_gen.go
+++ b/profile/mesgdef/zones_target_gen.go
@@ -86,12 +86,12 @@ func (m *ZonesTarget) ToMesg(options *Options) proto.Message {
 		field.Value = proto.Uint16(m.FunctionalThresholdPower)
 		fields = append(fields, field)
 	}
-	if byte(m.HrCalcType) != basetype.EnumInvalid {
+	if m.HrCalcType != typedef.HrZoneCalcInvalid {
 		field := fac.CreateField(mesg.Num, 5)
 		field.Value = proto.Uint8(byte(m.HrCalcType))
 		fields = append(fields, field)
 	}
-	if byte(m.PwrCalcType) != basetype.EnumInvalid {
+	if m.PwrCalcType != typedef.PwrZoneCalcInvalid {
 		field := fac.CreateField(mesg.Num, 7)
 		field.Value = proto.Uint8(byte(m.PwrCalcType))
 		fields = append(fields, field)

--- a/profile/typedef/bool.go
+++ b/profile/typedef/bool.go
@@ -1,0 +1,46 @@
+package typedef
+
+import (
+	"strconv"
+)
+
+// Bool is a special type to accommodate nullable/unset boolean value.
+// 0 is false and 1 is true, other value should be treated as invalid 255.
+type Bool uint8
+
+const (
+	BoolFalse   Bool = 0   // false
+	BoolTrue    Bool = 1   // true
+	BoolInvalid Bool = 255 // invalid or unset
+)
+
+func (b Bool) Uint8() uint8 { return uint8(b) }
+
+func (b Bool) String() string {
+	switch b {
+	case BoolTrue:
+		return "true"
+	case BoolFalse:
+		return "false"
+	}
+	return "BoolInvalid(" + strconv.Itoa(int(b)) + ")"
+}
+
+// BoolFromString parse string into Bool constant it represents, return BoolInvalid if not found.
+func BoolFromString(s string) Bool {
+	switch s {
+	case "true":
+		return BoolTrue
+	case "false":
+		return BoolFalse
+	}
+	return BoolInvalid
+}
+
+// BoolFromBool parse bool value into Bool.
+func BoolFromBool(t bool) Bool {
+	if t {
+		return BoolTrue
+	}
+	return BoolFalse
+}

--- a/profile/typedef/bool_test.go
+++ b/profile/typedef/bool_test.go
@@ -1,0 +1,76 @@
+package typedef
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBoolString(t *testing.T) {
+	tt := []struct {
+		name     string
+		value    Bool
+		expected string
+	}{
+		{name: "true", value: BoolTrue, expected: "true"},
+		{name: "true", value: BoolFalse, expected: "false"},
+		{name: "invalid", value: BoolInvalid, expected: "BoolInvalid(255)"},
+		{name: "2", value: Bool(2), expected: "BoolInvalid(2)"},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
+			v := tc.value.String()
+			if v != tc.expected {
+				t.Fatalf("expected: %q, got: %q", tc.expected, v)
+			}
+		})
+	}
+}
+
+func TestBoolFromString(t *testing.T) {
+	tt := []struct {
+		name     string
+		value    string
+		expected Bool
+	}{
+		{name: "true", value: "true", expected: BoolTrue},
+		{name: "false", value: "false", expected: BoolFalse},
+		{name: "invalid", value: "invalid", expected: BoolInvalid},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
+			v := BoolFromString(tc.value)
+			if v != tc.expected {
+				t.Fatalf("expected: %v, got: %v", tc.expected, v)
+			}
+		})
+	}
+}
+
+func TestBoolFromBool(t *testing.T) {
+	tt := []struct {
+		name     string
+		value    bool
+		expected Bool
+	}{
+		{name: "true", value: true, expected: BoolTrue},
+		{name: "false", value: false, expected: BoolFalse},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
+			v := BoolFromBool(tc.value)
+			if v != tc.expected {
+				t.Fatalf("expected: %v, got: %v", tc.expected, v)
+			}
+		})
+	}
+}
+
+func TestBoolUint8(t *testing.T) {
+	v := BoolTrue
+	if expected := uint8(v); expected != v.Uint8() {
+		t.Fatalf("expected: %v, got: %v", expected, v.Uint8())
+	}
+}

--- a/proto/value_marshal.go
+++ b/proto/value_marshal.go
@@ -18,19 +18,20 @@ func (v Value) MarshalAppend(b []byte, arch byte) ([]byte, error) {
 	// NOTE: The size of the resulting bytes should align with Sizeof.
 	switch v.Type() {
 	case TypeBool:
-		if v.Bool() {
-			b = append(b, 1)
+		val := v.Bool()
+		if val > 1 {
+			b = append(b, 255)
 		} else {
-			b = append(b, 0)
+			b = append(b, byte(val))
 		}
 		return b, nil
 	case TypeSliceBool:
 		vals := v.SliceBool()
 		for i := range vals {
-			if vals[i] {
-				b = append(b, 1)
+			if vals[i] > 1 {
+				b = append(b, 255)
 			} else {
-				b = append(b, 0)
+				b = append(b, byte(vals[i]))
 			}
 		}
 		return b, nil

--- a/proto/value_marshal_test.go
+++ b/proto/value_marshal_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/muktihari/fit/profile/typedef"
 )
 
 func TestValueMarshalAppend(t *testing.T) {
@@ -21,8 +22,9 @@ func TestValueMarshalAppend(t *testing.T) {
 		value Value
 		err   error
 	}{
-		{value: Bool(false)},
-		{value: Bool(true)},
+		{value: Bool(typedef.BoolFalse)},
+		{value: Bool(typedef.BoolTrue)},
+		{value: Bool(typedef.BoolInvalid)},
 		{value: Int8(-19)},
 		{value: Uint8(129)},
 		{value: Int16(1429)},
@@ -40,7 +42,8 @@ func TestValueMarshalAppend(t *testing.T) {
 		{value: Float64(-897912398989898.546734)},
 		{value: String("FIT SDK")},
 		{value: String("")},
-		{value: SliceBool([]bool{true, false})},
+		{value: SliceBool([]typedef.Bool{typedef.BoolTrue, typedef.BoolFalse})},
+		{value: SliceBool([]typedef.Bool{typedef.BoolTrue, typedef.BoolInvalid})},
 		{value: SliceUint8([]byte{1, 2})},
 		{value: SliceUint8([]uint8{1, 2})},
 		{value: SliceInt8([]int8{-19})},

--- a/proto/value_unmarshal.go
+++ b/proto/value_unmarshal.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/muktihari/fit/profile"
 	"github.com/muktihari/fit/profile/basetype"
+	"github.com/muktihari/fit/profile/typedef"
 )
 
 // UnmarshalValue unmarshals b into a proto.Value.
@@ -31,13 +32,13 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 		basetype.Uint8, basetype.Uint8z:
 		if profileType == profile.Bool { // Special Case
 			if isArray {
-				vals := make([]bool, 0, len(b))
+				vals := make([]typedef.Bool, 0, len(b))
 				for i := range b {
-					vals = append(vals, b[i] == 1)
+					vals = append(vals, typedef.Bool(b[i]))
 				}
 				return SliceBool(vals), nil
 			}
-			return Bool(b[0] == 1), nil
+			return Bool(typedef.Bool(b[0])), nil
 		}
 		if isArray {
 			vals := make([]byte, len(b))

--- a/proto/value_unmarshal_test.go
+++ b/proto/value_unmarshal_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/profile"
 	"github.com/muktihari/fit/profile/basetype"
+	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 )
 
@@ -78,8 +79,8 @@ func TestUnmarshalValue(t *testing.T) {
 			isArray:  true,
 		},
 		{value: proto.Int8(0), baseType: basetype.FromString("invalid"), err: proto.ErrTypeNotSupported},
-		{value: proto.Bool(true), baseType: basetype.Enum, profileType: profile.Bool},
-		{value: proto.SliceBool([]bool{false, true, false}), baseType: basetype.Enum, profileType: profile.Bool, isArray: true},
+		{value: proto.Bool(typedef.BoolTrue), baseType: basetype.Enum, profileType: profile.Bool},
+		{value: proto.SliceBool([]typedef.Bool{typedef.BoolFalse, typedef.BoolTrue, typedef.BoolFalse}), baseType: basetype.Enum, profileType: profile.Bool, isArray: true},
 	}
 
 	for i, tc := range tt {
@@ -141,7 +142,7 @@ func TestUnmarshalValueSliceAlloc(t *testing.T) {
 		value       proto.Value
 		profileType profile.ProfileType
 	}{
-		{value: proto.SliceBool(make([]bool, 256)), profileType: profile.Bool},
+		{value: proto.SliceBool(make([]typedef.Bool, 256)), profileType: profile.Bool},
 		{value: proto.SliceUint8(make([]uint8, 256)), profileType: profile.Uint8},
 		{value: proto.SliceInt8(make([]int8, 256)), profileType: profile.Sint8},
 		{value: proto.SliceUint8(make([]uint8, 256)), profileType: profile.Uint8},


### PR DESCRIPTION
When using primitive bool we can only represent an exist value: **true** and **false**, and we can't represent invalid value for boolean that way. Since a boolean value is typically used for configuration settings, using **false** as an invalid value is incorrect. How can we indicate that the user may not have set the value or the value may only be set when used?. For this reason, implementing typedef.Bool to accommodate nullable/unset boolean value becomes necessary.