### PR TITLE
fix: decoder component expansion

### DIFF
--- a/decoder/accumulator.go
+++ b/decoder/accumulator.go
@@ -36,8 +36,8 @@ func (a *Accumulator) Collect(mesgNum typedef.MesgNum, destFieldNum byte, val ui
 	})
 }
 
-// Accumulate calculates the accumulated value and update accordingly. It returns the original value
-// when the corresponding value does not exist.
+// Accumulate calculates the accumulated value and update it accordingly. If targeted value
+// does not exist, it will be collected and the original value will be returned.
 func (a *Accumulator) Accumulate(mesgNum typedef.MesgNum, destFieldNum byte, val uint32, bits byte) uint32 {
 	for i := range a.values {
 		av := &a.values[i]
@@ -48,6 +48,12 @@ func (a *Accumulator) Accumulate(mesgNum typedef.MesgNum, destFieldNum byte, val
 			return av.value
 		}
 	}
+	a.values = append(a.values, value{
+		mesgNum:  mesgNum,
+		fieldNum: destFieldNum,
+		value:    val,
+		last:     val,
+	})
 	return val
 }
 

--- a/decoder/bits.go
+++ b/decoder/bits.go
@@ -5,80 +5,192 @@
 package decoder
 
 import (
+	"math"
+
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/proto"
 )
 
-const (
-	bit     = 8
-	maxBit  = 32
-	bitSize = maxBit / bit
-)
-
-// bitsFromValue convert value into 32-bits unsigned integer.
+// bitvalue holds proto.Value in its integer form, enabling us to do bitwise operation over it.
+// This is used for component expansion as Field's Value requiring expansion can hold up to
+// 255 byte (2040 bits) data, this is obviously way more bits than Go's primitive value can handle.
 //
