### PR TITLE
perf: early validate all messages before encoding

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -314,7 +314,8 @@ func (e *Encoder) validateMessages(messages []proto.Message) (err error) {
 	for i := range messages {
 		mesg := &messages[i] // Must use pointer reference since validator may update the message.
 		if err = e.protocolValidator.ValidateMessage(mesg); err != nil {
-			return err
+			return fmt.Errorf("protocol validation failed: message index: %d, num: %d (%s): %w",
+				i, mesg.Num, mesg.Num.String(), err)
 		}
 		if err = e.options.messageValidator.Validate(mesg); err != nil {
 			return fmt.Errorf("message validation failed: message index: %d, num: %d (%s): %w",

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -927,6 +927,7 @@ func TestEncodeHeader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			bytebuf := new(bytes.Buffer)
 			enc := New(bytebuf, append(tc.opts, WithWriteBufferSize(0))...)
+			enc.selectProtocolVersion(&tc.header)
 			_ = enc.encodeFileHeader(&tc.header)
 
 			if diff := cmp.Diff(bytebuf.Bytes(), tc.b); diff != "" {

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -392,9 +392,25 @@ func TestEncode(t *testing.T) {
 			w:   fnWriteOK,
 			err: ErrExceedMaxAllowed,
 		},
+		{
+			name: "encode return error protocol violation since proto.V1 does not allow Int64",
+			fit: &proto.FIT{
+				FileHeader: proto.FileHeader{ProtocolVersion: proto.V1},
+				Messages: []proto.Message{
+					{Num: mesgnum.Record, Fields: []proto.Field{
+						{FieldBase: &proto.FieldBase{BaseType: basetype.Sint64}},
+					}},
+				},
+			},
+			w:   fnWriteOK,
+			err: proto.ErrProtocolViolation,
+		},
 	}
 
 	for i, tc := range tt {
+		if i != len(tt)-1 {
+			continue
+		}
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
 			enc := New(tc.w)
 			err := enc.Encode(tc.fit)

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -451,7 +451,7 @@ func TestValidateMessages(t *testing.T) {
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
 			enc := New(nil)
-			// Protocol Version now is set on encodeFileHeader as we allow dynamic protocol version
+			// Protocol Version is now selected by selectProtocolVersion method as we allow dynamic protocol version
 			// based on FileHeader. This by pass it since we don't encode file header.
 			enc.protocolValidator.ProtocolVersion = tc.protocolVersion
 			err := enc.validateMessages(tc.messages)

--- a/encoder/stream.go
+++ b/encoder/stream.go
@@ -30,6 +30,9 @@ func (e *StreamEncoder) WriteMessage(mesg *proto.Message) error {
 		}
 		e.fileHeaderWritten = true
 	}
+	if err := e.enc.protocolValidator.ValidateMessage(mesg); err != nil {
+		return fmt.Errorf("protocol validate message failed: %d (%s): %w", mesg.Num, mesg.Num, err)
+	}
 	if err := e.enc.options.messageValidator.Validate(mesg); err != nil {
 		return fmt.Errorf("message validation failed: mesgNum: %d (%s): %w", mesg.Num, mesg.Num, err)
 	}

--- a/encoder/stream.go
+++ b/encoder/stream.go
@@ -25,6 +25,7 @@ type StreamEncoder struct {
 //   - This method is called right after SequenceCompleted method has been called.
 func (e *StreamEncoder) WriteMessage(mesg *proto.Message) error {
 	if !e.fileHeaderWritten {
+		e.enc.selectProtocolVersion(&e.fileHeader)
 		if err := e.enc.encodeFileHeader(&e.fileHeader); err != nil {
 			return fmt.Errorf("could not encode file header: %w", err)
 		}

--- a/encoder/stream.go
+++ b/encoder/stream.go
@@ -30,6 +30,9 @@ func (e *StreamEncoder) WriteMessage(mesg *proto.Message) error {
 		}
 		e.fileHeaderWritten = true
 	}
+	if err := e.enc.options.messageValidator.Validate(mesg); err != nil {
+		return fmt.Errorf("message validation failed: mesgNum: %d (%s): %w", mesg.Num, mesg.Num, err)
+	}
 	if err := e.enc.encodeMessage(mesg); err != nil {
 		return fmt.Errorf("could not encode mesg: mesgNum: %d (%q): %w", mesg.Num, mesg.Num, err)
 	}

--- a/encoder/stream_test.go
+++ b/encoder/stream_test.go
@@ -146,6 +146,16 @@ func TestStreamEncoderUnhappyFlow(t *testing.T) {
 		t.Fatalf("expected err: %v, got: %v", io.EOF, err)
 	}
 
+	// Protocol validation error
+	streamEnc, _ = New(mockWriterAt{}).StreamEncoder()
+	streamEnc.enc.protocolValidator.ProtocolVersion = proto.V1
+	err = streamEnc.WriteMessage(&proto.Message{Fields: []proto.Field{
+		factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed1S).WithValue(make([]uint8, 256)),
+	}, DeveloperFields: []proto.DeveloperField{{}}})
+	if !errors.Is(err, proto.ErrProtocolViolation) {
+		t.Fatalf("expected err: %v, got: %v", proto.ErrProtocolViolation, err)
+	}
+
 	// Message validation error
 	streamEnc, _ = New(mockWriterAt{}).StreamEncoder()
 	err = streamEnc.WriteMessage(&proto.Message{Fields: []proto.Field{

--- a/encoder/stream_test.go
+++ b/encoder/stream_test.go
@@ -145,6 +145,15 @@ func TestStreamEncoderUnhappyFlow(t *testing.T) {
 	if !errors.Is(err, io.EOF) {
 		t.Fatalf("expected err: %v, got: %v", io.EOF, err)
 	}
+
+	// Message validation error
+	streamEnc, _ = New(mockWriterAt{}).StreamEncoder()
+	err = streamEnc.WriteMessage(&proto.Message{Fields: []proto.Field{
+		factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed1S).WithValue(make([]uint8, 256))}},
+	)
+	if !errors.Is(err, ErrExceedMaxAllowed) {
+		t.Fatalf("expected err: %v, got: %v", ErrExceedMaxAllowed, err)
+	}
 }
 
 func TestStreamEncoderWithoutWriteBuffer(t *testing.T) {

--- a/encoder/validator_test.go
+++ b/encoder/validator_test.go
@@ -493,6 +493,11 @@ func TestMessageValidatorValidate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "error no fields",
+			mesgs: []proto.Message{{Fields: []proto.Field{}}},
+			errs:  []error{ErrNoFields},
+		},
 	}
 
 	for i, tc := range tt {

--- a/proto/validator.go
+++ b/proto/validator.go
@@ -35,3 +35,19 @@ func (p *Validator) ValidateMessageDefinition(mesgDef *MessageDefinition) error 
 	}
 	return nil
 }
+
+// ValidateMessage validates whether the message contains unsupported data for the targeted version.
+func (p *Validator) ValidateMessage(mesg *Message) error {
+	if p.ProtocolVersion == V1 {
+		if len(mesg.DeveloperFields) > 0 {
+			return fmt.Errorf("protocol version 1.0 do not support developer fields: %w", ErrProtocolViolation)
+		}
+		for i := range mesg.Fields {
+			field := &mesg.Fields[i]
+			if field.BaseType&basetype.BaseTypeNumMask > basetype.Byte&basetype.BaseTypeNumMask { // byte was the last type added in 1.0
+				return fmt.Errorf("protocol version 1.0 do not support type '%s': %w", field.BaseType, ErrProtocolViolation)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Validating messages early give several advantages:
1. If invalid message occurs, we can return early without doing unnecessary works such as marshaling, calculate CRC or even do a syscall to write to the file.
2. If normal writer is given (a writer without offset writer capability), the encoding speed is improved by geomean 16% since  we don't need to validate messages twices. Benchmark:
  ```go
  goos: linuxl goarch: amd64l pkg: benchfitl cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                             │   old.txt   │               new.txt               │
                             │   sec/op    │   sec/op     vs base                │
  Encode/muktihari/fit_raw-4   93.57m ± 8%   74.63m ± 3%  -20.24% (p=0.000 n=10)
  Encode/muktihari/fit-4       157.2m ± 7%   136.7m ± 2%  -13.01% (p=0.000 n=10)
  geomean                      121.3m        101.0m       -16.71%
  ```
3. We can release all objects generated by the message validator early, so it can be garbage-collected as soon as we are done validating. The objects are only be generated when it encounters developer data.