### PR TITLE
fix: handle compressed timestamp

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -534,7 +534,10 @@ func (d *Decoder) decodeMessage() error {
 		return err
 	}
 	header := b[0]
-	if (header & proto.MesgDefinitionMask) == proto.MesgDefinitionMask {
+
+	// NOTE: Compressed Timestamp Header Bit 5-6 is the local message type.
+	// Bit 6 overlap with MesgDefinitionMask; It's a message definition only if Bit 7 is zero.
+	if (header & (proto.MesgCompressedHeaderMask | proto.MesgDefinitionMask)) == proto.MesgDefinitionMask {
 		return d.decodeMessageDefinition(header)
 	}
 	return d.decodeMessageData(header)

--- a/decoder/raw.go
+++ b/decoder/raw.go
@@ -136,7 +136,7 @@ func (d *RawDecoder) Decode(r io.Reader, fn func(flag RawFlag, b []byte) error) 
 			}
 
 			// 2. a. Decode Message Definition
-			if (d.BytesArray[0] & proto.MesgDefinitionMask) == proto.MesgDefinitionMask {
+			if (d.BytesArray[0] & (proto.MesgCompressedHeaderMask | proto.MesgDefinitionMask)) == proto.MesgDefinitionMask {
 				const fixedSize = uint16(6) //  Header + Reserved + Architecture + MesgNum (2 bytes) + n Fields
 				nr, err = io.ReadFull(r, d.BytesArray[1:fixedSize])
 				n += int64(nr)


### PR DESCRIPTION
- decoder: Compressed timestamp header message has local message type 0-3 positioned at bit 5-6 (note: normal message has local message type 0-15 positioned at bit 0-4). Bit 6 overlap with proto.MesgDefinitionMask, the only thing that differentiate them is the bit 7.  So we must take bit 7 into consideration when checking the header type, is it message definition or is it message data. Since only message has value at header bit 7, we we must include proto.MesgCompressedHeaderMask to do mask, only then we can get the correct header type.
- encoder: Previous implementation of timestamp compression has a bug, where we always has timestampReference 1. It should  have only been updated when Rollover Event occurs.