### PR TITLE
fix!: protocol validator export protocol version field

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -321,7 +321,7 @@ func (e *Encoder) encodeFileHeader(header *proto.FileHeader) error {
 	} else if header.ProtocolVersion == 0 { // Default when not specified in FileHeader.
 		header.ProtocolVersion = proto.V1
 	}
-	e.protocolValidator.SetProtocolVersion(header.ProtocolVersion)
+	e.protocolValidator.ProtocolVersion = header.ProtocolVersion
 
 	header.DataType = proto.DataTypeFIT
 	header.CRC = 0 // recalculated

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -874,7 +874,7 @@ func TestEncodeHeader(t *testing.T) {
 				t.Fatal(diff)
 			}
 
-			if enc.protocolValidator.ProtocolVersion() != tc.protocolVersion {
+			if enc.protocolValidator.ProtocolVersion != tc.protocolVersion {
 				t.Fatalf("expected protocol version: %v, got: %v",
 					tc.protocolVersion, enc.options.protocolVersion)
 			}
@@ -1016,7 +1016,7 @@ func TestEncodeMessage(t *testing.T) {
 			enc := New(tc.w, tc.opts...)
 			// Protocol Version now is set on encodeFileHeader as we allow dynamic protocol version
 			// based on FileHeader. This by pass it since we don't encode file header.
-			enc.protocolValidator.SetProtocolVersion(enc.options.protocolVersion)
+			enc.protocolValidator.ProtocolVersion = enc.options.protocolVersion
 			err := enc.encodeMessage(&tc.mesg)
 			if !errors.Is(err, tc.err) {
 				t.Fatalf("expected: %v, got: %v", tc.err, err)

--- a/proto/validator.go
+++ b/proto/validator.go
@@ -13,16 +13,16 @@ import (
 const ErrProtocolViolation = errorString("protocol violation")
 
 // NewValidator creates protocol validator base on given version.
-func NewValidator(version Version) *Validator {
-	return &Validator{version: version}
+func NewValidator(protocolVersion Version) *Validator {
+	return &Validator{ProtocolVersion: protocolVersion}
 }
 
 // Validator is protocol validator
-type Validator struct{ version Version }
+type Validator struct{ ProtocolVersion Version }
 
 // ValidateMessageDefinition validates whether the message definition contains unsupported data for the targeted version.
 func (p *Validator) ValidateMessageDefinition(mesgDef *MessageDefinition) error {
-	if p.version == V1 {
+	if p.ProtocolVersion == V1 {
 		if len(mesgDef.DeveloperFieldDefinitions) > 0 {
 			return fmt.Errorf("protocol version 1.0 do not support developer fields: %w", ErrProtocolViolation)
 		}
@@ -35,9 +35,3 @@ func (p *Validator) ValidateMessageDefinition(mesgDef *MessageDefinition) error 
 	}
 	return nil
 }
-
-// ProtocolVersion returns the protocol version that this validator validates.
-func (p *Validator) ProtocolVersion() Version { return p.version }
-
-// SetProtocolVersion sets new protocol version to validate.
-func (p *Validator) SetProtocolVersion(version Version) { p.version = version }

--- a/proto/validator_test.go
+++ b/proto/validator_test.go
@@ -72,12 +72,3 @@ func TestValidateMessageDefinition(t *testing.T) {
 		})
 	}
 }
-
-func TestValidatorSetProtocolVersion(t *testing.T) {
-	validator := proto.NewValidator(proto.V1)
-	validator.SetProtocolVersion(proto.V2)
-
-	if validator.ProtocolVersion() != proto.V2 {
-		t.Fatalf("expected: %v, got: %v", proto.V2, validator.ProtocolVersion())
-	}
-}


### PR DESCRIPTION
We don't need getter and setter for field that can be changed directly.