### PR TITLE
fix: fitactivity combine should accumulate all the accumulable values

### DIFF
--- a/cmd/fitactivity/README.md
+++ b/cmd/fitactivity/README.md
@@ -39,10 +39,10 @@ The common messages in an Activity File:
 - Session: fields will be aggregated with the correspoding session of the next FIT file.
 - Lap: append as it is.
 - Event: append as it is
-- Record: field `distance` will be accumulated before append, the rest will be appended as it is
+- Record: accumulable fields such as `distance` and `accumulated_power` will be accumulated before appending, the rest will be appended as they are.
 - SplitSummary: fields will be aggregated with the split summary of the next FIT file that has the same `split_type`.
 
-The rest of the messages from the next FIT files will be appended as it is.
+All fields in messages that are eligible for accumulation will be accumulated before appending, the rest will be appended as they are.
 
 ### Aggregating Fields:
 

--- a/cmd/fitactivity/combiner/accumulator.go
+++ b/cmd/fitactivity/combiner/accumulator.go
@@ -1,0 +1,123 @@
+package combiner
+
+import (
+	"github.com/muktihari/fit/kit/scaleoffset"
+	"github.com/muktihari/fit/profile/typedef"
+	"github.com/muktihari/fit/proto"
+)
+
+// accumulator is different than decoder's Accumulator, this works by just
+// add the incoming value with the previous value, returning the result.
+type accumulator struct{ values []value }
+
+// Collect collects the value, if it already exist,
+// update the existing value with this new value.
+func (a *accumulator) Collect(mesgNum typedef.MesgNum, fieldNum byte, val proto.Value) {
+	for i := range a.values {
+		v := &a.values[i]
+		if v.mesgNum == mesgNum && v.fieldNum == fieldNum {
+			v.value = val
+			v.last = val
+			return
+		}
+	}
+	a.values = append(a.values, value{mesgNum: mesgNum, fieldNum: fieldNum, value: val, last: val})
+}
+
+// Accumulate accumulates val with the previously collected value before.
+// If not found, it will be collected instead, returning the result.
+func (a *accumulator) Accumulate(mesgNum typedef.MesgNum, fieldNum byte, val proto.Value) proto.Value {
+	for i := range a.values {
+		v := &a.values[i]
+		if v.mesgNum == mesgNum && v.fieldNum == fieldNum {
+			v.last = sum(val, v.value) // val must be first argument in case we are handling slices
+			return v.last
+		}
+	}
+	a.values = append(a.values, value{mesgNum: mesgNum, fieldNum: fieldNum, value: val, last: val})
+	return val
+}
+
+// SequenceCompleted marks the sequence as completed, last value of
+// the previous sequence now becomes the new value.
+func (a *accumulator) SequenceCompleted() {
+	for i := range a.values {
+		v := &a.values[i]
+		v.value = v.last
+	}
+}
+
+type value struct {
+	mesgNum  typedef.MesgNum
+	fieldNum byte
+	value    proto.Value
+	last     proto.Value
+}
+
+// sum sums v1 and v2, returning the result.
+func sum(v1, v2 proto.Value) proto.Value {
+	switch v1.Type() {
+	case proto.TypeInt8:
+		return proto.Int8(v1.Int8() + v2.Int8())
+	case proto.TypeUint8:
+		return proto.Uint8(v1.Uint8() + v2.Uint8())
+	case proto.TypeInt16:
+		return proto.Int16(v1.Int16() + v2.Int16())
+	case proto.TypeUint16:
+		return proto.Uint16(v1.Uint16() + v2.Uint16())
+	case proto.TypeInt32:
+		return proto.Int32(v1.Int32() + v2.Int32())
+	case proto.TypeUint32:
+		return proto.Uint32(v1.Uint32() + v2.Uint32())
+	case proto.TypeInt64:
+		return proto.Int64(v1.Int64() + v2.Int64())
+	case proto.TypeUint64:
+		return proto.Uint64(v1.Uint64() + v2.Uint64())
+	case proto.TypeFloat32:
+		return proto.Float32(v1.Float32() + v2.Float32())
+	case proto.TypeFloat64:
+		return proto.Float64(v1.Float64() + v2.Float64())
+	case proto.TypeSliceInt8:
+		return proto.SliceInt8(sumslice(v1.SliceInt8(), v2.SliceInt8()))
+	case proto.TypeSliceUint8:
+		return proto.SliceUint8(sumslice(v1.SliceUint8(), v2.SliceUint8()))
+	case proto.TypeSliceInt16:
+		return proto.SliceInt16(sumslice(v1.SliceInt16(), v2.SliceInt16()))
+	case proto.TypeSliceUint16:
+		return proto.SliceUint16(sumslice(v1.SliceUint16(), v2.SliceUint16()))
+	case proto.TypeSliceInt32:
+		return proto.SliceInt32(sumslice(v1.SliceInt32(), v2.SliceInt32()))
+	case proto.TypeSliceUint32:
+		return proto.SliceUint32(sumslice(v1.SliceUint32(), v2.SliceUint32()))
+	case proto.TypeSliceInt64:
+		return proto.SliceInt64(sumslice(v1.SliceInt64(), v2.SliceInt64()))
+	case proto.TypeSliceUint64:
+		return proto.SliceUint64(sumslice(v1.SliceUint64(), v2.SliceUint64()))
+	case proto.TypeSliceFloat32:
+		return proto.SliceFloat32(sumslice(v1.SliceFloat32(), v2.SliceFloat32()))
+	case proto.TypeSliceFloat64:
+		return proto.SliceFloat64(sumslice(v1.SliceFloat64(), v2.SliceFloat64()))
+	}
+	return v1
+}
+
+// sumslice sums slice values.
+func sumslice[S []E, E scaleoffset.Numeric](v1, v2 S) S {
+	if len(v1) >= len(v2) {
+		for i := range v1 {
+			if i == len(v2) {
+				break
+			}
+			v1[i] += v2[i]
+		}
+		return v1
+	}
+	for i := range v2 {
+		if i == len(v1) {
+			v1 = append(v1, v2[i:]...)
+			break
+		}
+		v1[i] += v2[i]
+	}
+	return v1
+}

