### PR TITLE
fix: decoder should clear the pointers before reslicing

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -246,20 +246,20 @@ func (d *Decoder) reset() {
 	d.messages = nil
 	d.crc = 0
 	d.fileId = nil
-	d.developerDataIndexes = d.developerDataIndexes[:0]
-	d.fieldDescriptions = d.fieldDescriptions[:0]
 }
 
-// releaseTemporaryObjects releases objects that being created on a single decode process
-// by stops referencing those objects so it can be released on next GC cycle.
+// releaseTemporaryObjects releases objects that being created during a single decode process
+// by stops referencing those objects so it can be garbage-collected on next GC cycle.
 func (d *Decoder) releaseTemporaryObjects() {
 	d.localMessageDefinitions = [proto.LocalMesgNumMask + 1]*proto.MessageDefinition{}
 	d.fieldsArray = [255]proto.Field{}
 	d.developerFieldsArray = [255]proto.DeveloperField{}
 	d.messages = nil
+	d.developerDataIndexes = d.developerDataIndexes[:0]
 	for i := range d.fieldDescriptions {
 		d.fieldDescriptions[i] = nil
 	}
+	d.fieldDescriptions = d.fieldDescriptions[:0]
 }
 
 // CheckIntegrity checks all FIT sequences of given reader are valid determined by these following checks:


### PR DESCRIPTION
Previously, d.fieldDescriptions was resliced on reset, resulting d.releaseTemporaryObjects to do nothing regarding that field so the pointers (if any) will be keep until next decoding process reaching the previous slice index then replacing the 
value.

In general, this should not be a problem since the values will be replaced anyway when we do decode again, and the pointer will eventually be released at some point or when the decoder is no longer used (garbage-collected), but it becomes nondeterministic, so let's fix it.

We can move the resetting of d.fieldDescriptions and d.developerDataIndexes to d.releaseTemporaryObjects instead of in d.reset, since these fields only changes during decoding messages.