-// Profile.xlsx (on Bits header's comment) says: Current implementation only supports Bits value of max 32.
-func bitsFromValue(value proto.Value) (bits uint32, ok bool) {
-	switch value.Type() {
-	case proto.TypeInt8:
-		return uint32(value.Int8()), true
-	case proto.TypeUint8:
-		return uint32(value.Uint8()), true
-	case proto.TypeInt16:
-		return uint32(value.Int16()), true
-	case proto.TypeUint16:
-		return uint32(value.Uint16()), true
-	case proto.TypeInt32:
-		return uint32(value.Int32()), true
-	case proto.TypeUint32:
-		return value.Uint32(), true
-	case proto.TypeInt64:
-		return uint32(value.Int64()), true
-	case proto.TypeUint64:
-		return uint32(value.Uint64()), true
-	case proto.TypeFloat32:
-		return uint32(value.Float32()), true
-	case proto.TypeFloat64:
-		return uint32(value.Float64()), true
-	case proto.TypeSliceUint8:
-		val := value.SliceUint8()
-		if len(val) > bitSize {
-			return 0, false
-		}
-		for i := range val {
-			if val[i] == basetype.ByteInvalid { // all values must be valid
-				return 0, false
-			}
-			bits |= uint32(val[i]) << (i * bit) // little-endian
-		}
-		return bits, true
-	}
-	return 0, false
+// In Profile.xlsx (at least v21.141), the biggest value for component expansion is "raw_bbi"
+// message for having 240 bits on "data" and the second is "hr" message for having 120 bits
+// on "event_timestamp_12".
+type bitvalue struct {
+	// NOTE: We use array to avoid memory allocation, it's simple to maintain and it has more
+	// deterministic performance. Max value to hold is 2040 bits, so the value of the last
+	// index will always less than math.MaxUint64. We use the last index to determine the
+	// validity of this stuct, if last index is math.MaxUint64, it's an invalid bitval.
+	store [32]uint64
 }
 
-// valueFromBits cast back bits into it's original value.
-func valueFromBits(bits uint32, baseType basetype.BaseType) proto.Value {
+// makeBitValue creates bitvalue from proto.Value.
+func makeBitValue(value proto.Value) (v bitvalue, ok bool) {
+	switch value.Type() {
+	case proto.TypeInt8:
+		return bitvalue{store: [32]uint64{uint64(value.Int8())}}, true
+	case proto.TypeUint8:
+		return bitvalue{store: [32]uint64{uint64(value.Uint8())}}, true
+	case proto.TypeInt16:
+		return bitvalue{store: [32]uint64{uint64(value.Int16())}}, true
+	case proto.TypeUint16:
+		return bitvalue{store: [32]uint64{uint64(value.Uint16())}}, true
+	case proto.TypeInt32:
+		return bitvalue{store: [32]uint64{uint64(value.Int32())}}, true
+	case proto.TypeUint32:
+		return bitvalue{store: [32]uint64{uint64(value.Uint32())}}, true
+	case proto.TypeInt64:
+		return bitvalue{store: [32]uint64{uint64(value.Int64())}}, true
+	case proto.TypeUint64:
+		return bitvalue{store: [32]uint64{value.Uint64()}}, true
+	case proto.TypeFloat32:
+		return bitvalue{store: [32]uint64{uint64(value.Float32())}}, true
+	case proto.TypeFloat64:
+		return bitvalue{store: [32]uint64{uint64(value.Float64())}}, true
+	case proto.TypeSliceInt8:
+		return bitvalue{store: makeStoreFromSlice(value.SliceInt8(), 1)}, true
+	case proto.TypeSliceUint8:
+		return bitvalue{store: makeStoreFromSlice(value.SliceUint8(), 1)}, true
+	case proto.TypeSliceInt16:
+		return bitvalue{store: makeStoreFromSlice(value.SliceInt16(), 2)}, true
+	case proto.TypeSliceUint16:
+		return bitvalue{store: makeStoreFromSlice(value.SliceUint16(), 2)}, true
+	case proto.TypeSliceInt32:
+		return bitvalue{store: makeStoreFromSlice(value.SliceInt32(), 4)}, true
+	case proto.TypeSliceUint32:
+		return bitvalue{store: makeStoreFromSlice(value.SliceUint32(), 4)}, true
+	case proto.TypeSliceInt64:
+		return bitvalue{store: makeStoreFromSlice(value.SliceInt64(), 8)}, true
+	case proto.TypeSliceUint64:
+		return bitvalue{store: makeStoreFromSlice(value.SliceUint64(), 8)}, true
+	case proto.TypeSliceFloat32:
+		return bitvalue{store: makeStoreFromSlice(value.SliceFloat32(), 4)}, true
+	case proto.TypeSliceFloat64:
+		return bitvalue{store: makeStoreFromSlice(value.SliceFloat64(), 8)}, true
+	}
+	return bitvalue{store: [32]uint64{31: math.MaxUint64}}, false
+}
+
+type numeric interface {
+	int8 | uint8 | int16 | uint16 | int32 | uint32 | int64 | uint64 | float32 | float64
+}
+
+// makeStoreFromSlice creates value store from given s (slice of supported numeric type).
+func makeStoreFromSlice[S []E, E numeric](s S, bitsize uint8) (store [32]uint64) {
+	var index uint8
+	value, pos := uint64(0), uint8(0)
+	for {
+		if len(s) == 0 {
+			store[index] = value
+			break
+		}
+		if pos == 8 {
+			store[index] = value
+			value, pos = 0, 0
+			index++
+		}
+		value |= uint64(s[0]) << (pos * 8)
+		pos += bitsize
+		s = s[1:]
+	}
+	return store
+}
+
+// makeBitValueFromUint32 make bitval from uint32.
+func makeBitValueFromUint32(v uint32) bitvalue {
+	return bitvalue{store: [32]uint64{uint64(v)}}
+}
+
+// AsUint32 casts bitvalue into uint32, this will not update the bitval's value store.
+// This is used mainly for accumulating value, all accumulated value type is <= uint32.
+func (v *bitvalue) AsUint32() uint32 { return uint32(v.store[0] & math.MaxUint32) }
+
+// ToValue converts bitval into proto.Value. This will not evaluate the whole
+// bitvalue's value store as it's not necessary. bitval is only used for component
+// expansion that is only using 32 bits per component. Additionally it's also used
+// for converting []byte value into its representative numeric value. If bitvalue
+// is invalid or baseType target is invalid, proto.Value{} will be returned.
+func (v *bitvalue) ToValue(baseType basetype.BaseType) proto.Value {
+	if v.store[31] == math.MaxUint64 {
+		return proto.Value{}
+	}
 	switch baseType {
 	case basetype.Sint8:
-		return proto.Int8(int8(bits))
+		return proto.Int8(int8(v.store[0] & math.MaxUint8))
 	case basetype.Enum, basetype.Uint8, basetype.Uint8z:
-		return proto.Uint8(uint8(bits))
+		return proto.Uint8(uint8(v.store[0] & math.MaxUint8))
 	case basetype.Sint16:
-		return proto.Int16(int16(bits))
+		return proto.Int16(int16(v.store[0] & math.MaxUint16))
 	case basetype.Uint16, basetype.Uint16z:
-		return proto.Uint16(uint16(bits))
+		return proto.Uint16(uint16(v.store[0] & math.MaxUint16))
 	case basetype.Sint32:
-		return proto.Int32(int32(bits))
+		return proto.Int32(int32(v.store[0] & math.MaxUint32))
 	case basetype.Uint32, basetype.Uint32z:
-		return proto.Uint32(uint32(bits))
-	case basetype.Float32:
-		return proto.Float32(float32(bits))
-	case basetype.Float64:
-		return proto.Float64(float64(bits))
+		return proto.Uint32(uint32(v.store[0] & math.MaxUint32))
 	case basetype.Sint64:
-		return proto.Int64(int64(bits))
+		return proto.Int64(int64(v.store[0]))
 	case basetype.Uint64, basetype.Uint64z:
-		return proto.Uint64(uint64(bits))
+		return proto.Uint64(v.store[0])
+	case basetype.Float32:
+		return proto.Float32(float32(v.store[0] & math.MaxUint32))
+	case basetype.Float64:
+		return proto.Float64(float64(v.store[0]))
 	}
 	return proto.Value{}
+}
+
+// PullByMask retrieves a value of the specified bit size from the storage value and
+// the storage value will be updated accordingly. If one of these conditions is met,
+// zero and false will be returned:
+//   - bitvalue is invalid
+//   - value store run out bits (reach zero)
+//   - given bits > 32
+func (v *bitvalue) PullByMask(bits byte) (val uint32, ok bool) {
+	if v.store[0] == 0 || bits > 32 {
+		return 0, false
+	}
+
+	mask := uint64(1)<<bits - 1     // e.g. (1 << 8) - 1     = 255
+	val = uint32(v.store[0] & mask) // e.g. 0x27010E08 & 255 = 0x08
+	v.store[0] >>= bits             // e.g. 0x27010E08 >> 8  = 0x27010E
+
+	for i := 1; i < len(v.store); i++ {
+		if v.store[i] == 0 {
+			break
+		}
+		v.store[i-1] = v.store[i-1]<<bits | v.store[i]&mask
+		v.store[i] = v.store[i] >> bits
+	}
+
+	return val, true
+}
+
+// valueAppend appends elem into slice. Elem must be the proper element of
+// slice's element otherwise, unexpected behavior.
+func valueAppend(slice proto.Value, elem proto.Value) proto.Value {
+	switch elem.Type() {
+	case proto.TypeInt8:
+		return proto.SliceInt8(append(slice.SliceInt8(), elem.Int8()))
+	case proto.TypeUint8:
+		return proto.SliceUint8(append(slice.SliceUint8(), elem.Uint8()))
+	case proto.TypeInt16:
+		return proto.SliceInt16(append(slice.SliceInt16(), elem.Int16()))
+	case proto.TypeUint16:
+		return proto.SliceUint16(append(slice.SliceUint16(), elem.Uint16()))
+	case proto.TypeInt32:
+		return proto.SliceInt32(append(slice.SliceInt32(), elem.Int32()))
+	case proto.TypeUint32:
+		return proto.SliceUint32(append(slice.SliceUint32(), elem.Uint32()))
+	case proto.TypeInt64:
+		return proto.SliceInt64(append(slice.SliceInt64(), elem.Int64()))
+	case proto.TypeUint64:
+		return proto.SliceUint64(append(slice.SliceUint64(), elem.Uint64()))
+	case proto.TypeFloat32:
+		return proto.SliceFloat32(append(slice.SliceFloat32(), elem.Float32()))
+	case proto.TypeFloat64:
+		return proto.SliceFloat64(append(slice.SliceFloat64(), elem.Float64()))
+	}
+	return slice
 }

--- a/decoder/bits.go
+++ b/decoder/bits.go
@@ -7,78 +7,77 @@ package decoder
 import (
 	"math"
 
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/proto"
 )
 
-// bitvalue holds proto.Value in its integer form, enabling us to do bitwise operation over it.
-// This is used for component expansion as Field's Value requiring expansion can hold up to
-// 255 byte (2040 bits) data, this is obviously way more bits than Go's primitive value can handle.
+// bits is 2048 bits value implementation, large enough to hold proto.Value in its integer form.
+// This bits value enable us to do bitwise operation and it's used for component expansion as
+// Field's Value requiring expansion can hold up to 255 byte (2040 bits) data, this is obviously
+// way more bits than Go's primitive value can handle.
 //
-// In Profile.xlsx (at least v21.141), the biggest value for component expansion is "raw_bbi"
-// message for having 240 bits on "data" and the second is "hr" message for having 120 bits
-// on "event_timestamp_12".
-type bitvalue struct {
+// In Profile.xlsx v21.141, the biggest value for component expansion is "raw_bbi" message for
+// having 240 bits on "data" and the second is "hr" message for having 120 bits on "event_timestamp_12".
+type bits struct {
 	// NOTE: We use array to avoid memory allocation, it's simple to maintain and it has more
 	// deterministic performance. Max value to hold is 2040 bits, so the value of the last
 	// index will always less than math.MaxUint64. We use the last index to determine the
-	// validity of this stuct, if last index is math.MaxUint64, it's an invalid bitval.
+	// validity of this stuct, if last index is math.MaxUint64, this struct is invalid.
 	store [32]uint64
 }
 
-// makeBitValue creates bitvalue from proto.Value.
-func makeBitValue(value proto.Value) (v bitvalue, ok bool) {
+// makeBits creates 2048 bits value from proto.Value.
+func makeBits(value proto.Value) (v bits, ok bool) {
 	switch value.Type() {
 	case proto.TypeInt8:
-		return bitvalue{store: [32]uint64{uint64(value.Int8())}}, true
+		return bits{store: [32]uint64{0: uint64(value.Int8())}}, true
 	case proto.TypeUint8:
-		return bitvalue{store: [32]uint64{uint64(value.Uint8())}}, true
+		return bits{store: [32]uint64{0: uint64(value.Uint8())}}, true
 	case proto.TypeInt16:
-		return bitvalue{store: [32]uint64{uint64(value.Int16())}}, true
+		return bits{store: [32]uint64{0: uint64(value.Int16())}}, true
 	case proto.TypeUint16:
-		return bitvalue{store: [32]uint64{uint64(value.Uint16())}}, true
+		return bits{store: [32]uint64{0: uint64(value.Uint16())}}, true
 	case proto.TypeInt32:
-		return bitvalue{store: [32]uint64{uint64(value.Int32())}}, true
+		return bits{store: [32]uint64{0: uint64(value.Int32())}}, true
 	case proto.TypeUint32:
-		return bitvalue{store: [32]uint64{uint64(value.Uint32())}}, true
+		return bits{store: [32]uint64{0: uint64(value.Uint32())}}, true
 	case proto.TypeInt64:
-		return bitvalue{store: [32]uint64{uint64(value.Int64())}}, true
+		return bits{store: [32]uint64{0: uint64(value.Int64())}}, true
 	case proto.TypeUint64:
-		return bitvalue{store: [32]uint64{value.Uint64()}}, true
+		return bits{store: [32]uint64{0: value.Uint64()}}, true
 	case proto.TypeFloat32:
-		return bitvalue{store: [32]uint64{uint64(value.Float32())}}, true
+		return bits{store: [32]uint64{0: uint64(value.Float32())}}, true
 	case proto.TypeFloat64:
-		return bitvalue{store: [32]uint64{uint64(value.Float64())}}, true
+		return bits{store: [32]uint64{0: uint64(value.Float64())}}, true
 	case proto.TypeSliceInt8:
-		return bitvalue{store: makeStoreFromSlice(value.SliceInt8(), 1)}, true
+		return bits{store: storeFromSlice(value.SliceInt8(), 1)}, true
 	case proto.TypeSliceUint8:
-		return bitvalue{store: makeStoreFromSlice(value.SliceUint8(), 1)}, true
+		return bits{store: storeFromSlice(value.SliceUint8(), 1)}, true
 	case proto.TypeSliceInt16:
-		return bitvalue{store: makeStoreFromSlice(value.SliceInt16(), 2)}, true
+		return bits{store: storeFromSlice(value.SliceInt16(), 2)}, true
 	case proto.TypeSliceUint16:
-		return bitvalue{store: makeStoreFromSlice(value.SliceUint16(), 2)}, true
+		return bits{store: storeFromSlice(value.SliceUint16(), 2)}, true
 	case proto.TypeSliceInt32:
-		return bitvalue{store: makeStoreFromSlice(value.SliceInt32(), 4)}, true
+		return bits{store: storeFromSlice(value.SliceInt32(), 4)}, true
 	case proto.TypeSliceUint32:
-		return bitvalue{store: makeStoreFromSlice(value.SliceUint32(), 4)}, true
+		return bits{store: storeFromSlice(value.SliceUint32(), 4)}, true
 	case proto.TypeSliceInt64:
-		return bitvalue{store: makeStoreFromSlice(value.SliceInt64(), 8)}, true
+		return bits{store: storeFromSlice(value.SliceInt64(), 8)}, true
 	case proto.TypeSliceUint64:
-		return bitvalue{store: makeStoreFromSlice(value.SliceUint64(), 8)}, true
+		return bits{store: storeFromSlice(value.SliceUint64(), 8)}, true
 	case proto.TypeSliceFloat32:
-		return bitvalue{store: makeStoreFromSlice(value.SliceFloat32(), 4)}, true
+		return bits{store: storeFromSlice(value.SliceFloat32(), 4)}, true
 	case proto.TypeSliceFloat64:
-		return bitvalue{store: makeStoreFromSlice(value.SliceFloat64(), 8)}, true
+		return bits{store: storeFromSlice(value.SliceFloat64(), 8)}, true
 	}
-	return bitvalue{store: [32]uint64{31: math.MaxUint64}}, false
+	return bits{store: [32]uint64{31: math.MaxUint64}}, false
 }
 
 type numeric interface {
 	int8 | uint8 | int16 | uint16 | int32 | uint32 | int64 | uint64 | float32 | float64
 }
 
-// makeStoreFromSlice creates value store from given s (slice of supported numeric type).
-func makeStoreFromSlice[S []E, E numeric](s S, bitsize uint8) (store [32]uint64) {
+// storeFromSlice creates value store from given s (slice of supported numeric type).
+func storeFromSlice[S []E, E numeric](s S, bitsize uint8) (store [32]uint64) {
 	var index uint8
 	value, pos := uint64(0), uint8(0)
 	for {
@@ -98,57 +97,14 @@ func makeStoreFromSlice[S []E, E numeric](s S, bitsize uint8) (store [32]uint64)
 	return store
 }
 
-// makeBitValueFromUint32 make bitval from uint32.
-func makeBitValueFromUint32(v uint32) bitvalue {
-	return bitvalue{store: [32]uint64{uint64(v)}}
-}
-
-// AsUint32 casts bitvalue into uint32, this will not update the bitval's value store.
-// This is used mainly for accumulating value, all accumulated value type is <= uint32.
-func (v *bitvalue) AsUint32() uint32 { return uint32(v.store[0] & math.MaxUint32) }
-
-// ToValue converts bitval into proto.Value. This will not evaluate the whole
-// bitvalue's value store as it's not necessary. bitval is only used for component
-// expansion that is only using 32 bits per component. Additionally it's also used
-// for converting []byte value into its representative numeric value. If bitvalue
-// is invalid or baseType target is invalid, proto.Value{} will be returned.
-func (v *bitvalue) ToValue(baseType basetype.BaseType) proto.Value {
-	if v.store[31] == math.MaxUint64 {
-		return proto.Value{}
-	}
-	switch baseType {
-	case basetype.Sint8:
-		return proto.Int8(int8(v.store[0] & math.MaxUint8))
-	case basetype.Enum, basetype.Uint8, basetype.Uint8z:
-		return proto.Uint8(uint8(v.store[0] & math.MaxUint8))
-	case basetype.Sint16:
-		return proto.Int16(int16(v.store[0] & math.MaxUint16))
-	case basetype.Uint16, basetype.Uint16z:
-		return proto.Uint16(uint16(v.store[0] & math.MaxUint16))
-	case basetype.Sint32:
-		return proto.Int32(int32(v.store[0] & math.MaxUint32))
-	case basetype.Uint32, basetype.Uint32z:
-		return proto.Uint32(uint32(v.store[0] & math.MaxUint32))
-	case basetype.Sint64:
-		return proto.Int64(int64(v.store[0]))
-	case basetype.Uint64, basetype.Uint64z:
-		return proto.Uint64(v.store[0])
-	case basetype.Float32:
-		return proto.Float32(float32(v.store[0] & math.MaxUint32))
-	case basetype.Float64:
-		return proto.Float64(float64(v.store[0]))
-	}
-	return proto.Value{}
-}
-
-// PullByMask retrieves a value of the specified bit size from the storage value and
+// Pull retrieves a value of the specified bit size from the storage value and
 // the storage value will be updated accordingly. If one of these conditions is met,
 // zero and false will be returned:
-//   - bitvalue is invalid
-//   - value store run out bits (reach zero)
+//   - bits struct is invalid
+//   - bits's store run out value (reach zero)
 //   - given bits > 32
-func (v *bitvalue) PullByMask(bits byte) (val uint32, ok bool) {
-	if v.store[0] == 0 || bits > 32 {
+func (v *bits) Pull(bits byte) (val uint32, ok bool) {
+	if v.store[31] == math.MaxUint64 || v.store[0] == 0 || bits > 32 {
 		return 0, false
 	}
 
@@ -160,37 +116,13 @@ func (v *bitvalue) PullByMask(bits byte) (val uint32, ok bool) {
 		if v.store[i] == 0 {
 			break
 		}
-		v.store[i-1] = v.store[i-1]<<bits | v.store[i]&mask
-		v.store[i] = v.store[i] >> bits
+		// e.g. 128 bits Layout Before: 0x0000_0000_0000_FFFF_0000_0000_2701_0E08
+		hi := v.store[i] & mask // e.g. 0x0000_0000_0000_FFFF & 0xFF                  = 0x0000_0000_0000_00FF
+		lo := hi << (64 - bits) // e,g. 0x0000_0000_0000_00FF << (64 - 8)             = 0xFF00_0000_0000_0000
+		v.store[i-1] |= lo      // e.g. 0x0000_0000_0027_010E | 0xFF00_0000_0000_0000 = 0xFF00_0000_0027_010E
+		v.store[i] >>= bits     // e.g. 0x0000_0000_0000_FFFF >> 8                    = 0x0000_0000_0000_00FF
+		// e.g. 128 bits Layout After:  0x0000_0000_0000_00FF_FF00_0000_0027_010E
 	}
 
 	return val, true
-}
-
-// valueAppend appends elem into slice. Elem must be the proper element of
-// slice's element otherwise, unexpected behavior.
-func valueAppend(slice proto.Value, elem proto.Value) proto.Value {
-	switch elem.Type() {
-	case proto.TypeInt8:
-		return proto.SliceInt8(append(slice.SliceInt8(), elem.Int8()))
-	case proto.TypeUint8:
-		return proto.SliceUint8(append(slice.SliceUint8(), elem.Uint8()))
-	case proto.TypeInt16:
-		return proto.SliceInt16(append(slice.SliceInt16(), elem.Int16()))
-	case proto.TypeUint16:
-		return proto.SliceUint16(append(slice.SliceUint16(), elem.Uint16()))
-	case proto.TypeInt32:
-		return proto.SliceInt32(append(slice.SliceInt32(), elem.Int32()))
-	case proto.TypeUint32:
-		return proto.SliceUint32(append(slice.SliceUint32(), elem.Uint32()))
-	case proto.TypeInt64:
-		return proto.SliceInt64(append(slice.SliceInt64(), elem.Int64()))
-	case proto.TypeUint64:
-		return proto.SliceUint64(append(slice.SliceUint64(), elem.Uint64()))
-	case proto.TypeFloat32:
-		return proto.SliceFloat32(append(slice.SliceFloat32(), elem.Float32()))
-	case proto.TypeFloat64:
-		return proto.SliceFloat64(append(slice.SliceFloat64(), elem.Float64()))
-	}
-	return slice
 }

--- a/decoder/bits_test.go
+++ b/decoder/bits_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/muktihari/fit/proto"
 )
 
-func TestMakeBitValue(t *testing.T) {
+func TestMakeBits(t *testing.T) {
 	tt := []struct {
 		value    proto.Value
 		expected bits
@@ -145,7 +145,7 @@ func TestMakeBitValue(t *testing.T) {
 	}
 }
 
-func TestBitValuePull(t *testing.T) {
+func TestBitsPull(t *testing.T) {
 	type pull struct {
 		bits   byte
 		value  uint32

--- a/decoder/bits_test.go
+++ b/decoder/bits_test.go
@@ -5,90 +5,381 @@
 package decoder
 
 import (
+	"encoding/binary"
 	"fmt"
+	"math"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/proto"
 )
 
-func TestBitsFromValue(t *testing.T) {
+func TestMakeBitValue(t *testing.T) {
 	tt := []struct {
 		value    proto.Value
-		expected uint32
+		expected bitvalue
 		ok       bool
 	}{
-		{value: proto.Int8(10), expected: 10, ok: true},
-		{value: proto.Uint8(10), expected: 10, ok: true},
-		{value: proto.Int16(10), expected: 10, ok: true},
-		{value: proto.Uint16(10), expected: 10, ok: true},
-		{value: proto.Int32(10), expected: 10, ok: true},
-		{value: proto.Uint32(10), expected: 10, ok: true},
-		{value: proto.Int64(10), expected: 10, ok: true},
-		{value: proto.Uint64(10), expected: 10, ok: true},
-		{value: proto.Float32(10), expected: 10, ok: true},
-		{value: proto.Float64(10), expected: 10, ok: true},
-		{value: proto.SliceUint8([]byte{1, 1, 1}), expected: 1<<0 | 1<<8 | 1<<16, ok: true},
-		{value: proto.SliceUint8([]byte{1, 255, 1}), expected: 0, ok: false},
-		{value: proto.SliceUint8(make([]byte, 33)), expected: 0, ok: false},
-		{value: proto.String("string value"), expected: 0, ok: false},
-	}
-
-	for _, tc := range tt {
-		t.Run(fmt.Sprintf("%v (%T)", tc.value, tc.value), func(t *testing.T) {
-			res, ok := bitsFromValue(tc.value)
-			if ok != tc.ok {
-				t.Fatalf("expected ok: %t, got: %t", tc.ok, ok)
-			}
-			if res != tc.expected {
-				t.Fatalf("expected: %d, got: %d", tc.expected, res)
-			}
-		})
-	}
-}
-
-func TestValueFromBits(t *testing.T) {
-	tt := []struct {
-		bitsVal  uint32
-		basetype basetype.BaseType
-		expected proto.Value
-	}{
-		{bitsVal: 10, basetype: basetype.Sint8, expected: proto.Int8(10)},
-		{bitsVal: 10, basetype: basetype.Enum, expected: proto.Uint8(10)},
-		{bitsVal: 10, basetype: basetype.Uint8, expected: proto.Uint8(10)},
-		{bitsVal: 10, basetype: basetype.Uint8z, expected: proto.Uint8(10)},
-		{bitsVal: 10, basetype: basetype.Sint16, expected: proto.Int16(10)},
-		{bitsVal: 10, basetype: basetype.Uint16, expected: proto.Uint16(10)},
-		{bitsVal: 10, basetype: basetype.Uint16z, expected: proto.Uint16(10)},
-		{bitsVal: 10, basetype: basetype.Sint32, expected: proto.Int32(10)},
-		{bitsVal: 10, basetype: basetype.Uint32, expected: proto.Uint32(10)},
-		{bitsVal: 10, basetype: basetype.Uint32z, expected: proto.Uint32(10)},
-		{bitsVal: 10, basetype: basetype.Sint64, expected: proto.Int64(10)},
-		{bitsVal: 10, basetype: basetype.Uint64, expected: proto.Uint64(10)},
-		{bitsVal: 10, basetype: basetype.Uint64z, expected: proto.Uint64(10)},
-		{bitsVal: 10, basetype: basetype.Float32, expected: proto.Float32(10)},
-		{bitsVal: 10, basetype: basetype.Float64, expected: proto.Float64(10)},
-		{bitsVal: 10, basetype: basetype.String, expected: proto.Value{}},
+		{
+			value:    proto.Int8(10),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.Uint8(10),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.Int16(10),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.Uint16(10),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.Int32(10),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.Uint32(10),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.Int64(10),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.Uint64(10),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.Float32(10.5),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.Float64(12.9),
+			expected: bitvalue{[32]uint64{12}}, ok: true,
+		},
+		{
+			value:    proto.SliceInt8([]int8{10}),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value: proto.SliceUint8(func() []uint8 {
+				var b []uint8
+				b = binary.LittleEndian.AppendUint64(b, 10)
+				b = binary.LittleEndian.AppendUint64(b, 15)
+				return b
+			}()),
+			expected: bitvalue{[32]uint64{10, 15}}, ok: true,
+		},
+		{
+			value:    proto.SliceInt16([]int16{10}),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value: proto.SliceUint16([]uint16{10, 25, 55, 11, 12, 13, 14, 15}),
+			ok:    true,
+			expected: bitvalue{[32]uint64{
+				func() uint64 {
+					var b []uint8
+					b = binary.LittleEndian.AppendUint16(b, 10)
+					b = binary.LittleEndian.AppendUint16(b, 25)
+					b = binary.LittleEndian.AppendUint16(b, 55)
+					b = binary.LittleEndian.AppendUint16(b, 11)
+					return binary.LittleEndian.Uint64(b)
+				}(),
+				func() uint64 {
+					var b []uint8
+					b = binary.LittleEndian.AppendUint16(b, 12)
+					b = binary.LittleEndian.AppendUint16(b, 13)
+					b = binary.LittleEndian.AppendUint16(b, 14)
+					b = binary.LittleEndian.AppendUint16(b, 15)
+					return binary.LittleEndian.Uint64(b)
+				}(),
+			}},
+		},
+		{
+			value:    proto.SliceInt32([]int32{10}),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.SliceUint32([]uint32{10}),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.SliceInt64([]int64{10}),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.SliceUint64([]uint64{10}),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.SliceFloat32([]float32{10.5}),
+			expected: bitvalue{[32]uint64{10}}, ok: true,
+		},
+		{
+			value:    proto.SliceFloat64([]float64{12.9}),
+			expected: bitvalue{[32]uint64{12}}, ok: true,
+		},
+		{
+			value:    proto.String("invalid"),
+			expected: bitvalue{[32]uint64{31: math.MaxUint64}}, ok: false,
+		},
+		{
+			value:    proto.Value{},
+			expected: bitvalue{[32]uint64{31: math.MaxUint64}}, ok: false,
+		},
 	}
 
 	for i, tc := range tt {
-		t.Run(fmt.Sprintf("[%d] %s %v (%T)", i, tc.basetype, tc.expected.Any(), tc.expected.Any()), func(t *testing.T) {
-			res := valueFromBits(tc.bitsVal, tc.basetype)
-			if res.Any() != tc.expected.Any() {
-				t.Fatalf("expected: %v, got: %v", tc.expected.Any(), res.Any())
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.value.Type()), func(t *testing.T) {
+			bitVal, ok := makeBitValue(tc.value)
+			if ok != tc.ok {
+				t.Fatalf("expected ok: %t, got: %t", tc.ok, ok)
+			}
+			if bitVal != tc.expected {
+				t.Fatalf("expected bitVal: %v, got: %v", tc.expected, bitVal)
 			}
 		})
 	}
 }
 
-const v = 1080122531
-
-func BenchmarkValueFromBits(b *testing.B) {
-	val := proto.Float64(v)
-	for i := 0; i < b.N; i++ {
-		r := valueFromBits(v, basetype.Float64)
-		if r.Float64() != val.Float64() {
-			b.Fatalf("expected: %T: %v, got: %T: %v", v, v, r, r)
-		}
+func TestMakeBitFromUint32(t *testing.T) {
+	tt := []struct {
+		u32      uint32
+		expected bitvalue
+	}{
+		{u32: 20, expected: bitvalue{store: [32]uint64{20}}},
 	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %d", i, tc.u32), func(t *testing.T) {
+			bitVal := makeBitValueFromUint32(tc.u32)
+			if bitVal != tc.expected {
+				t.Fatalf("expected: %v, got: %v", tc.expected, bitVal)
+			}
+		})
+	}
+}
+
+func TestBitValueAsUint32(t *testing.T) {
+	tt := []struct {
+		bitVal   bitvalue
+		expected uint32
+	}{
+		{bitVal: bitvalue{store: [32]uint64{500}}, expected: 500},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %d", i, tc.bitVal.store[0]), func(t *testing.T) {
+			u32 := tc.bitVal.AsUint32()
+			if u32 != tc.expected {
+				t.Fatalf("expected: %v, got: %v", tc.expected, u32)
+			}
+		})
+	}
+}
+
+func TestBitValueToValue(t *testing.T) {
+	tt := []struct {
+		bitVal   bitvalue
+		baseType basetype.BaseType
+		expected proto.Value
+	}{
+		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Sint8, expected: proto.Int8(40)},
+		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Uint8, expected: proto.Uint8(40)},
+		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Sint16, expected: proto.Int16(40)},
+		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Uint16, expected: proto.Uint16(40)},
+		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Sint32, expected: proto.Int32(40)},
+		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Uint32, expected: proto.Uint32(40)},
+		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Sint64, expected: proto.Int64(40)},
+		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Uint64, expected: proto.Uint64(40)},
+		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Float32, expected: proto.Float32(40)},
+		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Float64, expected: proto.Float64(40)},
+		{bitVal: bitvalue{store: [32]uint64{10}}, baseType: basetype.String, expected: proto.Value{}},
+		{bitVal: bitvalue{store: [32]uint64{31: math.MaxUint64}}, baseType: basetype.Float64, expected: proto.Value{}},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.expected.Type()), func(t *testing.T) {
+			v := tc.bitVal.ToValue(tc.baseType)
+			if diff := cmp.Diff(v, tc.expected,
+				cmp.Transformer("Value", func(v proto.Value) any { return v.Any() }),
+			); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestBitValuePullByMask(t *testing.T) {
+	type pull struct {
+		bits   byte
+		value  uint32
+		ok     bool
+		bitVal bitvalue
+	}
+	tt := []struct {
+		name   string
+		bitVal bitvalue
+		pulls  []pull
+	}{
+		{
+			name:   "single value one pull",
+			bitVal: bitvalue{store: [32]uint64{20}},
+			pulls:  []pull{{bits: 8, value: 20, ok: true, bitVal: bitvalue{store: [32]uint64{0}}}},
+		},
+		{
+			name:   "single value multiple pull",
+			bitVal: bitvalue{store: [32]uint64{math.MaxUint16}},
+			pulls: []pull{
+				{bits: 8, value: 255, ok: true, bitVal: bitvalue{store: [32]uint64{255}}},
+				{bits: 8, value: 255, ok: true, bitVal: bitvalue{store: [32]uint64{0}}},
+			},
+		},
+		{
+			name:   "slice value one pull",
+			bitVal: bitvalue{store: [32]uint64{math.MaxUint16, math.MaxUint16}},
+			pulls: []pull{
+				{bits: 8, value: 255, ok: true, bitVal: bitvalue{store: [32]uint64{math.MaxUint16, 255}}},
+			},
+		},
+		{
+			name:   "slice value multiple pull",
+			bitVal: bitvalue{store: [32]uint64{math.MaxUint16, math.MaxUint16}},
+			pulls: []pull{
+				{bits: 8, value: 255, ok: true, bitVal: bitvalue{store: [32]uint64{math.MaxUint16, 255}}},
+				{bits: 8, value: 255, ok: true, bitVal: bitvalue{store: [32]uint64{math.MaxUint16}}},
+			},
+		},
+		{
+			name:   "single value one pull bits > 32 (64)",
+			bitVal: bitvalue{store: [32]uint64{20}},
+			pulls:  []pull{{bits: 64, value: 0, ok: false, bitVal: bitvalue{store: [32]uint64{20}}}},
+		},
+		{
+			name:   "single value one pull store is zero",
+			bitVal: bitvalue{store: [32]uint64{0}},
+			pulls:  []pull{{bits: 8, value: 0, ok: false, bitVal: bitvalue{store: [32]uint64{0}}}},
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
+			for _, p := range tc.pulls {
+				u32, ok := tc.bitVal.PullByMask(p.bits)
+				if ok != p.ok {
+					t.Fatalf("expected ok: %t, got: %t", p.ok, ok)
+				}
+				if u32 != p.value {
+					t.Fatalf("expected value: %t, got: %t", p.ok, ok)
+				}
+				if tc.bitVal != p.bitVal {
+					t.Fatalf("expected bitVal: %v, got: %v", tc.bitVal, tc.bitVal)
+				}
+			}
+		})
+	}
+}
+
+func TestValueAppend(t *testing.T) {
+	tt := []struct {
+		slice    proto.Value
+		elem     proto.Value
+		expected proto.Value
+	}{
+		{
+			slice:    proto.SliceInt8([]int8{10}),
+			elem:     proto.Int8(11),
+			expected: proto.SliceInt8([]int8{10, 11}),
+		},
+		{
+			slice:    proto.SliceUint8([]uint8{10}),
+			elem:     proto.Uint8(11),
+			expected: proto.SliceUint8([]uint8{10, 11}),
+		},
+		{
+			slice:    proto.SliceInt16([]int16{10}),
+			elem:     proto.Int16(11),
+			expected: proto.SliceInt16([]int16{10, 11}),
+		},
+		{
+			slice:    proto.SliceUint16([]uint16{10}),
+			elem:     proto.Uint16(11),
+			expected: proto.SliceUint16([]uint16{10, 11}),
+		},
+		{
+			slice:    proto.SliceInt32([]int32{10}),
+			elem:     proto.Int32(11),
+			expected: proto.SliceInt32([]int32{10, 11}),
+		},
+		{
+			slice:    proto.SliceUint32([]uint32{10}),
+			elem:     proto.Uint32(11),
+			expected: proto.SliceUint32([]uint32{10, 11}),
+		},
+		{
+			slice:    proto.SliceInt64([]int64{10}),
+			elem:     proto.Int64(11),
+			expected: proto.SliceInt64([]int64{10, 11}),
+		},
+		{
+			slice:    proto.SliceUint64([]uint64{10}),
+			elem:     proto.Uint64(11),
+			expected: proto.SliceUint64([]uint64{10, 11}),
+		},
+		{
+			slice:    proto.SliceFloat32([]float32{10}),
+			elem:     proto.Float32(11),
+			expected: proto.SliceFloat32([]float32{10, 11}),
+		},
+		{
+			slice:    proto.SliceFloat64([]float64{10}),
+			elem:     proto.Float64(11),
+			expected: proto.SliceFloat64([]float64{10, 11}),
+		},
+		{
+			slice:    proto.SliceString([]string{"invalid"}),
+			elem:     proto.String("qwerty"),
+			expected: proto.SliceString([]string{"invalid"}),
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.slice.Type()), func(t *testing.T) {
+			val := valueAppend(tc.slice, tc.elem)
+			if diff := cmp.Diff(val, tc.expected,
+				cmp.Transformer("Value", func(v proto.Value) any { return v.Any() }),
+			); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func BenchmarkMakeBitValueToValueRoundTrip(b *testing.B) {
+	b.Run("to float64", func(b *testing.B) {
+		const v = 1080122531
+		val := proto.Float64(v)
+		for i := 0; i < b.N; i++ {
+			bitVal, _ := makeBitValue(val)
+			if bitVal.ToValue(basetype.Float64).Float64() != val.Float64() {
+				b.Fatalf("expected: %T: %v, got: %T: %v", v, v, bitVal, bitVal)
+			}
+		}
+	})
+	b.Run("to bytes", func(b *testing.B) {
+		var buf []uint8
+		buf = binary.LittleEndian.AppendUint64(buf, 10)
+		buf = binary.LittleEndian.AppendUint64(buf, 11)
+		val := proto.SliceUint8(buf)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			bitVal, _ := makeBitValue(val)
+			_ = bitVal.ToValue(basetype.Byte).SliceUint8()
+		}
+	})
 }

--- a/decoder/bits_test.go
+++ b/decoder/bits_test.go
@@ -134,12 +134,12 @@ func TestMakeBits(t *testing.T) {
 
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.value.Type()), func(t *testing.T) {
-			bitVal, ok := makeBits(tc.value)
+			vbits, ok := makeBits(tc.value)
 			if ok != tc.ok {
 				t.Fatalf("expected ok: %t, got: %t", tc.ok, ok)
 			}
-			if bitVal != tc.expected {
-				t.Fatalf("expected bitVal: %v, got: %v", tc.expected, bitVal)
+			if vbits != tc.expected {
+				t.Fatalf("expected bits:\n%v,\n got:\n%v", tc.expected, vbits)
 			}
 		})
 	}
@@ -147,10 +147,10 @@ func TestMakeBits(t *testing.T) {
 
 func TestBitsPull(t *testing.T) {
 	type pull struct {
-		bits   byte
-		value  uint32
-		ok     bool
-		bitVal bits
+		bits  byte
+		value uint32
+		ok    bool
+		vbits bits
 	}
 	tt := []struct {
 		name  string
@@ -160,40 +160,40 @@ func TestBitsPull(t *testing.T) {
 		{
 			name:  "single value one pull",
 			vbits: bits{store: [32]uint64{20}},
-			pulls: []pull{{bits: 8, value: 20, ok: true, bitVal: bits{store: [32]uint64{0}}}},
+			pulls: []pull{{bits: 8, value: 20, ok: true, vbits: bits{store: [32]uint64{0}}}},
 		},
 		{
 			name:  "single value multiple pull",
 			vbits: bits{store: [32]uint64{math.MaxUint16}},
 			pulls: []pull{
-				{bits: 8, value: 255, ok: true, bitVal: bits{store: [32]uint64{255}}},
-				{bits: 8, value: 255, ok: true, bitVal: bits{store: [32]uint64{0}}},
+				{bits: 8, value: 255, ok: true, vbits: bits{store: [32]uint64{255}}},
+				{bits: 8, value: 255, ok: true, vbits: bits{store: [32]uint64{0}}},
 			},
 		},
 		{
 			name:  "slice value one pull",
 			vbits: bits{store: [32]uint64{math.MaxUint64, math.MaxUint16}},
 			pulls: []pull{
-				{bits: 8, value: 255, ok: true, bitVal: bits{store: [32]uint64{math.MaxUint64, 255}}},
+				{bits: 8, value: 255, ok: true, vbits: bits{store: [32]uint64{math.MaxUint64, 255}}},
 			},
 		},
 		{
 			name:  "slice value multiple pull",
 			vbits: bits{store: [32]uint64{math.MaxUint64, math.MaxUint16}},
 			pulls: []pull{
-				{bits: 8, value: 255, ok: true, bitVal: bits{store: [32]uint64{math.MaxUint64, 255}}},
-				{bits: 8, value: 255, ok: true, bitVal: bits{store: [32]uint64{math.MaxUint64}}},
+				{bits: 8, value: 255, ok: true, vbits: bits{store: [32]uint64{math.MaxUint64, 255}}},
+				{bits: 8, value: 255, ok: true, vbits: bits{store: [32]uint64{math.MaxUint64}}},
 			},
 		},
 		{
 			name:  "single value one pull bits > 32 (64)",
 			vbits: bits{store: [32]uint64{20}},
-			pulls: []pull{{bits: 64, value: 0, ok: false, bitVal: bits{store: [32]uint64{20}}}},
+			pulls: []pull{{bits: 64, value: 0, ok: false, vbits: bits{store: [32]uint64{20}}}},
 		},
 		{
 			name:  "single value one pull store is zero",
 			vbits: bits{store: [32]uint64{0}},
-			pulls: []pull{{bits: 8, value: 0, ok: false, bitVal: bits{store: [32]uint64{0}}}},
+			pulls: []pull{{bits: 8, value: 0, ok: false, vbits: bits{store: [32]uint64{0}}}},
 		},
 	}
 
@@ -207,8 +207,8 @@ func TestBitsPull(t *testing.T) {
 				if u32 != p.value {
 					t.Fatalf("expected value: %t, got: %t", p.ok, ok)
 				}
-				if tc.vbits != p.bitVal {
-					t.Fatalf("expected bitVal:\n%v,\n got:\n%v", tc.vbits, p.bitVal)
+				if tc.vbits != p.vbits {
+					t.Fatalf("expected bits:\n%v,\n got:\n%v", tc.vbits, p.vbits)
 				}
 			}
 		})

--- a/decoder/bits_test.go
+++ b/decoder/bits_test.go
@@ -10,60 +10,58 @@ import (
 	"math"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/muktihari/fit/profile/basetype"
 	"github.com/muktihari/fit/proto"
 )
 
 func TestMakeBitValue(t *testing.T) {
 	tt := []struct {
 		value    proto.Value
-		expected bitvalue
+		expected bits
 		ok       bool
 	}{
 		{
 			value:    proto.Int8(10),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.Uint8(10),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.Int16(10),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.Uint16(10),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.Int32(10),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.Uint32(10),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.Int64(10),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.Uint64(10),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.Float32(10.5),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.Float64(12.9),
-			expected: bitvalue{[32]uint64{12}}, ok: true,
+			expected: bits{[32]uint64{12}}, ok: true,
 		},
 		{
 			value:    proto.SliceInt8([]int8{10}),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value: proto.SliceUint8(func() []uint8 {
@@ -72,16 +70,16 @@ func TestMakeBitValue(t *testing.T) {
 				b = binary.LittleEndian.AppendUint64(b, 15)
 				return b
 			}()),
-			expected: bitvalue{[32]uint64{10, 15}}, ok: true,
+			expected: bits{[32]uint64{10, 15}}, ok: true,
 		},
 		{
 			value:    proto.SliceInt16([]int16{10}),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value: proto.SliceUint16([]uint16{10, 25, 55, 11, 12, 13, 14, 15}),
 			ok:    true,
-			expected: bitvalue{[32]uint64{
+			expected: bits{[32]uint64{
 				func() uint64 {
 					var b []uint8
 					b = binary.LittleEndian.AppendUint16(b, 10)
@@ -102,41 +100,41 @@ func TestMakeBitValue(t *testing.T) {
 		},
 		{
 			value:    proto.SliceInt32([]int32{10}),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.SliceUint32([]uint32{10}),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.SliceInt64([]int64{10}),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.SliceUint64([]uint64{10}),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.SliceFloat32([]float32{10.5}),
-			expected: bitvalue{[32]uint64{10}}, ok: true,
+			expected: bits{[32]uint64{10}}, ok: true,
 		},
 		{
 			value:    proto.SliceFloat64([]float64{12.9}),
-			expected: bitvalue{[32]uint64{12}}, ok: true,
+			expected: bits{[32]uint64{12}}, ok: true,
 		},
 		{
 			value:    proto.String("invalid"),
-			expected: bitvalue{[32]uint64{31: math.MaxUint64}}, ok: false,
+			expected: bits{[32]uint64{31: math.MaxUint64}}, ok: false,
 		},
 		{
 			value:    proto.Value{},
-			expected: bitvalue{[32]uint64{31: math.MaxUint64}}, ok: false,
+			expected: bits{[32]uint64{31: math.MaxUint64}}, ok: false,
 		},
 	}
 
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.value.Type()), func(t *testing.T) {
-			bitVal, ok := makeBitValue(tc.value)
+			bitVal, ok := makeBits(tc.value)
 			if ok != tc.ok {
 				t.Fatalf("expected ok: %t, got: %t", tc.ok, ok)
 			}
@@ -147,239 +145,72 @@ func TestMakeBitValue(t *testing.T) {
 	}
 }
 
-func TestMakeBitFromUint32(t *testing.T) {
-	tt := []struct {
-		u32      uint32
-		expected bitvalue
-	}{
-		{u32: 20, expected: bitvalue{store: [32]uint64{20}}},
-	}
-
-	for i, tc := range tt {
-		t.Run(fmt.Sprintf("[%d] %d", i, tc.u32), func(t *testing.T) {
-			bitVal := makeBitValueFromUint32(tc.u32)
-			if bitVal != tc.expected {
-				t.Fatalf("expected: %v, got: %v", tc.expected, bitVal)
-			}
-		})
-	}
-}
-
-func TestBitValueAsUint32(t *testing.T) {
-	tt := []struct {
-		bitVal   bitvalue
-		expected uint32
-	}{
-		{bitVal: bitvalue{store: [32]uint64{500}}, expected: 500},
-	}
-
-	for i, tc := range tt {
-		t.Run(fmt.Sprintf("[%d] %d", i, tc.bitVal.store[0]), func(t *testing.T) {
-			u32 := tc.bitVal.AsUint32()
-			if u32 != tc.expected {
-				t.Fatalf("expected: %v, got: %v", tc.expected, u32)
-			}
-		})
-	}
-}
-
-func TestBitValueToValue(t *testing.T) {
-	tt := []struct {
-		bitVal   bitvalue
-		baseType basetype.BaseType
-		expected proto.Value
-	}{
-		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Sint8, expected: proto.Int8(40)},
-		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Uint8, expected: proto.Uint8(40)},
-		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Sint16, expected: proto.Int16(40)},
-		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Uint16, expected: proto.Uint16(40)},
-		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Sint32, expected: proto.Int32(40)},
-		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Uint32, expected: proto.Uint32(40)},
-		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Sint64, expected: proto.Int64(40)},
-		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Uint64, expected: proto.Uint64(40)},
-		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Float32, expected: proto.Float32(40)},
-		{bitVal: bitvalue{store: [32]uint64{40}}, baseType: basetype.Float64, expected: proto.Float64(40)},
-		{bitVal: bitvalue{store: [32]uint64{10}}, baseType: basetype.String, expected: proto.Value{}},
-		{bitVal: bitvalue{store: [32]uint64{31: math.MaxUint64}}, baseType: basetype.Float64, expected: proto.Value{}},
-	}
-
-	for i, tc := range tt {
-		t.Run(fmt.Sprintf("[%d] %s", i, tc.expected.Type()), func(t *testing.T) {
-			v := tc.bitVal.ToValue(tc.baseType)
-			if diff := cmp.Diff(v, tc.expected,
-				cmp.Transformer("Value", func(v proto.Value) any { return v.Any() }),
-			); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
-}
-
-func TestBitValuePullByMask(t *testing.T) {
+func TestBitValuePull(t *testing.T) {
 	type pull struct {
 		bits   byte
 		value  uint32
 		ok     bool
-		bitVal bitvalue
+		bitVal bits
 	}
 	tt := []struct {
-		name   string
-		bitVal bitvalue
-		pulls  []pull
+		name  string
+		vbits bits
+		pulls []pull
 	}{
 		{
-			name:   "single value one pull",
-			bitVal: bitvalue{store: [32]uint64{20}},
-			pulls:  []pull{{bits: 8, value: 20, ok: true, bitVal: bitvalue{store: [32]uint64{0}}}},
+			name:  "single value one pull",
+			vbits: bits{store: [32]uint64{20}},
+			pulls: []pull{{bits: 8, value: 20, ok: true, bitVal: bits{store: [32]uint64{0}}}},
 		},
 		{
-			name:   "single value multiple pull",
-			bitVal: bitvalue{store: [32]uint64{math.MaxUint16}},
+			name:  "single value multiple pull",
+			vbits: bits{store: [32]uint64{math.MaxUint16}},
 			pulls: []pull{
-				{bits: 8, value: 255, ok: true, bitVal: bitvalue{store: [32]uint64{255}}},
-				{bits: 8, value: 255, ok: true, bitVal: bitvalue{store: [32]uint64{0}}},
+				{bits: 8, value: 255, ok: true, bitVal: bits{store: [32]uint64{255}}},
+				{bits: 8, value: 255, ok: true, bitVal: bits{store: [32]uint64{0}}},
 			},
 		},
 		{
-			name:   "slice value one pull",
-			bitVal: bitvalue{store: [32]uint64{math.MaxUint16, math.MaxUint16}},
+			name:  "slice value one pull",
+			vbits: bits{store: [32]uint64{math.MaxUint64, math.MaxUint16}},
 			pulls: []pull{
-				{bits: 8, value: 255, ok: true, bitVal: bitvalue{store: [32]uint64{math.MaxUint16, 255}}},
+				{bits: 8, value: 255, ok: true, bitVal: bits{store: [32]uint64{math.MaxUint64, 255}}},
 			},
 		},
 		{
-			name:   "slice value multiple pull",
-			bitVal: bitvalue{store: [32]uint64{math.MaxUint16, math.MaxUint16}},
+			name:  "slice value multiple pull",
+			vbits: bits{store: [32]uint64{math.MaxUint64, math.MaxUint16}},
 			pulls: []pull{
-				{bits: 8, value: 255, ok: true, bitVal: bitvalue{store: [32]uint64{math.MaxUint16, 255}}},
-				{bits: 8, value: 255, ok: true, bitVal: bitvalue{store: [32]uint64{math.MaxUint16}}},
+				{bits: 8, value: 255, ok: true, bitVal: bits{store: [32]uint64{math.MaxUint64, 255}}},
+				{bits: 8, value: 255, ok: true, bitVal: bits{store: [32]uint64{math.MaxUint64}}},
 			},
 		},
 		{
-			name:   "single value one pull bits > 32 (64)",
-			bitVal: bitvalue{store: [32]uint64{20}},
-			pulls:  []pull{{bits: 64, value: 0, ok: false, bitVal: bitvalue{store: [32]uint64{20}}}},
+			name:  "single value one pull bits > 32 (64)",
+			vbits: bits{store: [32]uint64{20}},
+			pulls: []pull{{bits: 64, value: 0, ok: false, bitVal: bits{store: [32]uint64{20}}}},
 		},
 		{
-			name:   "single value one pull store is zero",
-			bitVal: bitvalue{store: [32]uint64{0}},
-			pulls:  []pull{{bits: 8, value: 0, ok: false, bitVal: bitvalue{store: [32]uint64{0}}}},
+			name:  "single value one pull store is zero",
+			vbits: bits{store: [32]uint64{0}},
+			pulls: []pull{{bits: 8, value: 0, ok: false, bitVal: bits{store: [32]uint64{0}}}},
 		},
 	}
 
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
 			for _, p := range tc.pulls {
-				u32, ok := tc.bitVal.PullByMask(p.bits)
+				u32, ok := tc.vbits.Pull(p.bits)
 				if ok != p.ok {
 					t.Fatalf("expected ok: %t, got: %t", p.ok, ok)
 				}
 				if u32 != p.value {
 					t.Fatalf("expected value: %t, got: %t", p.ok, ok)
 				}
-				if tc.bitVal != p.bitVal {
-					t.Fatalf("expected bitVal: %v, got: %v", tc.bitVal, tc.bitVal)
+				if tc.vbits != p.bitVal {
+					t.Fatalf("expected bitVal:\n%v,\n got:\n%v", tc.vbits, p.bitVal)
 				}
 			}
 		})
 	}
-}
-
-func TestValueAppend(t *testing.T) {
-	tt := []struct {
-		slice    proto.Value
-		elem     proto.Value
-		expected proto.Value
-	}{
-		{
-			slice:    proto.SliceInt8([]int8{10}),
-			elem:     proto.Int8(11),
-			expected: proto.SliceInt8([]int8{10, 11}),
-		},
-		{
-			slice:    proto.SliceUint8([]uint8{10}),
-			elem:     proto.Uint8(11),
-			expected: proto.SliceUint8([]uint8{10, 11}),
-		},
-		{
-			slice:    proto.SliceInt16([]int16{10}),
-			elem:     proto.Int16(11),
-			expected: proto.SliceInt16([]int16{10, 11}),
-		},
-		{
-			slice:    proto.SliceUint16([]uint16{10}),
-			elem:     proto.Uint16(11),
-			expected: proto.SliceUint16([]uint16{10, 11}),
-		},
-		{
-			slice:    proto.SliceInt32([]int32{10}),
-			elem:     proto.Int32(11),
-			expected: proto.SliceInt32([]int32{10, 11}),
-		},
-		{
-			slice:    proto.SliceUint32([]uint32{10}),
-			elem:     proto.Uint32(11),
-			expected: proto.SliceUint32([]uint32{10, 11}),
-		},
-		{
-			slice:    proto.SliceInt64([]int64{10}),
-			elem:     proto.Int64(11),
-			expected: proto.SliceInt64([]int64{10, 11}),
-		},
-		{
-			slice:    proto.SliceUint64([]uint64{10}),
-			elem:     proto.Uint64(11),
-			expected: proto.SliceUint64([]uint64{10, 11}),
-		},
-		{
-			slice:    proto.SliceFloat32([]float32{10}),
-			elem:     proto.Float32(11),
-			expected: proto.SliceFloat32([]float32{10, 11}),
-		},
-		{
-			slice:    proto.SliceFloat64([]float64{10}),
-			elem:     proto.Float64(11),
-			expected: proto.SliceFloat64([]float64{10, 11}),
-		},
-		{
-			slice:    proto.SliceString([]string{"invalid"}),
-			elem:     proto.String("qwerty"),
-			expected: proto.SliceString([]string{"invalid"}),
-		},
-	}
-
-	for i, tc := range tt {
-		t.Run(fmt.Sprintf("[%d] %s", i, tc.slice.Type()), func(t *testing.T) {
-			val := valueAppend(tc.slice, tc.elem)
-			if diff := cmp.Diff(val, tc.expected,
-				cmp.Transformer("Value", func(v proto.Value) any { return v.Any() }),
-			); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
-}
-
-func BenchmarkMakeBitValueToValueRoundTrip(b *testing.B) {
-	b.Run("to float64", func(b *testing.B) {
-		const v = 1080122531
-		val := proto.Float64(v)
-		for i := 0; i < b.N; i++ {
-			bitVal, _ := makeBitValue(val)
-			if bitVal.ToValue(basetype.Float64).Float64() != val.Float64() {
-				b.Fatalf("expected: %T: %v, got: %T: %v", v, v, bitVal, bitVal)
-			}
-		}
-	})
-	b.Run("to bytes", func(b *testing.B) {
-		var buf []uint8
-		buf = binary.LittleEndian.AppendUint64(buf, 10)
-		buf = binary.LittleEndian.AppendUint64(buf, 11)
-		val := proto.SliceUint8(buf)
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			bitVal, _ := makeBitValue(val)
-			_ = bitVal.ToValue(basetype.Byte).SliceUint8()
-		}
-	})
 }

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -1862,6 +1862,54 @@ func TestDecodeFields(t *testing.T) {
 			opts: []Option{WithLogWriter(io.Discard)},
 			err:  nil,
 		},
+		{
+			name: "decode fields field def's size 2 < 4 size of uint32",
+			r: func() io.Reader {
+				mesg := proto.Message{
+					Num: 68,
+					Fields: []proto.Field{
+						{
+							FieldBase: &proto.FieldBase{
+								Num:  1,
+								Name: "Unknown",
+							},
+							Value: proto.SliceUint8([]byte{1, 0}),
+						},
+					},
+				}
+				mesgb, _ := mesg.MarshalAppend(nil, proto.LittleEndian)
+				mesgb = mesgb[1:] // splice mesg header
+				cur := 0
+				return fnReader(func(b []byte) (n int, err error) {
+					cur += copy(b, mesgb[cur:])
+					return len(b), nil
+				})
+			}(),
+			mesgdef: &proto.MessageDefinition{
+				Header:  proto.MesgDefinitionMask,
+				MesgNum: 68,
+				FieldDefinitions: []proto.FieldDefinition{
+					{
+						Num:      1,
+						Size:     2,
+						BaseType: basetype.Uint32,
+					},
+				},
+			},
+			validateFn: func(mesg proto.Message) error {
+				if mesg.Fields[0].Value.Type() != proto.TypeUint32 {
+					return fmt.Errorf("expected proto value type: %s, got: %s",
+						proto.TypeUint32, mesg.Fields[0].Value.Type(),
+					)
+				}
+				if mesg.Fields[0].Value.Uint32() != 1 {
+					return fmt.Errorf("expected value: 1, got: %d", mesg.Fields[0].Value.Any())
+				}
+				return nil
+			},
+			opts: []Option{WithLogWriter(io.Discard)},
+			err:  nil,
+		},
 	}
 
 	for i, tc := range tt {
@@ -1887,6 +1935,7 @@ func TestDecodeFields(t *testing.T) {
 func TestExpandComponents(t *testing.T) {
 	tt := []struct {
 		name                 string
+		accumu               *Accumulator
 		mesg                 proto.Message
 		fieldsAfterExpansion []proto.Field
 	}{
@@ -1957,11 +2006,51 @@ func TestExpandComponents(t *testing.T) {
 				factory.CreateField(mesgnum.Session, fieldnum.SessionAvgSpeed).WithValue(uint16(basetype.Uint16Invalid)),
 			},
 		},
+		{
+			name: "expand components requiring expansion: compressed_speed_distance -> (speed, speed -> enhanced_speed, distance)",
+			mesg: proto.Message{Num: mesgnum.Record, Fields: []proto.Field{
+				factory.CreateField(mesgnum.Record, fieldnum.RecordCompressedSpeedDistance).WithValue([]byte{0, 4, 1}),
+			}},
+			fieldsAfterExpansion: []proto.Field{
+				factory.CreateField(mesgnum.Record, fieldnum.RecordCompressedSpeedDistance).WithValue([]byte{0, 4, 1}),
+				{FieldBase: factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed).FieldBase, Value: proto.Uint16(10240), IsExpandedField: true},         // (1024 / 1000) * 1000
+				{FieldBase: factory.CreateField(mesgnum.Record, fieldnum.RecordEnhancedSpeed).FieldBase, Value: proto.Uint32(10240), IsExpandedField: true}, // (1024 / 100) * 1000
+				{FieldBase: factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).FieldBase, Value: proto.Uint32(100), IsExpandedField: true},        // (1600 / 16) * 1
+			},
+		},
+		{
+			// Real world use case from "testdata/from_official_sdk/activity_poolswim_with_hr.csv"
+			// prior Hr message event_timestamp value: 3.6201171875 -> 3707
+			// event_timestamp_12:  "158|114|57|159|6|167|29|142|25|244|228|130"
+			// event_timestamp:     "4.654296875|4.8974609375|5.6552734375|6.609375|7.5283203125|8.3984375|9.23828125|10.044921875"
+			// event_timestamp raw: "4766       |5015        |5791        |6768    |7709        |8600     |9460      |10286"
+			name: "expand components: Hr mesg's event_timestamp_12",
+			accumu: &Accumulator{values: []value{
+				// Prior Hr message
+				{mesgNum: mesgnum.Hr, fieldNum: fieldnum.HrEventTimestamp, value: 3707, last: 3707},
+			}},
+			mesg: proto.Message{Num: mesgnum.Hr, Fields: []proto.Field{
+				factory.CreateField(mesgnum.Hr, fieldnum.HrEventTimestamp12).WithValue([]byte{158, 114, 57, 159, 6, 167, 29, 142, 25, 244, 228, 130}),
+			}},
+			fieldsAfterExpansion: []proto.Field{
+				factory.CreateField(mesgnum.Hr, fieldnum.HrEventTimestamp12).WithValue([]byte{158, 114, 57, 159, 6, 167, 29, 142, 25, 244, 228, 130}),
+				{
+					FieldBase: factory.CreateField(mesgnum.Hr, fieldnum.HrEventTimestamp).FieldBase,
+					Value: proto.SliceUint32([]uint32{
+						4766, 5015, 5791, 6768, 7709, 8600, 9460, 10286,
+					}),
+					IsExpandedField: true,
+				},
+			},
+		},
 	}
 
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
 			dec := New(nil)
+			if tc.accumu != nil {
+				dec.accumulator = tc.accumu
+			}
 			for _, field := range tc.mesg.Fields {
 				if subField := field.SubFieldSubtitution(&tc.mesg); subField != nil {
 					dec.expandComponents(&tc.mesg, &field, subField.Components)
@@ -1975,50 +2064,6 @@ func TestExpandComponents(t *testing.T) {
 				t.Fatal(diff)
 			}
 		})
-	}
-}
-
-func TestExpandMutipleComponents(t *testing.T) {
-	// Expand componentField.Components that require expansion
-	compressedSepeedDistanceField := factory.CreateField(mesgnum.Record, fieldnum.RecordCompressedSpeedDistance).
-		WithValue([]byte{0, 4, 1})
-
-	mesg := proto.Message{Num: mesgnum.Record, Fields: []proto.Field{compressedSepeedDistanceField}}
-	dec := New(nil)
-	dec.expandComponents(&mesg, &compressedSepeedDistanceField, compressedSepeedDistanceField.Components)
-
-	if len(mesg.Fields) != 4 {
-		t.Errorf("expected n fields after expansion: %d, got: %d", 4, len(mesg.Fields))
-	}
-
-	if diff := cmp.Diff(
-		mesg.FieldValueByNum(fieldnum.RecordCompressedSpeedDistance).Any(),
-		[]byte{0, 4, 1},
-	); diff != "" {
-		t.Errorf("compressed_speed_distance: %s", diff)
-	}
-
-	// Formula: value = (value / component_speed_scale) * destination_field_scale
-
-	if diff := cmp.Diff(
-		mesg.FieldValueByNum(fieldnum.RecordSpeed).Any(),
-		uint16(10240), // (1024 / 100) * 1000
-	); diff != "" {
-		t.Errorf("speed: %s", diff)
-	}
-
-	if diff := cmp.Diff(
-		mesg.FieldValueByNum(fieldnum.RecordDistance).Any(),
-		uint32(100), // (1600 / 16) * 1
-	); diff != "" {
-		t.Errorf("distance: %s", diff)
-	}
-
-	if diff := cmp.Diff(
-		mesg.FieldValueByNum(fieldnum.RecordEnhancedSpeed).Any(),
-		uint32(10240), // (1024 / 1000) * 1000
-	); diff != "" {
-		t.Errorf("enhanced_speed: %s", diff)
 	}
 }
 
@@ -2702,6 +2747,297 @@ func TestReset(t *testing.T) {
 					}
 					return true
 				}),
+			); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestConvertValueToUint32(t *testing.T) {
+	tt := []struct {
+		value    proto.Value
+		expected uint32
+	}{
+		{
+			value:    proto.Int8(32),
+			expected: 32,
+		},
+		{
+			value:    proto.Uint8(32),
+			expected: 32,
+		},
+		{
+			value:    proto.Int16(32),
+			expected: 32,
+		},
+		{
+			value:    proto.Uint16(32),
+			expected: 32,
+		},
+		{
+			value:    proto.Int32(32),
+			expected: 32,
+		},
+		{
+			value:    proto.Uint32(32),
+			expected: 32,
+		},
+		{
+			value:    proto.Int64(32),
+			expected: 32,
+		},
+		{
+			value:    proto.Uint64(32),
+			expected: 32,
+		},
+		{
+			value:    proto.Float32(32),
+			expected: 32,
+		},
+		{
+			value:    proto.Float64(32),
+			expected: 32,
+		},
+		{
+			value:    proto.Value{},
+			expected: basetype.Uint32Invalid,
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %v", i, tc.value.Any()), func(t *testing.T) {
+			val := convertValueToUint32(tc.value)
+			if diff := cmp.Diff(val, tc.expected); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestConvertUint32ToValue(t *testing.T) {
+	tt := []struct {
+		value    uint32
+		baseType basetype.BaseType
+		expected proto.Value
+	}{
+		{
+			value:    32,
+			baseType: basetype.Sint8,
+			expected: proto.Int8(32),
+		},
+		{
+			value:    32,
+			baseType: basetype.Uint8,
+			expected: proto.Uint8(32),
+		},
+		{
+			value:    32,
+			baseType: basetype.Sint16,
+			expected: proto.Int16(32),
+		},
+		{
+			value:    32,
+			baseType: basetype.Uint16,
+			expected: proto.Uint16(32),
+		},
+		{
+			value:    32,
+			baseType: basetype.Sint32,
+			expected: proto.Int32(32),
+		},
+		{
+			value:    32,
+			baseType: basetype.Uint32,
+			expected: proto.Uint32(32),
+		},
+		{
+			value:    32,
+			baseType: basetype.Sint64,
+			expected: proto.Int64(32),
+		},
+		{
+			value:    32,
+			baseType: basetype.Uint64,
+			expected: proto.Uint64(32),
+		},
+		{
+			value:    32,
+			baseType: basetype.Float32,
+			expected: proto.Float32(32),
+		},
+		{
+			value:    32,
+			baseType: basetype.Float64,
+			expected: proto.Float64(32),
+		},
+		{
+			value:    32,
+			baseType: basetype.String,
+			expected: proto.Value{},
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %d -> %s", i, tc.value, tc.baseType), func(t *testing.T) {
+			val := convertUint32ToValue(tc.value, tc.baseType)
+			if diff := cmp.Diff(val, tc.expected,
+				cmp.Transformer("Value", func(v proto.Value) any { return v.Any() }),
+			); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestConvertBytesToValue(t *testing.T) {
+	tt := []struct {
+		value    proto.Value
+		baseType basetype.BaseType
+		expected proto.Value
+	}{
+		{
+			value:    proto.Uint8(1),
+			baseType: basetype.Sint8,
+			expected: proto.Int8(1),
+		},
+		{
+			value:    proto.Uint8(1),
+			baseType: basetype.Uint8,
+			expected: proto.Uint8(1),
+		},
+		{
+			value:    proto.Uint8(1),
+			baseType: basetype.Sint16,
+			expected: proto.Int16(1),
+		},
+		{
+			value:    proto.Uint8(1),
+			baseType: basetype.Uint16,
+			expected: proto.Uint16(1),
+		},
+		{
+			value:    proto.Uint8(1),
+			baseType: basetype.Sint32,
+			expected: proto.Int32(1),
+		},
+		{
+			value:    proto.Uint8(1),
+			baseType: basetype.Uint32,
+			expected: proto.Uint32(1),
+		},
+		{
+			value:    proto.Uint8(1),
+			baseType: basetype.Sint64,
+			expected: proto.Int64(1),
+		},
+		{
+			value:    proto.Uint8(1),
+			baseType: basetype.Uint64,
+			expected: proto.Uint64(1),
+		},
+		{
+			value:    proto.Uint8(1),
+			baseType: basetype.Float32,
+			expected: proto.Float32(1),
+		},
+		{
+			value:    proto.Uint8(1),
+			baseType: basetype.Float64,
+			expected: proto.Float64(1),
+		},
+		{
+			value:    proto.Uint8(1),
+			baseType: basetype.String,
+			expected: proto.Uint8(1),
+		},
+		{
+			value:    proto.SliceUint8([]uint8{1, 1}),
+			baseType: basetype.Uint32,
+			expected: proto.Uint32(257),
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %v", i, tc.value.Any()), func(t *testing.T) {
+			val := convertBytesToValue(tc.value, tc.baseType)
+			if diff := cmp.Diff(val, tc.expected,
+				cmp.Transformer("Value", func(v proto.Value) any { return v.Any() }),
+			); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestValueAppend(t *testing.T) {
+	tt := []struct {
+		slice    proto.Value
+		elem     proto.Value
+		expected proto.Value
+	}{
+		{
+			slice:    proto.SliceInt8([]int8{10}),
+			elem:     proto.Int8(11),
+			expected: proto.SliceInt8([]int8{10, 11}),
+		},
+		{
+			slice:    proto.SliceUint8([]uint8{10}),
+			elem:     proto.Uint8(11),
+			expected: proto.SliceUint8([]uint8{10, 11}),
+		},
+		{
+			slice:    proto.SliceInt16([]int16{10}),
+			elem:     proto.Int16(11),
+			expected: proto.SliceInt16([]int16{10, 11}),
+		},
+		{
+			slice:    proto.SliceUint16([]uint16{10}),
+			elem:     proto.Uint16(11),
+			expected: proto.SliceUint16([]uint16{10, 11}),
+		},
+		{
+			slice:    proto.SliceInt32([]int32{10}),
+			elem:     proto.Int32(11),
+			expected: proto.SliceInt32([]int32{10, 11}),
+		},
+		{
+			slice:    proto.SliceUint32([]uint32{10}),
+			elem:     proto.Uint32(11),
+			expected: proto.SliceUint32([]uint32{10, 11}),
+		},
+		{
+			slice:    proto.SliceInt64([]int64{10}),
+			elem:     proto.Int64(11),
+			expected: proto.SliceInt64([]int64{10, 11}),
+		},
+		{
+			slice:    proto.SliceUint64([]uint64{10}),
+			elem:     proto.Uint64(11),
+			expected: proto.SliceUint64([]uint64{10, 11}),
+		},
+		{
+			slice:    proto.SliceFloat32([]float32{10}),
+			elem:     proto.Float32(11),
+			expected: proto.SliceFloat32([]float32{10, 11}),
+		},
+		{
+			slice:    proto.SliceFloat64([]float64{10}),
+			elem:     proto.Float64(11),
+			expected: proto.SliceFloat64([]float64{10, 11}),
+		},
+		{
+			slice:    proto.SliceString([]string{"invalid"}),
+			elem:     proto.String("qwerty"),
+			expected: proto.SliceString([]string{"invalid"}),
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.slice.Type()), func(t *testing.T) {
+			val := valueAppend(tc.slice, tc.elem)
+			if diff := cmp.Diff(val, tc.expected,
+				cmp.Transformer("Value", func(v proto.Value) any { return v.Any() }),
 			); diff != "" {
 				t.Fatal(diff)
 			}


### PR DESCRIPTION
Previous implementation of component expansion does not accommodate containing field's value more than 32 bits. This results in expanding incorrect components for  messages that has more than 32 bits such as "Hr" `event_timestamp_12` (up to 120 bits) and "RawBbi" `data` (up to 240 bits). 

By design, field's value requiring expansion can hold up to 255 bytes (2040 bits) data, this is obviously way more bits than Go's primitive single value can hold. To handle this, I implement new type "bits" struct that can store up to 2048 bits data, enable us to do bitwise operation over it for component expansion.

To test the correctness, I use sample data from _"testdata/from_official_sdk/activity_poolswim_with_hr.csv"_, as it contains **96 bits data** to be expanded and the new implementation produces the correct values as in the CSV file.