--- a/cmd/fitactivity/combiner/accumulator_test.go
+++ b/cmd/fitactivity/combiner/accumulator_test.go
@@ -1,0 +1,86 @@
+package combiner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/muktihari/fit/profile/typedef"
+	"github.com/muktihari/fit/proto"
+)
+
+func TestSum(t *testing.T) {
+	tt := []struct {
+		v1 proto.Value
+		v2 proto.Value
+		r  proto.Value
+	}{
+		{v1: proto.Int8(1), v2: proto.Int8(2), r: proto.Int8(3)},
+		{v1: proto.Uint8(1), v2: proto.Uint8(2), r: proto.Uint8(3)},
+		{v1: proto.Int16(1), v2: proto.Int16(2), r: proto.Int16(3)},
+		{v1: proto.Uint16(1), v2: proto.Uint16(2), r: proto.Uint16(3)},
+		{v1: proto.Int32(1), v2: proto.Int32(2), r: proto.Int32(3)},
+		{v1: proto.Uint32(1), v2: proto.Uint32(2), r: proto.Uint32(3)},
+		{v1: proto.Int64(1), v2: proto.Int64(2), r: proto.Int64(3)},
+		{v1: proto.Uint64(1), v2: proto.Uint64(2), r: proto.Uint64(3)},
+		{v1: proto.Float32(1), v2: proto.Float32(2), r: proto.Float32(3)},
+		{v1: proto.Float64(1), v2: proto.Float64(2), r: proto.Float64(3)},
+		{v1: proto.SliceInt8([]int8{1}), v2: proto.SliceInt8([]int8{1}), r: proto.SliceInt8([]int8{2})},
+		{v1: proto.SliceUint8([]uint8{1}), v2: proto.SliceUint8([]uint8{1}), r: proto.SliceUint8([]uint8{2})},
+		{v1: proto.SliceInt16([]int16{1}), v2: proto.SliceInt16([]int16{1}), r: proto.SliceInt16([]int16{2})},
+		{v1: proto.SliceUint16([]uint16{1}), v2: proto.SliceUint16([]uint16{1}), r: proto.SliceUint16([]uint16{2})},
+		{v1: proto.SliceInt32([]int32{1}), v2: proto.SliceInt32([]int32{1}), r: proto.SliceInt32([]int32{2})},
+		{v1: proto.SliceUint32([]uint32{1}), v2: proto.SliceUint32([]uint32{1}), r: proto.SliceUint32([]uint32{2})},
+		{v1: proto.SliceInt64([]int64{1}), v2: proto.SliceInt64([]int64{1}), r: proto.SliceInt64([]int64{2})},
+		{v1: proto.SliceUint64([]uint64{1}), v2: proto.SliceUint64([]uint64{1}), r: proto.SliceUint64([]uint64{2})},
+		{v1: proto.SliceFloat32([]float32{1}), v2: proto.SliceFloat32([]float32{1}), r: proto.SliceFloat32([]float32{2})},
+		{v1: proto.SliceFloat64([]float64{1}), v2: proto.SliceFloat64([]float64{1}), r: proto.SliceFloat64([]float64{2})},
+		{v1: proto.Bool(typedef.BoolTrue), v2: proto.Bool(typedef.BoolFalse), r: proto.Bool(typedef.BoolTrue)},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.v1.Type()), func(t *testing.T) {
+			r := sum(tc.v1, tc.v2)
+			if diff := cmp.Diff(r.Any(), tc.r.Any()); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestSumSlice(t *testing.T) {
+	tt := []struct {
+		name string
+		v1   proto.Value
+		v2   proto.Value
+		r    []int8
+	}{
+		{
+			name: "same len",
+			v1:   proto.SliceInt8([]int8{10, 10}),
+			v2:   proto.SliceInt8([]int8{10, 10}),
+			r:    []int8{20, 20},
+		},
+		{
+			name: "len v1 > v2",
+			v1:   proto.SliceInt8([]int8{10, 10, 10}),
+			v2:   proto.SliceInt8([]int8{10, 10}),
+			r:    []int8{20, 20, 10},
+		},
+		{
+			name: "len v1 < v2",
+			v1:   proto.SliceInt8([]int8{10, 10}),
+			v2:   proto.SliceInt8([]int8{10, 10, 5}),
+			r:    []int8{20, 20, 5},
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
+			r := sumslice(tc.v1.SliceInt8(), tc.v2.SliceInt8())
+			if diff := cmp.Diff(r, tc.r); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/cmd/fitactivity/combiner/combiner_test.go
+++ b/cmd/fitactivity/combiner/combiner_test.go
@@ -41,6 +41,7 @@ func TestCombine(t *testing.T) {
 					{Num: mesgnum.Record, Fields: []proto.Field{
 						factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 1),
 						factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(100)),
+						factory.CreateField(mesgnum.Record, fieldnum.RecordAccumulatedPower).WithValue(uint32(100)),
 					}},
 					{Num: mesgnum.SplitSummary, Fields: []proto.Field{
 						factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummarySplitType).WithValue(typedef.SplitTypeRunActive),
@@ -53,6 +54,7 @@ func TestCombine(t *testing.T) {
 					{Num: mesgnum.Record, Fields: []proto.Field{
 						factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 2),
 						factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(200)),
+						factory.CreateField(mesgnum.Record, fieldnum.RecordAccumulatedPower).WithValue(uint32(200)),
 					}},
 					{Num: mesgnum.Session, Fields: []proto.Field{
 						factory.CreateField(mesgnum.Session, fieldnum.SessionSport).WithValue(typedef.SportCycling),
@@ -78,6 +80,7 @@ func TestCombine(t *testing.T) {
 					{Num: mesgnum.Record, Fields: []proto.Field{
 						factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 10),
 						factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(100)),
+						factory.CreateField(mesgnum.Record, fieldnum.RecordAccumulatedPower).WithValue(uint32(100)),
 					}},
 					{Num: mesgnum.SplitSummary, Fields: []proto.Field{
 						factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummarySplitType).WithValue(typedef.SplitTypeRunActive),
@@ -86,6 +89,7 @@ func TestCombine(t *testing.T) {
 					{Num: mesgnum.Record, Fields: []proto.Field{
 						factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 20),
 						factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(200)),
+						factory.CreateField(mesgnum.Record, fieldnum.RecordAccumulatedPower).WithValue(uint32(200)),
 					}},
 					{Num: mesgnum.Session, Fields: []proto.Field{
 						factory.CreateField(mesgnum.Session, fieldnum.SessionSport).WithValue(typedef.SportCycling),
@@ -112,18 +116,22 @@ func TestCombine(t *testing.T) {
 				{Num: mesgnum.Record, Fields: []proto.Field{
 					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 1),
 					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(100)),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordAccumulatedPower).WithValue(uint32(100)),
 				}},
 				{Num: mesgnum.Record, Fields: []proto.Field{
 					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 2),
 					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(200)),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordAccumulatedPower).WithValue(uint32(200)),
 				}},
 				{Num: mesgnum.Record, Fields: []proto.Field{
 					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 10),
 					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(300)),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordAccumulatedPower).WithValue(uint32(300)),
 				}},
 				{Num: mesgnum.Record, Fields: []proto.Field{
 					factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(now) + 20),
 					factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(400)),
