### PR TITLE
feat!: encoder compress timestamp with multiple local message type

### DIFF
--- a/cmd/fitactivity/main.go
+++ b/cmd/fitactivity/main.go
@@ -416,10 +416,10 @@ loop:
 	}
 
 	headerInfo := fmt.Sprintf("interleave: %d", interleave)
-	headerOption := encoder.WithNormalHeader(byte(interleave))
+	headerOption := encoder.WithHeaderOption(encoder.HeaderOptionNormal, byte(interleave))
 	if compress {
 		headerInfo = "compress"
-		headerOption = encoder.WithCompressedTimestampHeader()
+		headerOption = encoder.WithHeaderOption(encoder.HeaderOptionCompressedTimestamp, 0)
 	}
 
 	select {
@@ -511,10 +511,10 @@ func conceal(ctx context.Context, fs *flag.FlagSet, args []string) (err error) {
 	}
 
 	headerInfo := fmt.Sprintf("interleave: %d", interleave)
-	headerOption := encoder.WithNormalHeader(byte(interleave))
+	headerOption := encoder.WithHeaderOption(encoder.HeaderOptionNormal, byte(interleave))
 	if compress {
 		headerInfo = "compress"
-		headerOption = encoder.WithCompressedTimestampHeader()
+		headerOption = encoder.WithHeaderOption(encoder.HeaderOptionCompressedTimestamp, 0)
 	}
 
 	fmt.Fprintf(os.Stderr, "- Concealing %d file(s) [first: %s m; last: %s m]\n",
@@ -699,10 +699,10 @@ func reduce(ctx context.Context, fs *flag.FlagSet, args []string) (err error) {
 	}
 
 	headerInfo := fmt.Sprintf("interleave: %d", interleave)
-	headerOption := encoder.WithNormalHeader(byte(interleave))
+	headerOption := encoder.WithHeaderOption(encoder.HeaderOptionNormal, byte(interleave))
 	if compress {
 		headerInfo = "compress"
-		headerOption = encoder.WithCompressedTimestampHeader()
+		headerOption = encoder.WithHeaderOption(encoder.HeaderOptionCompressedTimestamp, 0)
 	}
 
 	fmt.Fprintf(os.Stderr, "- Reducing %d file(s) [%s]\n",
@@ -876,10 +876,10 @@ func remove(ctx context.Context, fs *flag.FlagSet, args []string) (err error) {
 	}
 
 	headerInfo := fmt.Sprintf("interleave: %d", interleave)
-	headerOption := encoder.WithNormalHeader(byte(interleave))
+	headerOption := encoder.WithHeaderOption(encoder.HeaderOptionNormal, byte(interleave))
 	if compress {
 		headerInfo = "compress"
-		headerOption = encoder.WithCompressedTimestampHeader()
+		headerOption = encoder.WithHeaderOption(encoder.HeaderOptionCompressedTimestamp, 0)
 	}
 
 	var nameSuffix string

--- a/cmd/fitconv/fitcsv/csv_to_fit.go
+++ b/cmd/fitconv/fitcsv/csv_to_fit.go
@@ -48,7 +48,7 @@ type CSVToFITConv struct {
 func NewCSVToFITConv(fitWriter io.Writer, csvReader io.Reader) *CSVToFITConv {
 	enc := encoder.New(fitWriter,
 		encoder.WithProtocolVersion(proto.V2),
-		encoder.WithNormalHeader(15),
+		encoder.WithHeaderOption(encoder.HeaderOptionNormal, 15),
 	)
 
 	csvr := csv.NewReader(csvReader)

--- a/encoder/encoder_bench_test.go
+++ b/encoder/encoder_bench_test.go
@@ -134,20 +134,20 @@ func BenchmarkEncode(b *testing.B) {
 	})
 	b.Run("normal header 15", func(b *testing.B) {
 		b.StopTimer()
-		enc := encoder.New(io.Discard, encoder.WithNormalHeader(15))
+		enc := encoder.New(io.Discard, encoder.WithHeaderOption(encoder.HeaderOptionNormal, 15))
 		b.StartTimer()
 		for i := 0; i < b.N; i++ {
 			_ = enc.Encode(fit)
-			enc.Reset(io.Discard, encoder.WithNormalHeader(15))
+			enc.Reset(io.Discard, encoder.WithHeaderOption(encoder.HeaderOptionNormal, 15))
 		}
 	})
 	b.Run("compressed timestamp header", func(b *testing.B) {
 		b.StopTimer()
-		enc := encoder.New(io.Discard, encoder.WithCompressedTimestampHeader())
+		enc := encoder.New(io.Discard, encoder.WithHeaderOption(encoder.HeaderOptionCompressedTimestamp, 0))
 		b.StartTimer()
 		for i := 0; i < b.N; i++ {
 			_ = enc.Encode(fit)
-			enc.Reset(io.Discard, encoder.WithCompressedTimestampHeader())
+			enc.Reset(io.Discard, encoder.WithHeaderOption(encoder.HeaderOptionCompressedTimestamp, 0))
 		}
 	})
 }
@@ -168,20 +168,20 @@ func BenchmarkEncodeWriterAt(b *testing.B) {
 	})
 	b.Run("normal header 15", func(b *testing.B) {
 		b.StopTimer()
-		enc := encoder.New(DiscardAt, encoder.WithNormalHeader(15))
+		enc := encoder.New(DiscardAt, encoder.WithHeaderOption(encoder.HeaderOptionNormal, 15))
 		b.StartTimer()
 		for i := 0; i < b.N; i++ {
 			_ = enc.Encode(fit)
-			enc.Reset(DiscardAt, encoder.WithNormalHeader(15))
+			enc.Reset(DiscardAt, encoder.WithHeaderOption(encoder.HeaderOptionNormal, 15))
 		}
 	})
 	b.Run("compressed timestamp header", func(b *testing.B) {
 		b.StopTimer()
-		enc := encoder.New(DiscardAt, encoder.WithCompressedTimestampHeader())
+		enc := encoder.New(DiscardAt, encoder.WithHeaderOption(encoder.HeaderOptionCompressedTimestamp, 0))
 		b.StartTimer()
 		for i := 0; i < b.N; i++ {
 			_ = enc.Encode(fit)
-			enc.Reset(DiscardAt, encoder.WithCompressedTimestampHeader())
+			enc.Reset(DiscardAt, encoder.WithHeaderOption(encoder.HeaderOptionCompressedTimestamp, 0))
 		}
 	})
 }


### PR DESCRIPTION
At the beginning, I thought that when using compressed timestamp, we can only use local message type zero, but after a year, I re-read the documentation again, it turns out that we can use 0-3 local message type. 

Message (Data) 's Header bit layout: 
| Bit   | Value  | Desc                        |
| ----- | ------ | --------------------------- |
| 7     | 1      | Compressed Timestamp Header |
| 5 – 6 | 0 - 3  | Local Message Type          |
| 0 - 4 | 0 - 31 | Time Offset (seconds)       |

With this being implemented, I think how FIT SDK handle compressed timestamp is finally completed. This change comes with breaking changes, dropping **WithNormalHeader** and **WithCompressedTimestampHeader** encoder options, replaced with **WithHeaderOption**