### PR TITLE
refactor!: decoder sentinel errors

### DIFF
--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -495,7 +495,7 @@ func TestCheckIntegrity(t *testing.T) {
 				return bytes.NewReader(b)
 			}(),
 			n:   0,
-			err: ErrDataSizeZero,
+			err: ErrNotFITFile,
 		},
 		{
 			name: "read message return error",
@@ -1392,7 +1392,7 @@ func TestDecodeMessageDefinition(t *testing.T) {
 				})
 			}(),
 			header: proto.MesgDefinitionMask,
-			err:    ErrInvalidBaseType,
+			err:    errInvalidBaseType,
 		},
 	}
 
@@ -1626,22 +1626,6 @@ func TestDecodeFields(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			name: "decode fields timestamp not uint32",
-			r:    fnReaderOK,
-			mesgdef: &proto.MessageDefinition{
-				Header:  proto.MesgDefinitionMask,
-				MesgNum: 68,
-				FieldDefinitions: []proto.FieldDefinition{
-					{
-						Num:      proto.FieldNumTimestamp,
-						Size:     1,
-						BaseType: basetype.Uint8,
-					},
-				},
-			},
-			err: ErrFieldValueTypeMismatch,
 		},
 		{
 			name: "decode fields accumulate distance",
@@ -2266,7 +2250,7 @@ func TestDecodeDeveloperFields(t *testing.T) {
 				},
 			},
 			mesg: &proto.Message{},
-			err:  ErrInvalidBaseType,
+			err:  errInvalidBaseType,
 		},
 	}
 


### PR DESCRIPTION
- Now we only keep value when fieldNum is 253 and the value type is uint32. We no longer return  **ErrFieldValueTypeMismatch** error when the fieldNum 253 is not an uint32, as there is no documentation that say 253 must be for timestamp and we found some old message may have timestamp for other fieldNum such as **CoursePoint** and **Set** messages, although these messages may be created before the rule was put in place. We think that maybe some manufacturers use this fieldNum for something else as well. We don't think returning error will add any value.

- Some errors are deleted or make private;  **ErrDataSizeZero** is deleted and an **ErrNotFITFile** will be returned instead when **FileHeader's DataSize** is zero.