+					factory.CreateField(mesgnum.Record, fieldnum.RecordAccumulatedPower).WithValue(uint32(400)),
 				}},
 				{Num: mesgnum.SplitSummary, Fields: []proto.Field{
 					factory.CreateField(mesgnum.Session, proto.FieldNumTimestamp).WithValue(datetime.ToUint32(now) + 20), // Additional

--- a/cmd/fitactivity/main.go
+++ b/cmd/fitactivity/main.go
@@ -415,7 +415,7 @@ loop:
 
 			prevLen := len(fit.Messages)
 
-			msg := fmt.Sprintf("Removing [unknown: %t, nums: %s, devdata: %t]",
+			msg := fmt.Sprintf("Removing [unknown: %t, mesgnums: %s, devdata: %t]",
 				removeUnknown, removeMesgNums, removeDevData)
 			verboserun(msg, func() {
 				remover.Remove(fit, opts...)
@@ -917,7 +917,7 @@ func remove(ctx context.Context, fs *flag.FlagSet, args []string) (err error) {
 			nameSuffix, strings.ReplaceAll(removeMesgNums, ",", "_"))
 	}
 
-	fmt.Fprintf(os.Stdout, "- Removing %d file(s) [unknown: %t, nums: %s, devdata: %t]\n",
+	fmt.Fprintf(os.Stdout, "- Removing %d file(s) [unknown: %t, mesgnums: %s, devdata: %t]\n",
 		len(files), removeUnknown, removeMesgNums, removeDevData)
 
 	var dec = decoder.New(nil)


### PR DESCRIPTION
Previously, we only accumulate Record's `distance`, but in reality, messages may have fields requires accumulation as well, such as Record's `accumulated_power`. We should dynamically find and accumulates those values.