### PR TITLE
fix: slices clone related items

### DIFF
--- a/cmd/fitconv/fitcsv/csv_to_fit.go
+++ b/cmd/fitconv/fitcsv/csv_to_fit.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/muktihari/fit/encoder"
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/scaleoffset"
 	"github.com/muktihari/fit/kit/semicircles"
 	"github.com/muktihari/fit/profile"
@@ -158,8 +159,8 @@ func (c *CSVToFITConv) convert() error {
 			}
 
 			if c.streamEnc == nil {
-				mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
-				mesg.DeveloperFields = append(mesg.DeveloperFields[:0:0], mesg.DeveloperFields...)
+				mesg.Fields = sliceutil.Clone(mesg.Fields)
+				mesg.DeveloperFields = sliceutil.Clone(mesg.DeveloperFields)
 				c.fit.Messages = append(c.fit.Messages, mesg)
 				continue
 			}

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/hash"
 	"github.com/muktihari/fit/kit/hash/crc16"
 	"github.com/muktihari/fit/kit/scaleoffset"
@@ -616,8 +617,8 @@ func (d *Decoder) decodeMessageDefinition(header byte) error {
 	if len(d.options.mesgDefListeners) > 0 {
 		// Clone since we don't have control of the object lifecycle outside Decoder.
 		mesgDef := *mesgDef
-		mesgDef.FieldDefinitions = append(mesgDef.FieldDefinitions[:0:0], mesgDef.FieldDefinitions...)
-		mesgDef.DeveloperFieldDefinitions = append(mesgDef.DeveloperFieldDefinitions[:0:0], mesgDef.DeveloperFieldDefinitions...)
+		mesgDef.FieldDefinitions = sliceutil.Clone(mesgDef.FieldDefinitions)
+		mesgDef.DeveloperFieldDefinitions = sliceutil.Clone(mesgDef.DeveloperFieldDefinitions)
 		for i := range d.options.mesgDefListeners {
 			d.options.mesgDefListeners[i].OnMesgDef(mesgDef) // blocking or non-blocking depends on listeners' implementation.
 		}
@@ -683,8 +684,8 @@ func (d *Decoder) decodeMessageData(header byte) (err error) {
 	}
 
 	if !d.options.broadcastOnly || d.options.broadcastMesgCopy {
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
-		mesg.DeveloperFields = append(mesg.DeveloperFields[:0:0], mesg.DeveloperFields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
+		mesg.DeveloperFields = sliceutil.Clone(mesg.DeveloperFields)
 	}
 
 	if !d.options.broadcastOnly {

--- a/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
+++ b/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
@@ -9,6 +9,7 @@ package {{ .Package }}
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 	{{- if .Imports -}}
@@ -66,10 +67,7 @@ func New{{ .Name }}(mesg *proto.Message) *{{ .Name }} {
 			{{ end -}}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		{{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
 			developerFields = mesg.DeveloperFields

--- a/internal/sliceutil/sliceutil.go
+++ b/internal/sliceutil/sliceutil.go
@@ -1,0 +1,26 @@
+// Copyright 2024 The FIT SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package sliceutil contains helper functions that either slices package does not
+// provide or it's provided but not suitable for our use case.
+package sliceutil
+
+// Clone shallow copies s, but unlike slices.Clone that uses append variant,
+// this uses make+copy variant so we don't generate additional unused capacity.
+// This will return nil when len(s) == 0 instead of returning zerobase slice
+// since we use it to clone a slice that is backed by an array pool.
+//
+// Related issues regarding slices.Clone that we are trying to solve with this:
+//   - https://go.dev/issue/68488: keep alive underlying array on zero len slice,
+//     affected Go version: v1.22.0 up to v.1.23.X. CL has been merged but it seems
+//     without a backport, so the issue might not be resolved until v1.24.0.
+//   - https://go.dev/issue/53643: suboptimal performance
+func Clone[S ~[]E, E any](s S) (s2 S) {
+	if len(s) == 0 {
+		return nil
+	}
+	s2 = make(S, len(s))
+	copy(s2, s)
+	return s2
+}

--- a/internal/sliceutil/sliceutil_test.go
+++ b/internal/sliceutil/sliceutil_test.go
@@ -1,0 +1,58 @@
+// Copyright 2024 The FIT SDK for Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sliceutil
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestClone(t *testing.T) {
+	tt := []struct {
+		name     string
+		values   []int
+		expected []int
+	}{
+		{
+			name:     "nil",
+			values:   nil,
+			expected: nil,
+		},
+		{
+			name:     "has one value",
+			values:   []int{0},
+			expected: []int{0},
+		},
+		{
+			name:     "has zero value",
+			values:   []int{},
+			expected: nil,
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
+			s := Clone(tc.values)
+			if tc.values == nil {
+				if s != nil {
+					t.Fatalf("expected nil")
+				}
+				return
+			}
+			if p1, p2 := unsafe.SliceData(s), unsafe.SliceData(tc.values); len(tc.values) == 0 && p1 == p2 {
+				t.Fatalf("cloned values (%v) shares the same underlying array: %p == %p", s, p1, p2)
+			}
+			if tc.expected == nil {
+				return
+			}
+			if diff := cmp.Diff(tc.values, tc.expected); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/profile/filedef/activity.go
+++ b/profile/filedef/activity.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -114,7 +115,7 @@ func (f *Activity) Add(mesg proto.Message) {
 	case mesgnum.Sport:
 		f.Sports = append(f.Sports, mesgdef.NewSport(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/activity_summary.go
+++ b/profile/filedef/activity_summary.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -52,7 +53,7 @@ func (f *ActivitySummary) Add(mesg proto.Message) {
 	case mesgnum.Lap:
 		f.Laps = append(f.Laps, mesgdef.NewLap(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/blood_pressure.go
+++ b/profile/filedef/blood_pressure.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -52,7 +53,7 @@ func (f *BloodPressure) Add(mesg proto.Message) {
 	case mesgnum.DeviceInfo:
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/course.go
+++ b/profile/filedef/course.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -68,7 +69,7 @@ func (f *Course) Add(mesg proto.Message) {
 	case mesgnum.CoursePoint:
 		f.CoursePoints = append(f.CoursePoints, mesgdef.NewCoursePoint(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/device.go
+++ b/profile/filedef/device.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -58,7 +59,7 @@ func (f *Device) Add(mesg proto.Message) {
 	case mesgnum.FieldCapabilities:
 		f.FieldCapabilities = append(f.FieldCapabilities, mesgdef.NewFieldCapabilities(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/goals.go
+++ b/profile/filedef/goals.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -46,7 +47,7 @@ func (f *Goals) Add(mesg proto.Message) {
 	case mesgnum.Goal:
 		f.Goals = append(f.Goals, mesgdef.NewGoal(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/listener.go
+++ b/profile/filedef/listener.go
@@ -6,6 +6,7 @@ package filedef
 
 import (
 	"github.com/muktihari/fit/decoder"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/profile/untyped/fieldnum"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
@@ -170,7 +171,7 @@ func (l *Listener) OnMesg(mesg proto.Message) {
 
 	mesg.Fields = append((<-l.poolc)[:0], mesg.Fields...)
 	// Must clone DeveloperFields since it is being referenced in mesgdef's structs.
-	mesg.DeveloperFields = append(mesg.DeveloperFields[:0:0], mesg.DeveloperFields...)
+	mesg.DeveloperFields = sliceutil.Clone(mesg.DeveloperFields)
 
 	l.mesgc <- mesg
 }

--- a/profile/filedef/monitoring_ab.go
+++ b/profile/filedef/monitoring_ab.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -56,7 +57,7 @@ func (f *MonitoringAB) Add(mesg proto.Message) {
 	case mesgnum.DeviceInfo:
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/monitoring_daily.go
+++ b/profile/filedef/monitoring_daily.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -52,7 +53,7 @@ func (f *MonitoringDaily) Add(mesg proto.Message) {
 	case mesgnum.DeviceInfo:
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/schedules.go
+++ b/profile/filedef/schedules.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -46,7 +47,7 @@ func (f *Schedules) Add(mesg proto.Message) {
 	case mesgnum.Schedule:
 		f.Schedules = append(f.Schedules, mesgdef.NewSchedule(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/segment.go
+++ b/profile/filedef/segment.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -55,7 +56,7 @@ func (f *Segment) Add(mesg proto.Message) {
 	case mesgnum.SegmentPoint:
 		f.SegmentPoints = append(f.SegmentPoints, mesgdef.NewSegmentPoint(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/segment_list.go
+++ b/profile/filedef/segment_list.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -49,7 +50,7 @@ func (f *SegmentList) Add(mesg proto.Message) {
 	case mesgnum.SegmentFile:
 		f.SegmentFiles = append(f.SegmentFiles, mesgdef.NewSegmentFile(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/settings.go
+++ b/profile/filedef/settings.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -58,7 +59,7 @@ func (f *Settings) Add(mesg proto.Message) {
 	case mesgnum.DeviceSettings:
 		f.DeviceSettings = append(f.DeviceSettings, mesgdef.NewDeviceSettings(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/sport.go
+++ b/profile/filedef/sport.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -64,7 +65,7 @@ func (f *Sport) Add(mesg proto.Message) {
 	case mesgnum.CadenceZone:
 		f.CadenceZones = append(f.CadenceZones, mesgdef.NewCadenceZone(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/totals.go
+++ b/profile/filedef/totals.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -47,7 +48,7 @@ func (f *Totals) Add(mesg proto.Message) {
 	case mesgnum.Totals:
 		f.Totals = append(f.Totals, mesgdef.NewTotals(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/weight.go
+++ b/profile/filedef/weight.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -52,7 +53,7 @@ func (f *Weight) Add(mesg proto.Message) {
 	case mesgnum.DeviceInfo:
 		f.DeviceInfos = append(f.DeviceInfos, mesgdef.NewDeviceInfo(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/filedef/workout.go
+++ b/profile/filedef/workout.go
@@ -5,6 +5,7 @@
 package filedef
 
 import (
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
@@ -53,7 +54,7 @@ func (f *Workout) Add(mesg proto.Message) {
 	case mesgnum.WorkoutStep:
 		f.WorkoutSteps = append(f.WorkoutSteps, mesgdef.NewWorkoutStep(&mesg))
 	default:
-		mesg.Fields = append(mesg.Fields[:0:0], mesg.Fields...)
+		mesg.Fields = sliceutil.Clone(mesg.Fields)
 		f.UnrelatedMessages = append(f.UnrelatedMessages, mesg)
 	}
 }

--- a/profile/mesgdef/aad_accel_features_gen.go
+++ b/profile/mesgdef/aad_accel_features_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -49,10 +50,7 @@ func NewAadAccelFeatures(mesg *proto.Message) *AadAccelFeatures {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/accelerometer_data_gen.go
+++ b/profile/mesgdef/accelerometer_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -54,10 +55,7 @@ func NewAccelerometerData(mesg *proto.Message) *AccelerometerData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/activity_gen.go
+++ b/profile/mesgdef/activity_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -51,10 +52,7 @@ func NewActivity(mesg *proto.Message) *Activity {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/ant_channel_id_gen.go
+++ b/profile/mesgdef/ant_channel_id_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -45,10 +46,7 @@ func NewAntChannelId(mesg *proto.Message) *AntChannelId {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/ant_rx_gen.go
+++ b/profile/mesgdef/ant_rx_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -56,10 +57,7 @@ func NewAntRx(mesg *proto.Message) *AntRx {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/ant_tx_gen.go
+++ b/profile/mesgdef/ant_tx_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -56,10 +57,7 @@ func NewAntTx(mesg *proto.Message) *AntTx {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/aviation_attitude_gen.go
+++ b/profile/mesgdef/aviation_attitude_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -56,10 +57,7 @@ func NewAviationAttitude(mesg *proto.Message) *AviationAttitude {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/barometer_data_gen.go
+++ b/profile/mesgdef/barometer_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -46,10 +47,7 @@ func NewBarometerData(mesg *proto.Message) *BarometerData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/beat_intervals_gen.go
+++ b/profile/mesgdef/beat_intervals_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -45,10 +46,7 @@ func NewBeatIntervals(mesg *proto.Message) *BeatIntervals {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/bike_profile_gen.go
+++ b/profile/mesgdef/bike_profile_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -73,10 +74,7 @@ func NewBikeProfile(mesg *proto.Message) *BikeProfile {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/blood_pressure_gen.go
+++ b/profile/mesgdef/blood_pressure_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -53,10 +54,7 @@ func NewBloodPressure(mesg *proto.Message) *BloodPressure {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/cadence_zone_gen.go
+++ b/profile/mesgdef/cadence_zone_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -43,10 +44,7 @@ func NewCadenceZone(mesg *proto.Message) *CadenceZone {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/camera_event_gen.go
+++ b/profile/mesgdef/camera_event_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -47,10 +48,7 @@ func NewCameraEvent(mesg *proto.Message) *CameraEvent {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/capabilities_gen.go
+++ b/profile/mesgdef/capabilities_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
 	"unsafe"
@@ -44,10 +45,7 @@ func NewCapabilities(mesg *proto.Message) *Capabilities {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/chrono_shot_data_gen.go
+++ b/profile/mesgdef/chrono_shot_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -46,10 +47,7 @@ func NewChronoShotData(mesg *proto.Message) *ChronoShotData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/chrono_shot_session_gen.go
+++ b/profile/mesgdef/chrono_shot_session_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -50,10 +51,7 @@ func NewChronoShotSession(mesg *proto.Message) *ChronoShotSession {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/climb_pro_gen.go
+++ b/profile/mesgdef/climb_pro_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/semicircles"
 	"github.com/muktihari/fit/profile/basetype"
@@ -51,10 +52,7 @@ func NewClimbPro(mesg *proto.Message) *ClimbPro {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/connectivity_gen.go
+++ b/profile/mesgdef/connectivity_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -53,10 +54,7 @@ func NewConnectivity(mesg *proto.Message) *Connectivity {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/course_gen.go
+++ b/profile/mesgdef/course_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -44,10 +45,7 @@ func NewCourse(mesg *proto.Message) *Course {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/course_point_gen.go
+++ b/profile/mesgdef/course_point_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/semicircles"
 	"github.com/muktihari/fit/profile/basetype"
@@ -52,10 +53,7 @@ func NewCoursePoint(mesg *proto.Message) *CoursePoint {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/developer_data_id_gen.go
+++ b/profile/mesgdef/developer_data_id_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -43,10 +44,7 @@ func NewDeveloperDataId(mesg *proto.Message) *DeveloperDataId {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 	}
 

--- a/profile/mesgdef/device_aux_battery_info_gen.go
+++ b/profile/mesgdef/device_aux_battery_info_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -48,10 +49,7 @@ func NewDeviceAuxBatteryInfo(mesg *proto.Message) *DeviceAuxBatteryInfo {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/device_info_gen.go
+++ b/profile/mesgdef/device_info_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -62,10 +63,7 @@ func NewDeviceInfo(mesg *proto.Message) *DeviceInfo {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/device_settings_gen.go
+++ b/profile/mesgdef/device_settings_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -68,10 +69,7 @@ func NewDeviceSettings(mesg *proto.Message) *DeviceSettings {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/dive_alarm_gen.go
+++ b/profile/mesgdef/dive_alarm_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -55,10 +56,7 @@ func NewDiveAlarm(mesg *proto.Message) *DiveAlarm {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/dive_apnea_alarm_gen.go
+++ b/profile/mesgdef/dive_apnea_alarm_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -55,10 +56,7 @@ func NewDiveApneaAlarm(mesg *proto.Message) *DiveApneaAlarm {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/dive_gas_gen.go
+++ b/profile/mesgdef/dive_gas_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -45,10 +46,7 @@ func NewDiveGas(mesg *proto.Message) *DiveGas {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/dive_settings_gen.go
+++ b/profile/mesgdef/dive_settings_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -78,10 +79,7 @@ func NewDiveSettings(mesg *proto.Message) *DiveSettings {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/dive_summary_gen.go
+++ b/profile/mesgdef/dive_summary_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -66,10 +67,7 @@ func NewDiveSummary(mesg *proto.Message) *DiveSummary {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/event_gen.go
+++ b/profile/mesgdef/event_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -69,10 +70,7 @@ func NewEvent(mesg *proto.Message) *Event {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/exd_data_concept_configuration_gen.go
+++ b/profile/mesgdef/exd_data_concept_configuration_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -58,10 +59,7 @@ func NewExdDataConceptConfiguration(mesg *proto.Message) *ExdDataConceptConfigur
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/exd_data_field_configuration_gen.go
+++ b/profile/mesgdef/exd_data_field_configuration_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -53,10 +54,7 @@ func NewExdDataFieldConfiguration(mesg *proto.Message) *ExdDataFieldConfiguratio
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/exd_screen_configuration_gen.go
+++ b/profile/mesgdef/exd_screen_configuration_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -44,10 +45,7 @@ func NewExdScreenConfiguration(mesg *proto.Message) *ExdScreenConfiguration {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/exercise_title_gen.go
+++ b/profile/mesgdef/exercise_title_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -44,10 +45,7 @@ func NewExerciseTitle(mesg *proto.Message) *ExerciseTitle {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/field_capabilities_gen.go
+++ b/profile/mesgdef/field_capabilities_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -45,10 +46,7 @@ func NewFieldCapabilities(mesg *proto.Message) *FieldCapabilities {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/field_description_gen.go
+++ b/profile/mesgdef/field_description_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -52,10 +53,7 @@ func NewFieldDescription(mesg *proto.Message) *FieldDescription {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 	}
 

--- a/profile/mesgdef/file_capabilities_gen.go
+++ b/profile/mesgdef/file_capabilities_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -46,10 +47,7 @@ func NewFileCapabilities(mesg *proto.Message) *FileCapabilities {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/file_creator_gen.go
+++ b/profile/mesgdef/file_creator_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -42,10 +43,7 @@ func NewFileCreator(mesg *proto.Message) *FileCreator {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/file_id_gen.go
+++ b/profile/mesgdef/file_id_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -47,10 +48,7 @@ func NewFileId(mesg *proto.Message) *FileId {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 	}
 

--- a/profile/mesgdef/goal_gen.go
+++ b/profile/mesgdef/goal_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -55,10 +56,7 @@ func NewGoal(mesg *proto.Message) *Goal {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/gps_metadata_gen.go
+++ b/profile/mesgdef/gps_metadata_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/semicircles"
 	"github.com/muktihari/fit/profile/basetype"
@@ -53,10 +54,7 @@ func NewGpsMetadata(mesg *proto.Message) *GpsMetadata {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/gyroscope_data_gen.go
+++ b/profile/mesgdef/gyroscope_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -51,10 +52,7 @@ func NewGyroscopeData(mesg *proto.Message) *GyroscopeData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hr_gen.go
+++ b/profile/mesgdef/hr_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -56,10 +57,7 @@ func NewHr(mesg *proto.Message) *Hr {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hr_zone_gen.go
+++ b/profile/mesgdef/hr_zone_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -43,10 +44,7 @@ func NewHrZone(mesg *proto.Message) *HrZone {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hrm_profile_gen.go
+++ b/profile/mesgdef/hrm_profile_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -45,10 +46,7 @@ func NewHrmProfile(mesg *proto.Message) *HrmProfile {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hrv_gen.go
+++ b/profile/mesgdef/hrv_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -42,10 +43,7 @@ func NewHrv(mesg *proto.Message) *Hrv {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hrv_status_summary_gen.go
+++ b/profile/mesgdef/hrv_status_summary_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -51,10 +52,7 @@ func NewHrvStatusSummary(mesg *proto.Message) *HrvStatusSummary {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hrv_value_gen.go
+++ b/profile/mesgdef/hrv_value_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -45,10 +46,7 @@ func NewHrvValue(mesg *proto.Message) *HrvValue {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hsa_accelerometer_data_gen.go
+++ b/profile/mesgdef/hsa_accelerometer_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -50,10 +51,7 @@ func NewHsaAccelerometerData(mesg *proto.Message) *HsaAccelerometerData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hsa_body_battery_data_gen.go
+++ b/profile/mesgdef/hsa_body_battery_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -47,10 +48,7 @@ func NewHsaBodyBatteryData(mesg *proto.Message) *HsaBodyBatteryData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hsa_configuration_data_gen.go
+++ b/profile/mesgdef/hsa_configuration_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -45,10 +46,7 @@ func NewHsaConfigurationData(mesg *proto.Message) *HsaConfigurationData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hsa_event_gen.go
+++ b/profile/mesgdef/hsa_event_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -44,10 +45,7 @@ func NewHsaEvent(mesg *proto.Message) *HsaEvent {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hsa_gyroscope_data_gen.go
+++ b/profile/mesgdef/hsa_gyroscope_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -50,10 +51,7 @@ func NewHsaGyroscopeData(mesg *proto.Message) *HsaGyroscopeData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hsa_heart_rate_data_gen.go
+++ b/profile/mesgdef/hsa_heart_rate_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -46,10 +47,7 @@ func NewHsaHeartRateData(mesg *proto.Message) *HsaHeartRateData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hsa_respiration_data_gen.go
+++ b/profile/mesgdef/hsa_respiration_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -46,10 +47,7 @@ func NewHsaRespirationData(mesg *proto.Message) *HsaRespirationData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hsa_spo2_data_gen.go
+++ b/profile/mesgdef/hsa_spo2_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -46,10 +47,7 @@ func NewHsaSpo2Data(mesg *proto.Message) *HsaSpo2Data {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hsa_step_data_gen.go
+++ b/profile/mesgdef/hsa_step_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -45,10 +46,7 @@ func NewHsaStepData(mesg *proto.Message) *HsaStepData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hsa_stress_data_gen.go
+++ b/profile/mesgdef/hsa_stress_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -45,10 +46,7 @@ func NewHsaStressData(mesg *proto.Message) *HsaStressData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/hsa_wrist_temperature_data_gen.go
+++ b/profile/mesgdef/hsa_wrist_temperature_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -46,10 +47,7 @@ func NewHsaWristTemperatureData(mesg *proto.Message) *HsaWristTemperatureData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/jump_gen.go
+++ b/profile/mesgdef/jump_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/semicircles"
 	"github.com/muktihari/fit/profile/basetype"
@@ -61,10 +62,7 @@ func NewJump(mesg *proto.Message) *Jump {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/lap_gen.go
+++ b/profile/mesgdef/lap_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/semicircles"
 	"github.com/muktihari/fit/profile/basetype"
@@ -174,10 +175,7 @@ func NewLap(mesg *proto.Message) *Lap {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/length_gen.go
+++ b/profile/mesgdef/length_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -72,10 +73,7 @@ func NewLength(mesg *proto.Message) *Length {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/magnetometer_data_gen.go
+++ b/profile/mesgdef/magnetometer_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -51,10 +52,7 @@ func NewMagnetometerData(mesg *proto.Message) *MagnetometerData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/max_met_data_gen.go
+++ b/profile/mesgdef/max_met_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -51,10 +52,7 @@ func NewMaxMetData(mesg *proto.Message) *MaxMetData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/memo_glob_gen.go
+++ b/profile/mesgdef/memo_glob_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -46,10 +47,7 @@ func NewMemoGlob(mesg *proto.Message) *MemoGlob {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/mesg_capabilities_gen.go
+++ b/profile/mesgdef/mesg_capabilities_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -45,10 +46,7 @@ func NewMesgCapabilities(mesg *proto.Message) *MesgCapabilities {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/met_zone_gen.go
+++ b/profile/mesgdef/met_zone_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -45,10 +46,7 @@ func NewMetZone(mesg *proto.Message) *MetZone {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/monitoring_gen.go
+++ b/profile/mesgdef/monitoring_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -79,10 +80,7 @@ func NewMonitoring(mesg *proto.Message) *Monitoring {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/monitoring_hr_data_gen.go
+++ b/profile/mesgdef/monitoring_hr_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -45,10 +46,7 @@ func NewMonitoringHrData(mesg *proto.Message) *MonitoringHrData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/monitoring_info_gen.go
+++ b/profile/mesgdef/monitoring_info_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -50,10 +51,7 @@ func NewMonitoringInfo(mesg *proto.Message) *MonitoringInfo {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/nmea_sentence_gen.go
+++ b/profile/mesgdef/nmea_sentence_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -45,10 +46,7 @@ func NewNmeaSentence(mesg *proto.Message) *NmeaSentence {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/obdii_data_gen.go
+++ b/profile/mesgdef/obdii_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -51,10 +52,7 @@ func NewObdiiData(mesg *proto.Message) *ObdiiData {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/ohr_settings_gen.go
+++ b/profile/mesgdef/ohr_settings_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -43,10 +44,7 @@ func NewOhrSettings(mesg *proto.Message) *OhrSettings {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/one_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/one_d_sensor_calibration_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -48,10 +49,7 @@ func NewOneDSensorCalibration(mesg *proto.Message) *OneDSensorCalibration {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/power_zone_gen.go
+++ b/profile/mesgdef/power_zone_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -43,10 +44,7 @@ func NewPowerZone(mesg *proto.Message) *PowerZone {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/raw_bbi_gen.go
+++ b/profile/mesgdef/raw_bbi_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -55,10 +56,7 @@ func NewRawBbi(mesg *proto.Message) *RawBbi {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/record_gen.go
+++ b/profile/mesgdef/record_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/semicircles"
 	"github.com/muktihari/fit/profile/basetype"
@@ -135,10 +136,7 @@ func NewRecord(mesg *proto.Message) *Record {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/respiration_rate_gen.go
+++ b/profile/mesgdef/respiration_rate_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -45,10 +46,7 @@ func NewRespirationRate(mesg *proto.Message) *RespirationRate {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/schedule_gen.go
+++ b/profile/mesgdef/schedule_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -49,10 +50,7 @@ func NewSchedule(mesg *proto.Message) *Schedule {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/sdm_profile_gen.go
+++ b/profile/mesgdef/sdm_profile_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -49,10 +50,7 @@ func NewSdmProfile(mesg *proto.Message) *SdmProfile {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/segment_file_gen.go
+++ b/profile/mesgdef/segment_file_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -50,10 +51,7 @@ func NewSegmentFile(mesg *proto.Message) *SegmentFile {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/segment_id_gen.go
+++ b/profile/mesgdef/segment_id_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -49,10 +50,7 @@ func NewSegmentId(mesg *proto.Message) *SegmentId {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/segment_lap_gen.go
+++ b/profile/mesgdef/segment_lap_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/semicircles"
 	"github.com/muktihari/fit/profile/basetype"
@@ -146,10 +147,7 @@ func NewSegmentLap(mesg *proto.Message) *SegmentLap {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/segment_leaderboard_entry_gen.go
+++ b/profile/mesgdef/segment_leaderboard_entry_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -48,10 +49,7 @@ func NewSegmentLeaderboardEntry(mesg *proto.Message) *SegmentLeaderboardEntry {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/segment_point_gen.go
+++ b/profile/mesgdef/segment_point_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/semicircles"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -56,10 +57,7 @@ func NewSegmentPoint(mesg *proto.Message) *SegmentPoint {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/session_gen.go
+++ b/profile/mesgdef/session_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/semicircles"
 	"github.com/muktihari/fit/profile/basetype"
@@ -207,10 +208,7 @@ func NewSession(mesg *proto.Message) *Session {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/set_gen.go
+++ b/profile/mesgdef/set_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -55,10 +56,7 @@ func NewSet(mesg *proto.Message) *Set {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/skin_temp_overnight_gen.go
+++ b/profile/mesgdef/skin_temp_overnight_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -48,10 +49,7 @@ func NewSkinTempOvernight(mesg *proto.Message) *SkinTempOvernight {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/slave_device_gen.go
+++ b/profile/mesgdef/slave_device_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -42,10 +43,7 @@ func NewSlaveDevice(mesg *proto.Message) *SlaveDevice {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/sleep_assessment_gen.go
+++ b/profile/mesgdef/sleep_assessment_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -55,10 +56,7 @@ func NewSleepAssessment(mesg *proto.Message) *SleepAssessment {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/sleep_level_gen.go
+++ b/profile/mesgdef/sleep_level_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -43,10 +44,7 @@ func NewSleepLevel(mesg *proto.Message) *SleepLevel {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/software_gen.go
+++ b/profile/mesgdef/software_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -44,10 +45,7 @@ func NewSoftware(mesg *proto.Message) *Software {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/speed_zone_gen.go
+++ b/profile/mesgdef/speed_zone_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -44,10 +45,7 @@ func NewSpeedZone(mesg *proto.Message) *SpeedZone {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/split_gen.go
+++ b/profile/mesgdef/split_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/semicircles"
 	"github.com/muktihari/fit/profile/basetype"
@@ -63,10 +64,7 @@ func NewSplit(mesg *proto.Message) *Split {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/split_summary_gen.go
+++ b/profile/mesgdef/split_summary_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -55,10 +56,7 @@ func NewSplitSummary(mesg *proto.Message) *SplitSummary {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/spo2_data_gen.go
+++ b/profile/mesgdef/spo2_data_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -46,10 +47,7 @@ func NewSpo2Data(mesg *proto.Message) *Spo2Data {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/sport_gen.go
+++ b/profile/mesgdef/sport_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -43,10 +44,7 @@ func NewSport(mesg *proto.Message) *Sport {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/stress_level_gen.go
+++ b/profile/mesgdef/stress_level_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -44,10 +45,7 @@ func NewStressLevel(mesg *proto.Message) *StressLevel {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/tank_summary_gen.go
+++ b/profile/mesgdef/tank_summary_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -48,10 +49,7 @@ func NewTankSummary(mesg *proto.Message) *TankSummary {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/tank_update_gen.go
+++ b/profile/mesgdef/tank_update_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -46,10 +47,7 @@ func NewTankUpdate(mesg *proto.Message) *TankUpdate {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/three_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/three_d_sensor_calibration_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -50,10 +51,7 @@ func NewThreeDSensorCalibration(mesg *proto.Message) *ThreeDSensorCalibration {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/time_in_zone_gen.go
+++ b/profile/mesgdef/time_in_zone_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -60,10 +61,7 @@ func NewTimeInZone(mesg *proto.Message) *TimeInZone {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/timestamp_correlation_gen.go
+++ b/profile/mesgdef/timestamp_correlation_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -50,10 +51,7 @@ func NewTimestampCorrelation(mesg *proto.Message) *TimestampCorrelation {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/totals_gen.go
+++ b/profile/mesgdef/totals_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -52,10 +53,7 @@ func NewTotals(mesg *proto.Message) *Totals {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/training_file_gen.go
+++ b/profile/mesgdef/training_file_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -48,10 +49,7 @@ func NewTrainingFile(mesg *proto.Message) *TrainingFile {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/user_profile_gen.go
+++ b/profile/mesgdef/user_profile_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -70,10 +71,7 @@ func NewUserProfile(mesg *proto.Message) *UserProfile {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/video_clip_gen.go
+++ b/profile/mesgdef/video_clip_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -49,10 +50,7 @@ func NewVideoClip(mesg *proto.Message) *VideoClip {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/video_description_gen.go
+++ b/profile/mesgdef/video_description_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -43,10 +44,7 @@ func NewVideoDescription(mesg *proto.Message) *VideoDescription {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/video_frame_gen.go
+++ b/profile/mesgdef/video_frame_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -45,10 +46,7 @@ func NewVideoFrame(mesg *proto.Message) *VideoFrame {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/video_gen.go
+++ b/profile/mesgdef/video_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -43,10 +44,7 @@ func NewVideo(mesg *proto.Message) *Video {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/video_title_gen.go
+++ b/profile/mesgdef/video_title_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -43,10 +44,7 @@ func NewVideoTitle(mesg *proto.Message) *VideoTitle {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/watchface_settings_gen.go
+++ b/profile/mesgdef/watchface_settings_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -43,10 +44,7 @@ func NewWatchfaceSettings(mesg *proto.Message) *WatchfaceSettings {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/weather_alert_gen.go
+++ b/profile/mesgdef/weather_alert_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -48,10 +49,7 @@ func NewWeatherAlert(mesg *proto.Message) *WeatherAlert {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/weather_conditions_gen.go
+++ b/profile/mesgdef/weather_conditions_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/kit/semicircles"
 	"github.com/muktihari/fit/profile/basetype"
@@ -60,10 +61,7 @@ func NewWeatherConditions(mesg *proto.Message) *WeatherConditions {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/weight_scale_gen.go
+++ b/profile/mesgdef/weight_scale_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
@@ -57,10 +58,7 @@ func NewWeightScale(mesg *proto.Message) *WeightScale {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/workout_gen.go
+++ b/profile/mesgdef/workout_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -49,10 +50,7 @@ func NewWorkout(mesg *proto.Message) *Workout {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/workout_session_gen.go
+++ b/profile/mesgdef/workout_session_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -48,10 +49,7 @@ func NewWorkoutSession(mesg *proto.Message) *WorkoutSession {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/workout_step_gen.go
+++ b/profile/mesgdef/workout_step_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -60,10 +61,7 @@ func NewWorkoutStep(mesg *proto.Message) *WorkoutStep {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}

--- a/profile/mesgdef/zones_target_gen.go
+++ b/profile/mesgdef/zones_target_gen.go
@@ -8,6 +8,7 @@ package mesgdef
 
 import (
 	"github.com/muktihari/fit/factory"
+	"github.com/muktihari/fit/internal/sliceutil"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/profile/typedef"
 	"github.com/muktihari/fit/proto"
@@ -45,10 +46,7 @@ func NewZonesTarget(mesg *proto.Message) *ZonesTarget {
 			}
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
-		if len(unknownFields) == 0 {
-			unknownFields = nil
-		}
-		unknownFields = append(unknownFields[:0:0], unknownFields...)
+		unknownFields = sliceutil.Clone(unknownFields)
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}


### PR DESCRIPTION
Currently we use  `append(s[:0:0], s...)` to clone a slice from an array pool. That approach comes with drawback if the slice happen to have zero len, the returning slice will share the same backing array of the array pool, causing array pool can not be freed until the returning slice become unreachable. More detail is declared here: https://github.com/golang/go/issues/68488#issuecomment-2378374828

This pattern was inspired from `slices.Clone`'s CL that was first introduced in Go version v1.22.0. A new CL has been merged into Go's main branch to fix this issue but it seems without a backport request, so it might not be available until v1.24.0. If that's the case, people using v1.22.0 to v1.23.X are still being affected unless we do something about it. Since we typically clone a slice from an array pool, let's create our own clone function that better suite that case.