### PR TITLE
fix: segment file can have multiple leaderboard entries

### DIFF
--- a/profile/filedef/segment.go
+++ b/profile/filedef/segment.go
@@ -19,8 +19,8 @@ type Segment struct {
 	FieldDescriptions []*mesgdef.FieldDescription
 
 	SegmentId               *mesgdef.SegmentId
-	SegmentLeaderboardEntry []*mesgdef.SegmentLeaderboardEntry
 	SegmentLap              *mesgdef.SegmentLap
+	SegmentLeaderboardEntry []*mesgdef.SegmentLeaderboardEntry
 	SegmentPoints           []*mesgdef.SegmentPoint
 
 	UnrelatedMessages []proto.Message

--- a/profile/filedef/segment.go
+++ b/profile/filedef/segment.go
@@ -62,7 +62,7 @@ func (f *Segment) Add(mesg proto.Message) {
 
 // ToFIT converts Segment to proto.FIT. If options is nil, default options will be used.
 func (f *Segment) ToFIT(options *mesgdef.Options) proto.FIT {
-	var size = 4 // non slice fields
+	var size = 3 // non slice fields
 
 	size += len(f.SegmentPoints) + len(f.DeveloperDataIds) +
 		len(f.FieldDescriptions) + len(f.UnrelatedMessages)

--- a/profile/filedef/segment.go
+++ b/profile/filedef/segment.go
@@ -19,7 +19,7 @@ type Segment struct {
 	FieldDescriptions []*mesgdef.FieldDescription
 
 	SegmentId               *mesgdef.SegmentId
-	SegmentLeaderboardEntry *mesgdef.SegmentLeaderboardEntry
+	SegmentLeaderboardEntry []*mesgdef.SegmentLeaderboardEntry
 	SegmentLap              *mesgdef.SegmentLap
 	SegmentPoints           []*mesgdef.SegmentPoint
 
@@ -49,7 +49,7 @@ func (f *Segment) Add(mesg proto.Message) {
 	case mesgnum.SegmentId:
 		f.SegmentId = mesgdef.NewSegmentId(&mesg)
 	case mesgnum.SegmentLeaderboardEntry:
-		f.SegmentLeaderboardEntry = mesgdef.NewSegmentLeaderboardEntry(&mesg)
+		f.SegmentLeaderboardEntry = append(f.SegmentLeaderboardEntry, mesgdef.NewSegmentLeaderboardEntry(&mesg))
 	case mesgnum.SegmentLap:
 		f.SegmentLap = mesgdef.NewSegmentLap(&mesg)
 	case mesgnum.SegmentPoint:
@@ -83,8 +83,8 @@ func (f *Segment) ToFIT(options *mesgdef.Options) proto.FIT {
 	if f.SegmentId != nil {
 		fit.Messages = append(fit.Messages, f.SegmentId.ToMesg(options))
 	}
-	if f.SegmentLeaderboardEntry != nil {
-		fit.Messages = append(fit.Messages, f.SegmentLeaderboardEntry.ToMesg(options))
+	for i := range f.SegmentLeaderboardEntry {
+		fit.Messages = append(fit.Messages, f.SegmentLeaderboardEntry[i].ToMesg(options))
 	}
 	if f.SegmentLap != nil {
 		fit.Messages = append(fit.Messages, f.SegmentLap.ToMesg(options))

--- a/profile/filedef/segment.go
+++ b/profile/filedef/segment.go
@@ -18,10 +18,10 @@ type Segment struct {
 	DeveloperDataIds  []*mesgdef.DeveloperDataId
 	FieldDescriptions []*mesgdef.FieldDescription
 
-	SegmentId               *mesgdef.SegmentId
-	SegmentLap              *mesgdef.SegmentLap
-	SegmentLeaderboardEntry []*mesgdef.SegmentLeaderboardEntry
-	SegmentPoints           []*mesgdef.SegmentPoint
+	SegmentId                 *mesgdef.SegmentId
+	SegmentLap                *mesgdef.SegmentLap
+	SegmentLeaderboardEntries []*mesgdef.SegmentLeaderboardEntry
+	SegmentPoints             []*mesgdef.SegmentPoint
 
 	UnrelatedMessages []proto.Message
 }
@@ -49,7 +49,7 @@ func (f *Segment) Add(mesg proto.Message) {
 	case mesgnum.SegmentId:
 		f.SegmentId = mesgdef.NewSegmentId(&mesg)
 	case mesgnum.SegmentLeaderboardEntry:
-		f.SegmentLeaderboardEntry = append(f.SegmentLeaderboardEntry, mesgdef.NewSegmentLeaderboardEntry(&mesg))
+		f.SegmentLeaderboardEntries = append(f.SegmentLeaderboardEntries, mesgdef.NewSegmentLeaderboardEntry(&mesg))
 	case mesgnum.SegmentLap:
 		f.SegmentLap = mesgdef.NewSegmentLap(&mesg)
 	case mesgnum.SegmentPoint:
@@ -83,8 +83,8 @@ func (f *Segment) ToFIT(options *mesgdef.Options) proto.FIT {
 	if f.SegmentId != nil {
 		fit.Messages = append(fit.Messages, f.SegmentId.ToMesg(options))
 	}
-	for i := range f.SegmentLeaderboardEntry {
-		fit.Messages = append(fit.Messages, f.SegmentLeaderboardEntry[i].ToMesg(options))
+	for i := range f.SegmentLeaderboardEntries {
+		fit.Messages = append(fit.Messages, f.SegmentLeaderboardEntries[i].ToMesg(options))
 	}
 	if f.SegmentLap != nil {
 		fit.Messages = append(fit.Messages, f.SegmentLap.ToMesg(options))

--- a/profile/filedef/segment.go
+++ b/profile/filedef/segment.go
@@ -64,7 +64,7 @@ func (f *Segment) Add(mesg proto.Message) {
 func (f *Segment) ToFIT(options *mesgdef.Options) proto.FIT {
 	var size = 3 // non slice fields
 
-	size += len(f.SegmentPoints) + len(f.DeveloperDataIds) +
+	size += len(f.SegmentPoints) + len(f.SegmentLeaderboardEntries) + len(f.DeveloperDataIds) +
 		len(f.FieldDescriptions) + len(f.UnrelatedMessages)
 
 	fit := proto.FIT{


### PR DESCRIPTION
Hi folks! 

Thank you for pretty handy SDK. I found that currently a segment file can have the only one leaderboard entry. This is not expected behaviour. Multiple leaders should be supported by design. In the case of Strava segment it is quite often that a segment has atleast three leaderboard entries like KOM, QOM and Personal Best. 

This PR makes possible to add multiple leaderboard entries to a segment file.

Keep going!

Regards, Ilya