### PR TITLE
feat: filedef activity file add sports and update its sorting

### DIFF
--- a/profile/filedef/activity_test.go
+++ b/profile/filedef/activity_test.go
@@ -61,6 +61,7 @@ func newActivityMessageForTest(now time.Time) []proto.Message {
 
 func newActivityMessagesWithExpectedOrder(now time.Time) (mesgs []proto.Message, ordered []proto.Message) {
 	mesgs = []proto.Message{
+		// Messages have no timestamp field:
 		0: {Num: mesgnum.FileId, Fields: []proto.Field{
 			factory.CreateField(mesgnum.FileId, fieldnum.FileIdType).WithValue(uint8(typedef.FileActivity)),
 			factory.CreateField(mesgnum.FileId, fieldnum.FileIdTimeCreated).WithValue(datetime.ToUint32(now)),
@@ -76,89 +77,99 @@ func newActivityMessagesWithExpectedOrder(now time.Time) (mesgs []proto.Message,
 			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionNativeFieldNum).WithValue(uint8(fieldnum.RecordHeartRate)),
 			factory.CreateField(mesgnum.FieldDescription, fieldnum.FieldDescriptionFitBaseTypeId).WithValue(uint8(basetype.Uint8)),
 		}},
-		3: {Num: mesgnum.DeviceInfo, Fields: []proto.Field{
-			factory.CreateField(mesgnum.DeviceInfo, fieldnum.DeviceInfoManufacturer).WithValue(uint16(typedef.ManufacturerGarmin)),
-		}},
-		4: {Num: mesgnum.UserProfile, Fields: []proto.Field{
+		3: {Num: mesgnum.UserProfile, Fields: []proto.Field{
 			factory.CreateField(mesgnum.UserProfile, fieldnum.UserProfileFriendlyName).WithValue("Mary Jane"),
 			factory.CreateField(mesgnum.UserProfile, fieldnum.UserProfileAge).WithValue(uint8(21)),
 		}},
-		5: {Num: mesgnum.Event, Fields: []proto.Field{
+		4: {Num: mesgnum.ZonesTarget, Fields: []proto.Field{
+			factory.CreateField(mesgnum.ZonesTarget, fieldnum.ZonesTargetMaxHeartRate).WithValue(uint8(190)),
+		}},
+		5: {Num: mesgnum.Workout, Fields: []proto.Field{
+			factory.CreateField(mesgnum.Workout, fieldnum.WorkoutSport).WithValue(uint8(typedef.SportCycling)),
+		}},
+		6: {Num: mesgnum.WorkoutStep, Fields: []proto.Field{
+			factory.CreateField(mesgnum.WorkoutStep, fieldnum.WorkoutStepIntensity).WithValue(uint8(typedef.IntensityActive)),
+		}},
+		7: {Num: mesgnum.Hrv, Fields: []proto.Field{
+			factory.CreateField(mesgnum.Hrv, fieldnum.HrvTime).WithValue([]uint16{uint16(1000)}),
+		}},
+		8: {Num: mesgnum.Split, Fields: []proto.Field{
+			factory.CreateField(mesgnum.Split, fieldnum.SplitTotalDistance).WithValue(uint32(10000)),
+		}},
+		9: {Num: mesgnum.SplitSummary, Fields: []proto.Field{
+			factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummarySplitType).WithValue(typedef.SplitTypeAscentSplit.Byte()),
+		}},
+		10: {Num: mesgnum.Sport, Fields: []proto.Field{
+			factory.CreateField(mesgnum.Sport, fieldnum.SportName).WithValue("cycling"),
+		}},
+		// Messages have timestamp field:
+		11: {Num: mesgnum.DeviceInfo, Fields: []proto.Field{
+			factory.CreateField(mesgnum.DeviceInfo, fieldnum.DeviceInfoTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
+			factory.CreateField(mesgnum.DeviceInfo, fieldnum.DeviceInfoManufacturer).WithValue(uint16(typedef.ManufacturerGarmin)),
+		}},
+		12: {Num: mesgnum.Event, Fields: []proto.Field{
 			factory.CreateField(mesgnum.Event, fieldnum.EventTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 			factory.CreateField(mesgnum.Event, fieldnum.EventEvent).WithValue(uint8(typedef.EventActivity)),
 			factory.CreateField(mesgnum.Event, fieldnum.EventEventType).WithValue(uint8(typedef.EventTypeStart)),
 		}},
-		6: {Num: mesgnum.Record, Fields: []proto.Field{
+		13: {Num: mesgnum.Record, Fields: []proto.Field{
 			factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		}},
-		7: {Num: mesgnum.Record, Fields: []proto.Field{
+		14: {Num: mesgnum.Record, Fields: []proto.Field{
 			factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		}},
-		8: {Num: mesgnum.Event, Fields: []proto.Field{
+		15: {Num: mesgnum.Event, Fields: []proto.Field{
 			factory.CreateField(mesgnum.Event, fieldnum.EventTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		}},
-		9: {Num: mesgnum.Record, Fields: []proto.Field{
+		16: {Num: mesgnum.Record, Fields: []proto.Field{
 			factory.CreateField(mesgnum.Record, fieldnum.RecordTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		}},
-		10: {Num: mesgnum.Event, Fields: []proto.Field{
+		17: {Num: mesgnum.Event, Fields: []proto.Field{
 			// Intentionally using same timestamp as last message.
 			factory.CreateField(mesgnum.Event, fieldnum.EventTimestamp).WithValue(datetime.ToUint32(now)),
 		}},
-		11: {Num: mesgnum.Lap, Fields: []proto.Field{
+		18: {Num: mesgnum.Lap, Fields: []proto.Field{
 			factory.CreateField(mesgnum.Lap, fieldnum.LapTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		}},
-		12: {Num: mesgnum.Session, Fields: []proto.Field{
+		19: {Num: mesgnum.Session, Fields: []proto.Field{
 			factory.CreateField(mesgnum.Session, fieldnum.SessionTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		}},
-		13: {Num: mesgnum.Activity, Fields: []proto.Field{
+		20: {Num: mesgnum.Activity, Fields: []proto.Field{
 			factory.CreateField(mesgnum.Activity, fieldnum.ActivityTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		}},
-		// Unordered optional Messages
-		14: {Num: mesgnum.Length, Fields: []proto.Field{
+		21: {Num: mesgnum.Length, Fields: []proto.Field{
+			factory.CreateField(mesgnum.Length, fieldnum.LengthTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 			factory.CreateField(mesgnum.Length, fieldnum.LengthAvgSpeed).WithValue(uint16(1000)),
 		}},
-		15: {Num: mesgnum.SegmentLap, Fields: []proto.Field{
+		22: {Num: mesgnum.SegmentLap, Fields: []proto.Field{
+			factory.CreateField(mesgnum.SegmentLap, fieldnum.SegmentLapTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 			factory.CreateField(mesgnum.SegmentLap, fieldnum.SegmentLapAvgCadence).WithValue(uint8(100)),
 		}},
-		16: {Num: mesgnum.ZonesTarget, Fields: []proto.Field{
-			factory.CreateField(mesgnum.ZonesTarget, fieldnum.ZonesTargetMaxHeartRate).WithValue(uint8(190)),
-		}},
-		17: {Num: mesgnum.Workout, Fields: []proto.Field{
-			factory.CreateField(mesgnum.Workout, fieldnum.WorkoutSport).WithValue(uint8(typedef.SportCycling)),
-		}},
-		18: {Num: mesgnum.WorkoutStep, Fields: []proto.Field{
-			factory.CreateField(mesgnum.WorkoutStep, fieldnum.WorkoutStepIntensity).WithValue(uint8(typedef.IntensityActive)),
-		}},
-		19: {Num: mesgnum.Hr, Fields: []proto.Field{
+		23: {Num: mesgnum.Hr, Fields: []proto.Field{
 			factory.CreateField(mesgnum.Hr, fieldnum.HrTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		}},
-		20: {Num: mesgnum.Hrv, Fields: []proto.Field{
-			factory.CreateField(mesgnum.Hrv, fieldnum.HrvTime).WithValue([]uint16{uint16(1000)}),
-		}},
 		// Unrelated messages
-		21: {Num: mesgnum.BarometerData, Fields: []proto.Field{
+		24: {Num: mesgnum.BarometerData, Fields: []proto.Field{
 			factory.CreateField(mesgnum.BarometerData, fieldnum.BarometerDataTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
+		}},
+		25: {Num: mesgnum.BikeProfile, Fields: []proto.Field{ // have no timestamp, should be sorted at top.
+			factory.CreateField(mesgnum.BikeProfile, fieldnum.BikeProfileBikeWeight).WithValue(uint16(100)),
 		}},
 		// Special case:
 		// 1. CoursePoint's Timestamp Num is 1
 		// 2. Set's Timestamp Num is 254
-		22: {Num: mesgnum.CoursePoint, Fields: []proto.Field{
+		26: {Num: mesgnum.CoursePoint, Fields: []proto.Field{
 			factory.CreateField(mesgnum.CoursePoint, fieldnum.CoursePointTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		}},
-		23: {Num: mesgnum.Set, Fields: []proto.Field{
+		27: {Num: mesgnum.Set, Fields: []proto.Field{
 			factory.CreateField(mesgnum.Set, fieldnum.SetTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		}},
-		24: {Num: mesgnum.GpsMetadata, Fields: []proto.Field{
+		// Optional messages:
+		28: {Num: mesgnum.GpsMetadata, Fields: []proto.Field{
 			factory.CreateField(mesgnum.GpsMetadata, fieldnum.GpsMetadataTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
 		}},
-		25: {Num: mesgnum.TimeInZone, Fields: []proto.Field{
+		29: {Num: mesgnum.TimeInZone, Fields: []proto.Field{
 			factory.CreateField(mesgnum.TimeInZone, fieldnum.TimeInZoneTimestamp).WithValue(datetime.ToUint32(incrementSecond(&now))),
-		}},
-		26: {Num: mesgnum.Split, Fields: []proto.Field{
-			factory.CreateField(mesgnum.Split, fieldnum.SplitTotalDistance).WithValue(uint32(10000)),
-		}},
-		27: {Num: mesgnum.SplitSummary, Fields: []proto.Field{
-			factory.CreateField(mesgnum.SplitSummary, fieldnum.SplitSummarySplitType).WithValue(typedef.SplitTypeAscentSplit.Byte()),
 		}},
 	}
 
@@ -168,29 +179,31 @@ func newActivityMessagesWithExpectedOrder(now time.Time) (mesgs []proto.Message,
 		2:  mesgs[2],
 		3:  mesgs[3],
 		4:  mesgs[4],
-		5:  mesgs[14],
-		6:  mesgs[15],
-		7:  mesgs[16],
-		8:  mesgs[17],
-		9:  mesgs[18],
-		10: mesgs[20],
-		11: mesgs[26],
-		12: mesgs[27],
-		13: mesgs[5],
-		14: mesgs[6],
-		15: mesgs[7],
-		16: mesgs[8],
-		17: mesgs[9],
-		18: mesgs[10],
-		19: mesgs[11],
-		20: mesgs[12],
-		21: mesgs[13],
-		22: mesgs[19],
-		23: mesgs[21],
-		24: mesgs[22],
-		25: mesgs[23],
-		26: mesgs[24],
-		27: mesgs[25],
+		5:  mesgs[5],
+		6:  mesgs[6],
+		7:  mesgs[7],
+		8:  mesgs[8],
+		9:  mesgs[9],
+		10: mesgs[10],
+		11: mesgs[25],
+		12: mesgs[11],
+		13: mesgs[12],
+		14: mesgs[13],
+		15: mesgs[14],
+		16: mesgs[15],
+		17: mesgs[16],
+		18: mesgs[17],
+		19: mesgs[18],
+		20: mesgs[19],
+		21: mesgs[20],
+		22: mesgs[21],
+		23: mesgs[22],
+		24: mesgs[23],
+		25: mesgs[24],
+		26: mesgs[26],
+		27: mesgs[27],
+		28: mesgs[28],
+		29: mesgs[29],
 	}
 	return
 }


### PR DESCRIPTION
- Add sports messages in Activity File. FIT files produced by Garmin devices typically has this message, and it can be multiple sports messages such as when doing a Triathlon.
- Manually put messages that, we know upfront, have no timestamp at the beginning of the resulting messages, we don't need to include it to be sorted. This will save a bit of resource and time.