### PR TITLE
perf: mesgdef clear array pool

### DIFF
--- a/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
+++ b/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
@@ -68,6 +68,7 @@ func New{{ .Name }}(mesg *proto.Message) *{{ .Name }} {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)]) {{/* In case of unknown field or field.Value contains pointer to a slice */}}
 		pool.Put(arr)
 		{{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
 			developerFields = mesg.DeveloperFields
@@ -132,6 +133,7 @@ func (m *{{ .Name }}) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields) {{/* In case of unknown field or field.Value contains pointer to a slice */}}
 	pool.Put(arr)
 
 	{{ if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
@@ -282,14 +284,14 @@ func (m *{{ $.Name }}) Set{{ .Name }}Degrees(degrees float64) *{{ $.Name }} {
 
 {{ end }}
 
-// SetDeveloperFields {{ $.Name }}'s UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *{{ $.Name }}) SetUnknownFields(unknownFields ...proto.Field) *{{ $.Name }} {
 	m.UnknownFields = unknownFields
 	return m
 }
 
 {{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription")) }}
-// SetDeveloperFields {{ $.Name }}'s DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *{{ $.Name }}) SetDeveloperFields(developerFields ...proto.DeveloperField) *{{ $.Name }} {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/aad_accel_features_gen.go
+++ b/profile/mesgdef/aad_accel_features_gen.go
@@ -203,13 +203,13 @@ func (m *AadAccelFeatures) SetTimeAboveThresholdScaled(v float64) *AadAccelFeatu
 	return m
 }
 
-// SetUnknownFields AadAccelFeatures's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *AadAccelFeatures) SetUnknownFields(unknownFields ...proto.Field) *AadAccelFeatures {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields AadAccelFeatures's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *AadAccelFeatures) SetDeveloperFields(developerFields ...proto.DeveloperField) *AadAccelFeatures {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/aad_accel_features_gen.go
+++ b/profile/mesgdef/aad_accel_features_gen.go
@@ -51,6 +51,7 @@ func NewAadAccelFeatures(mesg *proto.Message) *AadAccelFeatures {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -120,6 +121,7 @@ func (m *AadAccelFeatures) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -201,7 +203,7 @@ func (m *AadAccelFeatures) SetTimeAboveThresholdScaled(v float64) *AadAccelFeatu
 	return m
 }
 
-// SetDeveloperFields AadAccelFeatures's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields AadAccelFeatures's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *AadAccelFeatures) SetUnknownFields(unknownFields ...proto.Field) *AadAccelFeatures {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/accelerometer_data_gen.go
+++ b/profile/mesgdef/accelerometer_data_gen.go
@@ -56,6 +56,7 @@ func NewAccelerometerData(mesg *proto.Message) *AccelerometerData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -161,6 +162,7 @@ func (m *AccelerometerData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -267,7 +269,7 @@ func (m *AccelerometerData) SetCompressedCalibratedAccelZ(v []int16) *Accelerome
 	return m
 }
 
-// SetDeveloperFields AccelerometerData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields AccelerometerData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *AccelerometerData) SetUnknownFields(unknownFields ...proto.Field) *AccelerometerData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/accelerometer_data_gen.go
+++ b/profile/mesgdef/accelerometer_data_gen.go
@@ -269,13 +269,13 @@ func (m *AccelerometerData) SetCompressedCalibratedAccelZ(v []int16) *Accelerome
 	return m
 }
 
-// SetUnknownFields AccelerometerData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *AccelerometerData) SetUnknownFields(unknownFields ...proto.Field) *AccelerometerData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields AccelerometerData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *AccelerometerData) SetDeveloperFields(developerFields ...proto.DeveloperField) *AccelerometerData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/activity_gen.go
+++ b/profile/mesgdef/activity_gen.go
@@ -226,13 +226,13 @@ func (m *Activity) SetEventGroup(v uint8) *Activity {
 	return m
 }
 
-// SetUnknownFields Activity's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Activity) SetUnknownFields(unknownFields ...proto.Field) *Activity {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Activity's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Activity) SetDeveloperFields(developerFields ...proto.DeveloperField) *Activity {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/activity_gen.go
+++ b/profile/mesgdef/activity_gen.go
@@ -53,6 +53,7 @@ func NewActivity(mesg *proto.Message) *Activity {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -134,6 +135,7 @@ func (m *Activity) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -224,7 +226,7 @@ func (m *Activity) SetEventGroup(v uint8) *Activity {
 	return m
 }
 
-// SetDeveloperFields Activity's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Activity's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Activity) SetUnknownFields(unknownFields ...proto.Field) *Activity {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/ant_channel_id_gen.go
+++ b/profile/mesgdef/ant_channel_id_gen.go
@@ -155,13 +155,13 @@ func (m *AntChannelId) SetDeviceIndex(v typedef.DeviceIndex) *AntChannelId {
 	return m
 }
 
-// SetUnknownFields AntChannelId's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *AntChannelId) SetUnknownFields(unknownFields ...proto.Field) *AntChannelId {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields AntChannelId's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *AntChannelId) SetDeveloperFields(developerFields ...proto.DeveloperField) *AntChannelId {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/ant_channel_id_gen.go
+++ b/profile/mesgdef/ant_channel_id_gen.go
@@ -47,6 +47,7 @@ func NewAntChannelId(mesg *proto.Message) *AntChannelId {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -110,6 +111,7 @@ func (m *AntChannelId) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -153,7 +155,7 @@ func (m *AntChannelId) SetDeviceIndex(v typedef.DeviceIndex) *AntChannelId {
 	return m
 }
 
-// SetDeveloperFields AntChannelId's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields AntChannelId's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *AntChannelId) SetUnknownFields(unknownFields ...proto.Field) *AntChannelId {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/ant_rx_gen.go
+++ b/profile/mesgdef/ant_rx_gen.go
@@ -216,13 +216,13 @@ func (m *AntRx) SetData(v []byte) *AntRx {
 	return m
 }
 
-// SetUnknownFields AntRx's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *AntRx) SetUnknownFields(unknownFields ...proto.Field) *AntRx {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields AntRx's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *AntRx) SetDeveloperFields(developerFields ...proto.DeveloperField) *AntRx {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/ant_rx_gen.go
+++ b/profile/mesgdef/ant_rx_gen.go
@@ -58,6 +58,7 @@ func NewAntRx(mesg *proto.Message) *AntRx {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -135,6 +136,7 @@ func (m *AntRx) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -214,7 +216,7 @@ func (m *AntRx) SetData(v []byte) *AntRx {
 	return m
 }
 
-// SetDeveloperFields AntRx's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields AntRx's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *AntRx) SetUnknownFields(unknownFields ...proto.Field) *AntRx {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/ant_tx_gen.go
+++ b/profile/mesgdef/ant_tx_gen.go
@@ -216,13 +216,13 @@ func (m *AntTx) SetData(v []byte) *AntTx {
 	return m
 }
 
-// SetUnknownFields AntTx's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *AntTx) SetUnknownFields(unknownFields ...proto.Field) *AntTx {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields AntTx's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *AntTx) SetDeveloperFields(developerFields ...proto.DeveloperField) *AntTx {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/ant_tx_gen.go
+++ b/profile/mesgdef/ant_tx_gen.go
@@ -58,6 +58,7 @@ func NewAntTx(mesg *proto.Message) *AntTx {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -135,6 +136,7 @@ func (m *AntTx) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -214,7 +216,7 @@ func (m *AntTx) SetData(v []byte) *AntTx {
 	return m
 }
 
-// SetDeveloperFields AntTx's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields AntTx's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *AntTx) SetUnknownFields(unknownFields ...proto.Field) *AntTx {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/aviation_attitude_gen.go
+++ b/profile/mesgdef/aviation_attitude_gen.go
@@ -519,13 +519,13 @@ func (m *AviationAttitude) SetValidity(v []typedef.AttitudeValidity) *AviationAt
 	return m
 }
 
-// SetUnknownFields AviationAttitude's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *AviationAttitude) SetUnknownFields(unknownFields ...proto.Field) *AviationAttitude {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields AviationAttitude's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *AviationAttitude) SetDeveloperFields(developerFields ...proto.DeveloperField) *AviationAttitude {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/aviation_attitude_gen.go
+++ b/profile/mesgdef/aviation_attitude_gen.go
@@ -58,6 +58,7 @@ func NewAviationAttitude(mesg *proto.Message) *AviationAttitude {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -171,6 +172,7 @@ func (m *AviationAttitude) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -517,7 +519,7 @@ func (m *AviationAttitude) SetValidity(v []typedef.AttitudeValidity) *AviationAt
 	return m
 }
 
-// SetDeveloperFields AviationAttitude's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields AviationAttitude's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *AviationAttitude) SetUnknownFields(unknownFields ...proto.Field) *AviationAttitude {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/barometer_data_gen.go
+++ b/profile/mesgdef/barometer_data_gen.go
@@ -48,6 +48,7 @@ func NewBarometerData(mesg *proto.Message) *BarometerData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -105,6 +106,7 @@ func (m *BarometerData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -147,7 +149,7 @@ func (m *BarometerData) SetBaroPres(v []uint32) *BarometerData {
 	return m
 }
 
-// SetDeveloperFields BarometerData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields BarometerData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *BarometerData) SetUnknownFields(unknownFields ...proto.Field) *BarometerData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/barometer_data_gen.go
+++ b/profile/mesgdef/barometer_data_gen.go
@@ -149,13 +149,13 @@ func (m *BarometerData) SetBaroPres(v []uint32) *BarometerData {
 	return m
 }
 
-// SetUnknownFields BarometerData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *BarometerData) SetUnknownFields(unknownFields ...proto.Field) *BarometerData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields BarometerData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *BarometerData) SetDeveloperFields(developerFields ...proto.DeveloperField) *BarometerData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/beat_intervals_gen.go
+++ b/profile/mesgdef/beat_intervals_gen.go
@@ -132,13 +132,13 @@ func (m *BeatIntervals) SetTime(v []uint16) *BeatIntervals {
 	return m
 }
 
-// SetUnknownFields BeatIntervals's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *BeatIntervals) SetUnknownFields(unknownFields ...proto.Field) *BeatIntervals {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields BeatIntervals's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *BeatIntervals) SetDeveloperFields(developerFields ...proto.DeveloperField) *BeatIntervals {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/beat_intervals_gen.go
+++ b/profile/mesgdef/beat_intervals_gen.go
@@ -47,6 +47,7 @@ func NewBeatIntervals(mesg *proto.Message) *BeatIntervals {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -98,6 +99,7 @@ func (m *BeatIntervals) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -130,7 +132,7 @@ func (m *BeatIntervals) SetTime(v []uint16) *BeatIntervals {
 	return m
 }
 
-// SetDeveloperFields BeatIntervals's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields BeatIntervals's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *BeatIntervals) SetUnknownFields(unknownFields ...proto.Field) *BeatIntervals {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/bike_profile_gen.go
+++ b/profile/mesgdef/bike_profile_gen.go
@@ -689,13 +689,13 @@ func (m *BikeProfile) SetShimanoDi2Enabled(v typedef.Bool) *BikeProfile {
 	return m
 }
 
-// SetUnknownFields BikeProfile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *BikeProfile) SetUnknownFields(unknownFields ...proto.Field) *BikeProfile {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields BikeProfile's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *BikeProfile) SetDeveloperFields(developerFields ...proto.DeveloperField) *BikeProfile {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/bike_profile_gen.go
+++ b/profile/mesgdef/bike_profile_gen.go
@@ -75,6 +75,7 @@ func NewBikeProfile(mesg *proto.Message) *BikeProfile {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -300,6 +301,7 @@ func (m *BikeProfile) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -687,7 +689,7 @@ func (m *BikeProfile) SetShimanoDi2Enabled(v typedef.Bool) *BikeProfile {
 	return m
 }
 
-// SetDeveloperFields BikeProfile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields BikeProfile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *BikeProfile) SetUnknownFields(unknownFields ...proto.Field) *BikeProfile {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/blood_pressure_gen.go
+++ b/profile/mesgdef/blood_pressure_gen.go
@@ -55,6 +55,7 @@ func NewBloodPressure(mesg *proto.Message) *BloodPressure {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -154,6 +155,7 @@ func (m *BloodPressure) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -248,7 +250,7 @@ func (m *BloodPressure) SetUserProfileIndex(v typedef.MessageIndex) *BloodPressu
 	return m
 }
 
-// SetDeveloperFields BloodPressure's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields BloodPressure's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *BloodPressure) SetUnknownFields(unknownFields ...proto.Field) *BloodPressure {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/blood_pressure_gen.go
+++ b/profile/mesgdef/blood_pressure_gen.go
@@ -250,13 +250,13 @@ func (m *BloodPressure) SetUserProfileIndex(v typedef.MessageIndex) *BloodPressu
 	return m
 }
 
-// SetUnknownFields BloodPressure's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *BloodPressure) SetUnknownFields(unknownFields ...proto.Field) *BloodPressure {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields BloodPressure's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *BloodPressure) SetDeveloperFields(developerFields ...proto.DeveloperField) *BloodPressure {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/cadence_zone_gen.go
+++ b/profile/mesgdef/cadence_zone_gen.go
@@ -125,13 +125,13 @@ func (m *CadenceZone) SetName(v string) *CadenceZone {
 	return m
 }
 
-// SetUnknownFields CadenceZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *CadenceZone) SetUnknownFields(unknownFields ...proto.Field) *CadenceZone {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields CadenceZone's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *CadenceZone) SetDeveloperFields(developerFields ...proto.DeveloperField) *CadenceZone {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/cadence_zone_gen.go
+++ b/profile/mesgdef/cadence_zone_gen.go
@@ -45,6 +45,7 @@ func NewCadenceZone(mesg *proto.Message) *CadenceZone {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -96,6 +97,7 @@ func (m *CadenceZone) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -123,7 +125,7 @@ func (m *CadenceZone) SetName(v string) *CadenceZone {
 	return m
 }
 
-// SetDeveloperFields CadenceZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields CadenceZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *CadenceZone) SetUnknownFields(unknownFields ...proto.Field) *CadenceZone {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/camera_event_gen.go
+++ b/profile/mesgdef/camera_event_gen.go
@@ -158,13 +158,13 @@ func (m *CameraEvent) SetCameraOrientation(v typedef.CameraOrientationType) *Cam
 	return m
 }
 
-// SetUnknownFields CameraEvent's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *CameraEvent) SetUnknownFields(unknownFields ...proto.Field) *CameraEvent {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields CameraEvent's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *CameraEvent) SetDeveloperFields(developerFields ...proto.DeveloperField) *CameraEvent {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/camera_event_gen.go
+++ b/profile/mesgdef/camera_event_gen.go
@@ -49,6 +49,7 @@ func NewCameraEvent(mesg *proto.Message) *CameraEvent {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -112,6 +113,7 @@ func (m *CameraEvent) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -156,7 +158,7 @@ func (m *CameraEvent) SetCameraOrientation(v typedef.CameraOrientationType) *Cam
 	return m
 }
 
-// SetDeveloperFields CameraEvent's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields CameraEvent's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *CameraEvent) SetUnknownFields(unknownFields ...proto.Field) *CameraEvent {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/capabilities_gen.go
+++ b/profile/mesgdef/capabilities_gen.go
@@ -148,13 +148,13 @@ func (m *Capabilities) SetConnectivitySupported(v typedef.ConnectivityCapabiliti
 	return m
 }
 
-// SetUnknownFields Capabilities's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Capabilities) SetUnknownFields(unknownFields ...proto.Field) *Capabilities {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Capabilities's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Capabilities) SetDeveloperFields(developerFields ...proto.DeveloperField) *Capabilities {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/capabilities_gen.go
+++ b/profile/mesgdef/capabilities_gen.go
@@ -46,6 +46,7 @@ func NewCapabilities(mesg *proto.Message) *Capabilities {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -107,6 +108,7 @@ func (m *Capabilities) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -146,7 +148,7 @@ func (m *Capabilities) SetConnectivitySupported(v typedef.ConnectivityCapabiliti
 	return m
 }
 
-// SetDeveloperFields Capabilities's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Capabilities's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Capabilities) SetUnknownFields(unknownFields ...proto.Field) *Capabilities {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/chrono_shot_data_gen.go
+++ b/profile/mesgdef/chrono_shot_data_gen.go
@@ -156,13 +156,13 @@ func (m *ChronoShotData) SetShotNum(v uint16) *ChronoShotData {
 	return m
 }
 
-// SetUnknownFields ChronoShotData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ChronoShotData) SetUnknownFields(unknownFields ...proto.Field) *ChronoShotData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields ChronoShotData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *ChronoShotData) SetDeveloperFields(developerFields ...proto.DeveloperField) *ChronoShotData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/chrono_shot_data_gen.go
+++ b/profile/mesgdef/chrono_shot_data_gen.go
@@ -48,6 +48,7 @@ func NewChronoShotData(mesg *proto.Message) *ChronoShotData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -99,6 +100,7 @@ func (m *ChronoShotData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -154,7 +156,7 @@ func (m *ChronoShotData) SetShotNum(v uint16) *ChronoShotData {
 	return m
 }
 
-// SetDeveloperFields ChronoShotData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields ChronoShotData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ChronoShotData) SetUnknownFields(unknownFields ...proto.Field) *ChronoShotData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/chrono_shot_session_gen.go
+++ b/profile/mesgdef/chrono_shot_session_gen.go
@@ -289,13 +289,13 @@ func (m *ChronoShotSession) SetGrainWeightScaled(v float64) *ChronoShotSession {
 	return m
 }
 
-// SetUnknownFields ChronoShotSession's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ChronoShotSession) SetUnknownFields(unknownFields ...proto.Field) *ChronoShotSession {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields ChronoShotSession's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *ChronoShotSession) SetDeveloperFields(developerFields ...proto.DeveloperField) *ChronoShotSession {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/chrono_shot_session_gen.go
+++ b/profile/mesgdef/chrono_shot_session_gen.go
@@ -52,6 +52,7 @@ func NewChronoShotSession(mesg *proto.Message) *ChronoShotSession {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -127,6 +128,7 @@ func (m *ChronoShotSession) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -287,7 +289,7 @@ func (m *ChronoShotSession) SetGrainWeightScaled(v float64) *ChronoShotSession {
 	return m
 }
 
-// SetDeveloperFields ChronoShotSession's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields ChronoShotSession's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ChronoShotSession) SetUnknownFields(unknownFields ...proto.Field) *ChronoShotSession {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/climb_pro_gen.go
+++ b/profile/mesgdef/climb_pro_gen.go
@@ -53,6 +53,7 @@ func NewClimbPro(mesg *proto.Message) *ClimbPro {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -128,6 +129,7 @@ func (m *ClimbPro) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -214,7 +216,7 @@ func (m *ClimbPro) SetCurrentDist(v float32) *ClimbPro {
 	return m
 }
 
-// SetDeveloperFields ClimbPro's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields ClimbPro's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ClimbPro) SetUnknownFields(unknownFields ...proto.Field) *ClimbPro {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/climb_pro_gen.go
+++ b/profile/mesgdef/climb_pro_gen.go
@@ -216,13 +216,13 @@ func (m *ClimbPro) SetCurrentDist(v float32) *ClimbPro {
 	return m
 }
 
-// SetUnknownFields ClimbPro's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ClimbPro) SetUnknownFields(unknownFields ...proto.Field) *ClimbPro {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields ClimbPro's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *ClimbPro) SetDeveloperFields(developerFields ...proto.DeveloperField) *ClimbPro {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/connectivity_gen.go
+++ b/profile/mesgdef/connectivity_gen.go
@@ -259,13 +259,13 @@ func (m *Connectivity) SetGrouptrackEnabled(v typedef.Bool) *Connectivity {
 	return m
 }
 
-// SetUnknownFields Connectivity's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Connectivity) SetUnknownFields(unknownFields ...proto.Field) *Connectivity {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Connectivity's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Connectivity) SetDeveloperFields(developerFields ...proto.DeveloperField) *Connectivity {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/connectivity_gen.go
+++ b/profile/mesgdef/connectivity_gen.go
@@ -55,6 +55,7 @@ func NewConnectivity(mesg *proto.Message) *Connectivity {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -166,6 +167,7 @@ func (m *Connectivity) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -257,7 +259,7 @@ func (m *Connectivity) SetGrouptrackEnabled(v typedef.Bool) *Connectivity {
 	return m
 }
 
-// SetDeveloperFields Connectivity's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Connectivity's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Connectivity) SetUnknownFields(unknownFields ...proto.Field) *Connectivity {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/course_gen.go
+++ b/profile/mesgdef/course_gen.go
@@ -138,13 +138,13 @@ func (m *Course) SetSubSport(v typedef.SubSport) *Course {
 	return m
 }
 
-// SetUnknownFields Course's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Course) SetUnknownFields(unknownFields ...proto.Field) *Course {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Course's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Course) SetDeveloperFields(developerFields ...proto.DeveloperField) *Course {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/course_gen.go
+++ b/profile/mesgdef/course_gen.go
@@ -46,6 +46,7 @@ func NewCourse(mesg *proto.Message) *Course {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -103,6 +104,7 @@ func (m *Course) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -136,7 +138,7 @@ func (m *Course) SetSubSport(v typedef.SubSport) *Course {
 	return m
 }
 
-// SetDeveloperFields Course's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Course's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Course) SetUnknownFields(unknownFields ...proto.Field) *Course {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/course_point_gen.go
+++ b/profile/mesgdef/course_point_gen.go
@@ -54,6 +54,7 @@ func NewCoursePoint(mesg *proto.Message) *CoursePoint {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -135,6 +136,7 @@ func (m *CoursePoint) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -250,7 +252,7 @@ func (m *CoursePoint) SetFavorite(v typedef.Bool) *CoursePoint {
 	return m
 }
 
-// SetDeveloperFields CoursePoint's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields CoursePoint's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *CoursePoint) SetUnknownFields(unknownFields ...proto.Field) *CoursePoint {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/course_point_gen.go
+++ b/profile/mesgdef/course_point_gen.go
@@ -252,13 +252,13 @@ func (m *CoursePoint) SetFavorite(v typedef.Bool) *CoursePoint {
 	return m
 }
 
-// SetUnknownFields CoursePoint's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *CoursePoint) SetUnknownFields(unknownFields ...proto.Field) *CoursePoint {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields CoursePoint's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *CoursePoint) SetDeveloperFields(developerFields ...proto.DeveloperField) *CoursePoint {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/developer_data_id_gen.go
+++ b/profile/mesgdef/developer_data_id_gen.go
@@ -45,6 +45,7 @@ func NewDeveloperDataId(mesg *proto.Message) *DeveloperDataId {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 	}
 
@@ -106,6 +107,7 @@ func (m *DeveloperDataId) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	return mesg
@@ -145,7 +147,7 @@ func (m *DeveloperDataId) SetApplicationVersion(v uint32) *DeveloperDataId {
 	return m
 }
 
-// SetDeveloperFields DeveloperDataId's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields DeveloperDataId's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DeveloperDataId) SetUnknownFields(unknownFields ...proto.Field) *DeveloperDataId {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/developer_data_id_gen.go
+++ b/profile/mesgdef/developer_data_id_gen.go
@@ -147,7 +147,7 @@ func (m *DeveloperDataId) SetApplicationVersion(v uint32) *DeveloperDataId {
 	return m
 }
 
-// SetUnknownFields DeveloperDataId's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DeveloperDataId) SetUnknownFields(unknownFields ...proto.Field) *DeveloperDataId {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/device_aux_battery_info_gen.go
+++ b/profile/mesgdef/device_aux_battery_info_gen.go
@@ -50,6 +50,7 @@ func NewDeviceAuxBatteryInfo(mesg *proto.Message) *DeviceAuxBatteryInfo {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -113,6 +114,7 @@ func (m *DeviceAuxBatteryInfo) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -180,7 +182,7 @@ func (m *DeviceAuxBatteryInfo) SetBatteryIdentifier(v uint8) *DeviceAuxBatteryIn
 	return m
 }
 
-// SetDeveloperFields DeviceAuxBatteryInfo's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields DeviceAuxBatteryInfo's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DeviceAuxBatteryInfo) SetUnknownFields(unknownFields ...proto.Field) *DeviceAuxBatteryInfo {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/device_aux_battery_info_gen.go
+++ b/profile/mesgdef/device_aux_battery_info_gen.go
@@ -182,13 +182,13 @@ func (m *DeviceAuxBatteryInfo) SetBatteryIdentifier(v uint8) *DeviceAuxBatteryIn
 	return m
 }
 
-// SetUnknownFields DeviceAuxBatteryInfo's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DeviceAuxBatteryInfo) SetUnknownFields(unknownFields ...proto.Field) *DeviceAuxBatteryInfo {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields DeviceAuxBatteryInfo's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *DeviceAuxBatteryInfo) SetDeveloperFields(developerFields ...proto.DeveloperField) *DeviceAuxBatteryInfo {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/device_info_gen.go
+++ b/profile/mesgdef/device_info_gen.go
@@ -64,6 +64,7 @@ func NewDeviceInfo(mesg *proto.Message) *DeviceInfo {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -211,6 +212,7 @@ func (m *DeviceInfo) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -449,7 +451,7 @@ func (m *DeviceInfo) SetBatteryLevel(v uint8) *DeviceInfo {
 	return m
 }
 
-// SetDeveloperFields DeviceInfo's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields DeviceInfo's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DeviceInfo) SetUnknownFields(unknownFields ...proto.Field) *DeviceInfo {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/device_info_gen.go
+++ b/profile/mesgdef/device_info_gen.go
@@ -451,13 +451,13 @@ func (m *DeviceInfo) SetBatteryLevel(v uint8) *DeviceInfo {
 	return m
 }
 
-// SetUnknownFields DeviceInfo's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DeviceInfo) SetUnknownFields(unknownFields ...proto.Field) *DeviceInfo {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields DeviceInfo's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *DeviceInfo) SetDeveloperFields(developerFields ...proto.DeveloperField) *DeviceInfo {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/device_settings_gen.go
+++ b/profile/mesgdef/device_settings_gen.go
@@ -489,13 +489,13 @@ func (m *DeviceSettings) SetTapSensitivity(v typedef.TapSensitivity) *DeviceSett
 	return m
 }
 
-// SetUnknownFields DeviceSettings's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DeviceSettings) SetUnknownFields(unknownFields ...proto.Field) *DeviceSettings {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields DeviceSettings's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *DeviceSettings) SetDeveloperFields(developerFields ...proto.DeveloperField) *DeviceSettings {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/device_settings_gen.go
+++ b/profile/mesgdef/device_settings_gen.go
@@ -70,6 +70,7 @@ func NewDeviceSettings(mesg *proto.Message) *DeviceSettings {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -251,6 +252,7 @@ func (m *DeviceSettings) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -487,7 +489,7 @@ func (m *DeviceSettings) SetTapSensitivity(v typedef.TapSensitivity) *DeviceSett
 	return m
 }
 
-// SetDeveloperFields DeviceSettings's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields DeviceSettings's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DeviceSettings) SetUnknownFields(unknownFields ...proto.Field) *DeviceSettings {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/dive_alarm_gen.go
+++ b/profile/mesgdef/dive_alarm_gen.go
@@ -335,13 +335,13 @@ func (m *DiveAlarm) SetSpeedScaled(v float64) *DiveAlarm {
 	return m
 }
 
-// SetUnknownFields DiveAlarm's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DiveAlarm) SetUnknownFields(unknownFields ...proto.Field) *DiveAlarm {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields DiveAlarm's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *DiveAlarm) SetDeveloperFields(developerFields ...proto.DeveloperField) *DiveAlarm {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/dive_alarm_gen.go
+++ b/profile/mesgdef/dive_alarm_gen.go
@@ -57,6 +57,7 @@ func NewDiveAlarm(mesg *proto.Message) *DiveAlarm {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -172,6 +173,7 @@ func (m *DiveAlarm) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -333,7 +335,7 @@ func (m *DiveAlarm) SetSpeedScaled(v float64) *DiveAlarm {
 	return m
 }
 
-// SetDeveloperFields DiveAlarm's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields DiveAlarm's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DiveAlarm) SetUnknownFields(unknownFields ...proto.Field) *DiveAlarm {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/dive_apnea_alarm_gen.go
+++ b/profile/mesgdef/dive_apnea_alarm_gen.go
@@ -335,13 +335,13 @@ func (m *DiveApneaAlarm) SetSpeedScaled(v float64) *DiveApneaAlarm {
 	return m
 }
 
-// SetUnknownFields DiveApneaAlarm's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DiveApneaAlarm) SetUnknownFields(unknownFields ...proto.Field) *DiveApneaAlarm {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields DiveApneaAlarm's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *DiveApneaAlarm) SetDeveloperFields(developerFields ...proto.DeveloperField) *DiveApneaAlarm {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/dive_apnea_alarm_gen.go
+++ b/profile/mesgdef/dive_apnea_alarm_gen.go
@@ -57,6 +57,7 @@ func NewDiveApneaAlarm(mesg *proto.Message) *DiveApneaAlarm {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -172,6 +173,7 @@ func (m *DiveApneaAlarm) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -333,7 +335,7 @@ func (m *DiveApneaAlarm) SetSpeedScaled(v float64) *DiveApneaAlarm {
 	return m
 }
 
-// SetDeveloperFields DiveApneaAlarm's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields DiveApneaAlarm's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DiveApneaAlarm) SetUnknownFields(unknownFields ...proto.Field) *DiveApneaAlarm {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/dive_gas_gen.go
+++ b/profile/mesgdef/dive_gas_gen.go
@@ -153,13 +153,13 @@ func (m *DiveGas) SetMode(v typedef.DiveGasMode) *DiveGas {
 	return m
 }
 
-// SetUnknownFields DiveGas's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DiveGas) SetUnknownFields(unknownFields ...proto.Field) *DiveGas {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields DiveGas's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *DiveGas) SetDeveloperFields(developerFields ...proto.DeveloperField) *DiveGas {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/dive_gas_gen.go
+++ b/profile/mesgdef/dive_gas_gen.go
@@ -47,6 +47,7 @@ func NewDiveGas(mesg *proto.Message) *DiveGas {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -110,6 +111,7 @@ func (m *DiveGas) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -151,7 +153,7 @@ func (m *DiveGas) SetMode(v typedef.DiveGasMode) *DiveGas {
 	return m
 }
 
-// SetDeveloperFields DiveGas's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields DiveGas's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DiveGas) SetUnknownFields(unknownFields ...proto.Field) *DiveGas {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/dive_settings_gen.go
+++ b/profile/mesgdef/dive_settings_gen.go
@@ -80,6 +80,7 @@ func NewDiveSettings(mesg *proto.Message) *DiveSettings {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -323,6 +324,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -801,7 +803,7 @@ func (m *DiveSettings) SetNoFlyTimeMode(v typedef.NoFlyTimeMode) *DiveSettings {
 	return m
 }
 
-// SetDeveloperFields DiveSettings's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields DiveSettings's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DiveSettings) SetUnknownFields(unknownFields ...proto.Field) *DiveSettings {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/dive_settings_gen.go
+++ b/profile/mesgdef/dive_settings_gen.go
@@ -803,13 +803,13 @@ func (m *DiveSettings) SetNoFlyTimeMode(v typedef.NoFlyTimeMode) *DiveSettings {
 	return m
 }
 
-// SetUnknownFields DiveSettings's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DiveSettings) SetUnknownFields(unknownFields ...proto.Field) *DiveSettings {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields DiveSettings's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *DiveSettings) SetDeveloperFields(developerFields ...proto.DeveloperField) *DiveSettings {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/dive_summary_gen.go
+++ b/profile/mesgdef/dive_summary_gen.go
@@ -68,6 +68,7 @@ func NewDiveSummary(mesg *proto.Message) *DiveSummary {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -239,6 +240,7 @@ func (m *DiveSummary) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -752,7 +754,7 @@ func (m *DiveSummary) SetHangTimeScaled(v float64) *DiveSummary {
 	return m
 }
 
-// SetDeveloperFields DiveSummary's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields DiveSummary's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DiveSummary) SetUnknownFields(unknownFields ...proto.Field) *DiveSummary {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/dive_summary_gen.go
+++ b/profile/mesgdef/dive_summary_gen.go
@@ -754,13 +754,13 @@ func (m *DiveSummary) SetHangTimeScaled(v float64) *DiveSummary {
 	return m
 }
 
-// SetUnknownFields DiveSummary's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *DiveSummary) SetUnknownFields(unknownFields ...proto.Field) *DiveSummary {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields DiveSummary's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *DiveSummary) SetDeveloperFields(developerFields ...proto.DeveloperField) *DiveSummary {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/event_gen.go
+++ b/profile/mesgdef/event_gen.go
@@ -554,13 +554,13 @@ func (m *Event) SetRadarThreatMaxApproachSpeedScaled(v float64) *Event {
 	return m
 }
 
-// SetUnknownFields Event's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Event) SetUnknownFields(unknownFields ...proto.Field) *Event {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Event's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Event) SetDeveloperFields(developerFields ...proto.DeveloperField) *Event {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/event_gen.go
+++ b/profile/mesgdef/event_gen.go
@@ -71,6 +71,7 @@ func NewEvent(mesg *proto.Message) *Event {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -253,6 +254,7 @@ func (m *Event) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -552,7 +554,7 @@ func (m *Event) SetRadarThreatMaxApproachSpeedScaled(v float64) *Event {
 	return m
 }
 
-// SetDeveloperFields Event's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Event's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Event) SetUnknownFields(unknownFields ...proto.Field) *Event {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/exd_data_concept_configuration_gen.go
+++ b/profile/mesgdef/exd_data_concept_configuration_gen.go
@@ -242,13 +242,13 @@ func (m *ExdDataConceptConfiguration) SetIsSigned(v typedef.Bool) *ExdDataConcep
 	return m
 }
 
-// SetUnknownFields ExdDataConceptConfiguration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ExdDataConceptConfiguration) SetUnknownFields(unknownFields ...proto.Field) *ExdDataConceptConfiguration {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields ExdDataConceptConfiguration's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *ExdDataConceptConfiguration) SetDeveloperFields(developerFields ...proto.DeveloperField) *ExdDataConceptConfiguration {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/exd_data_concept_configuration_gen.go
+++ b/profile/mesgdef/exd_data_concept_configuration_gen.go
@@ -60,6 +60,7 @@ func NewExdDataConceptConfiguration(mesg *proto.Message) *ExdDataConceptConfigur
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -167,6 +168,7 @@ func (m *ExdDataConceptConfiguration) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -240,7 +242,7 @@ func (m *ExdDataConceptConfiguration) SetIsSigned(v typedef.Bool) *ExdDataConcep
 	return m
 }
 
-// SetDeveloperFields ExdDataConceptConfiguration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields ExdDataConceptConfiguration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ExdDataConceptConfiguration) SetUnknownFields(unknownFields ...proto.Field) *ExdDataConceptConfiguration {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/exd_data_field_configuration_gen.go
+++ b/profile/mesgdef/exd_data_field_configuration_gen.go
@@ -250,13 +250,13 @@ func (m *ExdDataFieldConfiguration) SetTitle(v [32]string) *ExdDataFieldConfigur
 	return m
 }
 
-// SetUnknownFields ExdDataFieldConfiguration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ExdDataFieldConfiguration) SetUnknownFields(unknownFields ...proto.Field) *ExdDataFieldConfiguration {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields ExdDataFieldConfiguration's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *ExdDataFieldConfiguration) SetDeveloperFields(developerFields ...proto.DeveloperField) *ExdDataFieldConfiguration {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/exd_data_field_configuration_gen.go
+++ b/profile/mesgdef/exd_data_field_configuration_gen.go
@@ -55,6 +55,7 @@ func NewExdDataFieldConfiguration(mesg *proto.Message) *ExdDataFieldConfiguratio
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -203,6 +204,7 @@ func (m *ExdDataFieldConfiguration) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -248,7 +250,7 @@ func (m *ExdDataFieldConfiguration) SetTitle(v [32]string) *ExdDataFieldConfigur
 	return m
 }
 
-// SetDeveloperFields ExdDataFieldConfiguration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields ExdDataFieldConfiguration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ExdDataFieldConfiguration) SetUnknownFields(unknownFields ...proto.Field) *ExdDataFieldConfiguration {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/exd_screen_configuration_gen.go
+++ b/profile/mesgdef/exd_screen_configuration_gen.go
@@ -46,6 +46,7 @@ func NewExdScreenConfiguration(mesg *proto.Message) *ExdScreenConfiguration {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -103,6 +104,7 @@ func (m *ExdScreenConfiguration) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -136,7 +138,7 @@ func (m *ExdScreenConfiguration) SetScreenEnabled(v typedef.Bool) *ExdScreenConf
 	return m
 }
 
-// SetDeveloperFields ExdScreenConfiguration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields ExdScreenConfiguration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ExdScreenConfiguration) SetUnknownFields(unknownFields ...proto.Field) *ExdScreenConfiguration {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/exd_screen_configuration_gen.go
+++ b/profile/mesgdef/exd_screen_configuration_gen.go
@@ -138,13 +138,13 @@ func (m *ExdScreenConfiguration) SetScreenEnabled(v typedef.Bool) *ExdScreenConf
 	return m
 }
 
-// SetUnknownFields ExdScreenConfiguration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ExdScreenConfiguration) SetUnknownFields(unknownFields ...proto.Field) *ExdScreenConfiguration {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields ExdScreenConfiguration's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *ExdScreenConfiguration) SetDeveloperFields(developerFields ...proto.DeveloperField) *ExdScreenConfiguration {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/exercise_title_gen.go
+++ b/profile/mesgdef/exercise_title_gen.go
@@ -138,13 +138,13 @@ func (m *ExerciseTitle) SetWktStepName(v []string) *ExerciseTitle {
 	return m
 }
 
-// SetUnknownFields ExerciseTitle's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ExerciseTitle) SetUnknownFields(unknownFields ...proto.Field) *ExerciseTitle {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields ExerciseTitle's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *ExerciseTitle) SetDeveloperFields(developerFields ...proto.DeveloperField) *ExerciseTitle {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/exercise_title_gen.go
+++ b/profile/mesgdef/exercise_title_gen.go
@@ -46,6 +46,7 @@ func NewExerciseTitle(mesg *proto.Message) *ExerciseTitle {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -103,6 +104,7 @@ func (m *ExerciseTitle) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -136,7 +138,7 @@ func (m *ExerciseTitle) SetWktStepName(v []string) *ExerciseTitle {
 	return m
 }
 
-// SetDeveloperFields ExerciseTitle's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields ExerciseTitle's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ExerciseTitle) SetUnknownFields(unknownFields ...proto.Field) *ExerciseTitle {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/field_capabilities_gen.go
+++ b/profile/mesgdef/field_capabilities_gen.go
@@ -149,13 +149,13 @@ func (m *FieldCapabilities) SetCount(v uint16) *FieldCapabilities {
 	return m
 }
 
-// SetUnknownFields FieldCapabilities's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *FieldCapabilities) SetUnknownFields(unknownFields ...proto.Field) *FieldCapabilities {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields FieldCapabilities's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *FieldCapabilities) SetDeveloperFields(developerFields ...proto.DeveloperField) *FieldCapabilities {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/field_capabilities_gen.go
+++ b/profile/mesgdef/field_capabilities_gen.go
@@ -47,6 +47,7 @@ func NewFieldCapabilities(mesg *proto.Message) *FieldCapabilities {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -110,6 +111,7 @@ func (m *FieldCapabilities) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -147,7 +149,7 @@ func (m *FieldCapabilities) SetCount(v uint16) *FieldCapabilities {
 	return m
 }
 
-// SetDeveloperFields FieldCapabilities's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields FieldCapabilities's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *FieldCapabilities) SetUnknownFields(unknownFields ...proto.Field) *FieldCapabilities {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/field_description_gen.go
+++ b/profile/mesgdef/field_description_gen.go
@@ -264,7 +264,7 @@ func (m *FieldDescription) SetNativeFieldNum(v uint8) *FieldDescription {
 	return m
 }
 
-// SetUnknownFields FieldDescription's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *FieldDescription) SetUnknownFields(unknownFields ...proto.Field) *FieldDescription {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/field_description_gen.go
+++ b/profile/mesgdef/field_description_gen.go
@@ -54,6 +54,7 @@ func NewFieldDescription(mesg *proto.Message) *FieldDescription {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 	}
 
@@ -169,6 +170,7 @@ func (m *FieldDescription) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	return mesg
@@ -262,7 +264,7 @@ func (m *FieldDescription) SetNativeFieldNum(v uint8) *FieldDescription {
 	return m
 }
 
-// SetDeveloperFields FieldDescription's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields FieldDescription's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *FieldDescription) SetUnknownFields(unknownFields ...proto.Field) *FieldDescription {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/file_capabilities_gen.go
+++ b/profile/mesgdef/file_capabilities_gen.go
@@ -48,6 +48,7 @@ func NewFileCapabilities(mesg *proto.Message) *FileCapabilities {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -117,6 +118,7 @@ func (m *FileCapabilities) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -164,7 +166,7 @@ func (m *FileCapabilities) SetMaxSize(v uint32) *FileCapabilities {
 	return m
 }
 
-// SetDeveloperFields FileCapabilities's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields FileCapabilities's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *FileCapabilities) SetUnknownFields(unknownFields ...proto.Field) *FileCapabilities {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/file_capabilities_gen.go
+++ b/profile/mesgdef/file_capabilities_gen.go
@@ -166,13 +166,13 @@ func (m *FileCapabilities) SetMaxSize(v uint32) *FileCapabilities {
 	return m
 }
 
-// SetUnknownFields FileCapabilities's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *FileCapabilities) SetUnknownFields(unknownFields ...proto.Field) *FileCapabilities {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields FileCapabilities's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *FileCapabilities) SetDeveloperFields(developerFields ...proto.DeveloperField) *FileCapabilities {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/file_creator_gen.go
+++ b/profile/mesgdef/file_creator_gen.go
@@ -44,6 +44,7 @@ func NewFileCreator(mesg *proto.Message) *FileCreator {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -89,6 +90,7 @@ func (m *FileCreator) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -108,7 +110,7 @@ func (m *FileCreator) SetHardwareVersion(v uint8) *FileCreator {
 	return m
 }
 
-// SetDeveloperFields FileCreator's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields FileCreator's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *FileCreator) SetUnknownFields(unknownFields ...proto.Field) *FileCreator {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/file_creator_gen.go
+++ b/profile/mesgdef/file_creator_gen.go
@@ -110,13 +110,13 @@ func (m *FileCreator) SetHardwareVersion(v uint8) *FileCreator {
 	return m
 }
 
-// SetUnknownFields FileCreator's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *FileCreator) SetUnknownFields(unknownFields ...proto.Field) *FileCreator {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields FileCreator's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *FileCreator) SetDeveloperFields(developerFields ...proto.DeveloperField) *FileCreator {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/file_id_gen.go
+++ b/profile/mesgdef/file_id_gen.go
@@ -49,6 +49,7 @@ func NewFileId(mesg *proto.Message) *FileId {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 	}
 
@@ -122,6 +123,7 @@ func (m *FileId) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	return mesg
@@ -198,7 +200,7 @@ func (m *FileId) SetProductName(v string) *FileId {
 	return m
 }
 
-// SetDeveloperFields FileId's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields FileId's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *FileId) SetUnknownFields(unknownFields ...proto.Field) *FileId {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/file_id_gen.go
+++ b/profile/mesgdef/file_id_gen.go
@@ -200,7 +200,7 @@ func (m *FileId) SetProductName(v string) *FileId {
 	return m
 }
 
-// SetUnknownFields FileId's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *FileId) SetUnknownFields(unknownFields ...proto.Field) *FileId {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/goal_gen.go
+++ b/profile/mesgdef/goal_gen.go
@@ -57,6 +57,7 @@ func NewGoal(mesg *proto.Message) *Goal {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -168,6 +169,7 @@ func (m *Goal) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -259,7 +261,7 @@ func (m *Goal) SetSource(v typedef.GoalSource) *Goal {
 	return m
 }
 
-// SetDeveloperFields Goal's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Goal's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Goal) SetUnknownFields(unknownFields ...proto.Field) *Goal {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/goal_gen.go
+++ b/profile/mesgdef/goal_gen.go
@@ -261,13 +261,13 @@ func (m *Goal) SetSource(v typedef.GoalSource) *Goal {
 	return m
 }
 
-// SetUnknownFields Goal's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Goal) SetUnknownFields(unknownFields ...proto.Field) *Goal {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Goal's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Goal) SetDeveloperFields(developerFields ...proto.DeveloperField) *Goal {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/gps_metadata_gen.go
+++ b/profile/mesgdef/gps_metadata_gen.go
@@ -390,13 +390,13 @@ func (m *GpsMetadata) SetVelocityScaled(vs [3]float64) *GpsMetadata {
 	return m
 }
 
-// SetUnknownFields GpsMetadata's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *GpsMetadata) SetUnknownFields(unknownFields ...proto.Field) *GpsMetadata {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields GpsMetadata's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *GpsMetadata) SetDeveloperFields(developerFields ...proto.DeveloperField) *GpsMetadata {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/gps_metadata_gen.go
+++ b/profile/mesgdef/gps_metadata_gen.go
@@ -55,6 +55,7 @@ func NewGpsMetadata(mesg *proto.Message) *GpsMetadata {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -155,6 +156,7 @@ func (m *GpsMetadata) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -388,7 +390,7 @@ func (m *GpsMetadata) SetVelocityScaled(vs [3]float64) *GpsMetadata {
 	return m
 }
 
-// SetDeveloperFields GpsMetadata's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields GpsMetadata's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *GpsMetadata) SetUnknownFields(unknownFields ...proto.Field) *GpsMetadata {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/gyroscope_data_gen.go
+++ b/profile/mesgdef/gyroscope_data_gen.go
@@ -224,13 +224,13 @@ func (m *GyroscopeData) SetCalibratedGyroZ(v []float32) *GyroscopeData {
 	return m
 }
 
-// SetUnknownFields GyroscopeData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *GyroscopeData) SetUnknownFields(unknownFields ...proto.Field) *GyroscopeData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields GyroscopeData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *GyroscopeData) SetDeveloperFields(developerFields ...proto.DeveloperField) *GyroscopeData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/gyroscope_data_gen.go
+++ b/profile/mesgdef/gyroscope_data_gen.go
@@ -53,6 +53,7 @@ func NewGyroscopeData(mesg *proto.Message) *GyroscopeData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -140,6 +141,7 @@ func (m *GyroscopeData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -222,7 +224,7 @@ func (m *GyroscopeData) SetCalibratedGyroZ(v []float32) *GyroscopeData {
 	return m
 }
 
-// SetDeveloperFields GyroscopeData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields GyroscopeData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *GyroscopeData) SetUnknownFields(unknownFields ...proto.Field) *GyroscopeData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hr_gen.go
+++ b/profile/mesgdef/hr_gen.go
@@ -283,13 +283,13 @@ func (m *Hr) SetEventTimestamp12(v []byte) *Hr {
 	return m
 }
 
-// SetUnknownFields Hr's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Hr) SetUnknownFields(unknownFields ...proto.Field) *Hr {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Hr's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Hr) SetDeveloperFields(developerFields ...proto.DeveloperField) *Hr {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hr_gen.go
+++ b/profile/mesgdef/hr_gen.go
@@ -58,6 +58,7 @@ func NewHr(mesg *proto.Message) *Hr {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -135,6 +136,7 @@ func (m *Hr) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -281,7 +283,7 @@ func (m *Hr) SetEventTimestamp12(v []byte) *Hr {
 	return m
 }
 
-// SetDeveloperFields Hr's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Hr's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Hr) SetUnknownFields(unknownFields ...proto.Field) *Hr {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hr_zone_gen.go
+++ b/profile/mesgdef/hr_zone_gen.go
@@ -125,13 +125,13 @@ func (m *HrZone) SetName(v string) *HrZone {
 	return m
 }
 
-// SetUnknownFields HrZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HrZone) SetUnknownFields(unknownFields ...proto.Field) *HrZone {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HrZone's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HrZone) SetDeveloperFields(developerFields ...proto.DeveloperField) *HrZone {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hr_zone_gen.go
+++ b/profile/mesgdef/hr_zone_gen.go
@@ -45,6 +45,7 @@ func NewHrZone(mesg *proto.Message) *HrZone {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -96,6 +97,7 @@ func (m *HrZone) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -123,7 +125,7 @@ func (m *HrZone) SetName(v string) *HrZone {
 	return m
 }
 
-// SetDeveloperFields HrZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HrZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HrZone) SetUnknownFields(unknownFields ...proto.Field) *HrZone {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hrm_profile_gen.go
+++ b/profile/mesgdef/hrm_profile_gen.go
@@ -47,6 +47,7 @@ func NewHrmProfile(mesg *proto.Message) *HrmProfile {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -110,6 +111,7 @@ func (m *HrmProfile) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -151,7 +153,7 @@ func (m *HrmProfile) SetHrmAntIdTransType(v uint8) *HrmProfile {
 	return m
 }
 
-// SetDeveloperFields HrmProfile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HrmProfile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HrmProfile) SetUnknownFields(unknownFields ...proto.Field) *HrmProfile {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hrm_profile_gen.go
+++ b/profile/mesgdef/hrm_profile_gen.go
@@ -153,13 +153,13 @@ func (m *HrmProfile) SetHrmAntIdTransType(v uint8) *HrmProfile {
 	return m
 }
 
-// SetUnknownFields HrmProfile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HrmProfile) SetUnknownFields(unknownFields ...proto.Field) *HrmProfile {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HrmProfile's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HrmProfile) SetDeveloperFields(developerFields ...proto.DeveloperField) *HrmProfile {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hrv_gen.go
+++ b/profile/mesgdef/hrv_gen.go
@@ -44,6 +44,7 @@ func NewHrv(mesg *proto.Message) *Hrv {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -83,6 +84,7 @@ func (m *Hrv) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -138,7 +140,7 @@ func (m *Hrv) SetTimeScaled(vs []float64) *Hrv {
 	return m
 }
 
-// SetDeveloperFields Hrv's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Hrv's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Hrv) SetUnknownFields(unknownFields ...proto.Field) *Hrv {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hrv_gen.go
+++ b/profile/mesgdef/hrv_gen.go
@@ -140,13 +140,13 @@ func (m *Hrv) SetTimeScaled(vs []float64) *Hrv {
 	return m
 }
 
-// SetUnknownFields Hrv's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Hrv) SetUnknownFields(unknownFields ...proto.Field) *Hrv {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Hrv's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Hrv) SetDeveloperFields(developerFields ...proto.DeveloperField) *Hrv {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hrv_status_summary_gen.go
+++ b/profile/mesgdef/hrv_status_summary_gen.go
@@ -53,6 +53,7 @@ func NewHrvStatusSummary(mesg *proto.Message) *HrvStatusSummary {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -134,6 +135,7 @@ func (m *HrvStatusSummary) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -354,7 +356,7 @@ func (m *HrvStatusSummary) SetStatus(v typedef.HrvStatus) *HrvStatusSummary {
 	return m
 }
 
-// SetDeveloperFields HrvStatusSummary's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HrvStatusSummary's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HrvStatusSummary) SetUnknownFields(unknownFields ...proto.Field) *HrvStatusSummary {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hrv_status_summary_gen.go
+++ b/profile/mesgdef/hrv_status_summary_gen.go
@@ -356,13 +356,13 @@ func (m *HrvStatusSummary) SetStatus(v typedef.HrvStatus) *HrvStatusSummary {
 	return m
 }
 
-// SetUnknownFields HrvStatusSummary's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HrvStatusSummary) SetUnknownFields(unknownFields ...proto.Field) *HrvStatusSummary {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HrvStatusSummary's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HrvStatusSummary) SetDeveloperFields(developerFields ...proto.DeveloperField) *HrvStatusSummary {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hrv_value_gen.go
+++ b/profile/mesgdef/hrv_value_gen.go
@@ -47,6 +47,7 @@ func NewHrvValue(mesg *proto.Message) *HrvValue {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -92,6 +93,7 @@ func (m *HrvValue) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -141,7 +143,7 @@ func (m *HrvValue) SetValueScaled(v float64) *HrvValue {
 	return m
 }
 
-// SetDeveloperFields HrvValue's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HrvValue's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HrvValue) SetUnknownFields(unknownFields ...proto.Field) *HrvValue {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hrv_value_gen.go
+++ b/profile/mesgdef/hrv_value_gen.go
@@ -143,13 +143,13 @@ func (m *HrvValue) SetValueScaled(v float64) *HrvValue {
 	return m
 }
 
-// SetUnknownFields HrvValue's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HrvValue) SetUnknownFields(unknownFields ...proto.Field) *HrvValue {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HrvValue's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HrvValue) SetDeveloperFields(developerFields ...proto.DeveloperField) *HrvValue {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hsa_accelerometer_data_gen.go
+++ b/profile/mesgdef/hsa_accelerometer_data_gen.go
@@ -315,13 +315,13 @@ func (m *HsaAccelerometerData) SetTimestamp32K(v uint32) *HsaAccelerometerData {
 	return m
 }
 
-// SetUnknownFields HsaAccelerometerData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaAccelerometerData) SetUnknownFields(unknownFields ...proto.Field) *HsaAccelerometerData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HsaAccelerometerData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HsaAccelerometerData) SetDeveloperFields(developerFields ...proto.DeveloperField) *HsaAccelerometerData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hsa_accelerometer_data_gen.go
+++ b/profile/mesgdef/hsa_accelerometer_data_gen.go
@@ -52,6 +52,7 @@ func NewHsaAccelerometerData(mesg *proto.Message) *HsaAccelerometerData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -127,6 +128,7 @@ func (m *HsaAccelerometerData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -313,7 +315,7 @@ func (m *HsaAccelerometerData) SetTimestamp32K(v uint32) *HsaAccelerometerData {
 	return m
 }
 
-// SetDeveloperFields HsaAccelerometerData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HsaAccelerometerData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaAccelerometerData) SetUnknownFields(unknownFields ...proto.Field) *HsaAccelerometerData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hsa_body_battery_data_gen.go
+++ b/profile/mesgdef/hsa_body_battery_data_gen.go
@@ -164,13 +164,13 @@ func (m *HsaBodyBatteryData) SetUncharged(v []int16) *HsaBodyBatteryData {
 	return m
 }
 
-// SetUnknownFields HsaBodyBatteryData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaBodyBatteryData) SetUnknownFields(unknownFields ...proto.Field) *HsaBodyBatteryData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HsaBodyBatteryData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HsaBodyBatteryData) SetDeveloperFields(developerFields ...proto.DeveloperField) *HsaBodyBatteryData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hsa_body_battery_data_gen.go
+++ b/profile/mesgdef/hsa_body_battery_data_gen.go
@@ -49,6 +49,7 @@ func NewHsaBodyBatteryData(mesg *proto.Message) *HsaBodyBatteryData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -112,6 +113,7 @@ func (m *HsaBodyBatteryData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -162,7 +164,7 @@ func (m *HsaBodyBatteryData) SetUncharged(v []int16) *HsaBodyBatteryData {
 	return m
 }
 
-// SetDeveloperFields HsaBodyBatteryData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HsaBodyBatteryData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaBodyBatteryData) SetUnknownFields(unknownFields ...proto.Field) *HsaBodyBatteryData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hsa_configuration_data_gen.go
+++ b/profile/mesgdef/hsa_configuration_data_gen.go
@@ -134,13 +134,13 @@ func (m *HsaConfigurationData) SetDataSize(v uint8) *HsaConfigurationData {
 	return m
 }
 
-// SetUnknownFields HsaConfigurationData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaConfigurationData) SetUnknownFields(unknownFields ...proto.Field) *HsaConfigurationData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HsaConfigurationData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HsaConfigurationData) SetDeveloperFields(developerFields ...proto.DeveloperField) *HsaConfigurationData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hsa_configuration_data_gen.go
+++ b/profile/mesgdef/hsa_configuration_data_gen.go
@@ -47,6 +47,7 @@ func NewHsaConfigurationData(mesg *proto.Message) *HsaConfigurationData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -98,6 +99,7 @@ func (m *HsaConfigurationData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -132,7 +134,7 @@ func (m *HsaConfigurationData) SetDataSize(v uint8) *HsaConfigurationData {
 	return m
 }
 
-// SetDeveloperFields HsaConfigurationData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HsaConfigurationData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaConfigurationData) SetUnknownFields(unknownFields ...proto.Field) *HsaConfigurationData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hsa_event_gen.go
+++ b/profile/mesgdef/hsa_event_gen.go
@@ -46,6 +46,7 @@ func NewHsaEvent(mesg *proto.Message) *HsaEvent {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -91,6 +92,7 @@ func (m *HsaEvent) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -117,7 +119,7 @@ func (m *HsaEvent) SetEventId(v uint8) *HsaEvent {
 	return m
 }
 
-// SetDeveloperFields HsaEvent's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HsaEvent's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaEvent) SetUnknownFields(unknownFields ...proto.Field) *HsaEvent {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hsa_event_gen.go
+++ b/profile/mesgdef/hsa_event_gen.go
@@ -119,13 +119,13 @@ func (m *HsaEvent) SetEventId(v uint8) *HsaEvent {
 	return m
 }
 
-// SetUnknownFields HsaEvent's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaEvent) SetUnknownFields(unknownFields ...proto.Field) *HsaEvent {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HsaEvent's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HsaEvent) SetDeveloperFields(developerFields ...proto.DeveloperField) *HsaEvent {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hsa_gyroscope_data_gen.go
+++ b/profile/mesgdef/hsa_gyroscope_data_gen.go
@@ -315,13 +315,13 @@ func (m *HsaGyroscopeData) SetTimestamp32K(v uint32) *HsaGyroscopeData {
 	return m
 }
 
-// SetUnknownFields HsaGyroscopeData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaGyroscopeData) SetUnknownFields(unknownFields ...proto.Field) *HsaGyroscopeData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HsaGyroscopeData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HsaGyroscopeData) SetDeveloperFields(developerFields ...proto.DeveloperField) *HsaGyroscopeData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hsa_gyroscope_data_gen.go
+++ b/profile/mesgdef/hsa_gyroscope_data_gen.go
@@ -52,6 +52,7 @@ func NewHsaGyroscopeData(mesg *proto.Message) *HsaGyroscopeData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -127,6 +128,7 @@ func (m *HsaGyroscopeData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -313,7 +315,7 @@ func (m *HsaGyroscopeData) SetTimestamp32K(v uint32) *HsaGyroscopeData {
 	return m
 }
 
-// SetDeveloperFields HsaGyroscopeData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HsaGyroscopeData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaGyroscopeData) SetUnknownFields(unknownFields ...proto.Field) *HsaGyroscopeData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hsa_heart_rate_data_gen.go
+++ b/profile/mesgdef/hsa_heart_rate_data_gen.go
@@ -149,13 +149,13 @@ func (m *HsaHeartRateData) SetHeartRate(v []uint8) *HsaHeartRateData {
 	return m
 }
 
-// SetUnknownFields HsaHeartRateData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaHeartRateData) SetUnknownFields(unknownFields ...proto.Field) *HsaHeartRateData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HsaHeartRateData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HsaHeartRateData) SetDeveloperFields(developerFields ...proto.DeveloperField) *HsaHeartRateData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hsa_heart_rate_data_gen.go
+++ b/profile/mesgdef/hsa_heart_rate_data_gen.go
@@ -48,6 +48,7 @@ func NewHsaHeartRateData(mesg *proto.Message) *HsaHeartRateData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -105,6 +106,7 @@ func (m *HsaHeartRateData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -147,7 +149,7 @@ func (m *HsaHeartRateData) SetHeartRate(v []uint8) *HsaHeartRateData {
 	return m
 }
 
-// SetDeveloperFields HsaHeartRateData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HsaHeartRateData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaHeartRateData) SetUnknownFields(unknownFields ...proto.Field) *HsaHeartRateData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hsa_respiration_data_gen.go
+++ b/profile/mesgdef/hsa_respiration_data_gen.go
@@ -175,13 +175,13 @@ func (m *HsaRespirationData) SetRespirationRateScaled(vs []float64) *HsaRespirat
 	return m
 }
 
-// SetUnknownFields HsaRespirationData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaRespirationData) SetUnknownFields(unknownFields ...proto.Field) *HsaRespirationData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HsaRespirationData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HsaRespirationData) SetDeveloperFields(developerFields ...proto.DeveloperField) *HsaRespirationData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hsa_respiration_data_gen.go
+++ b/profile/mesgdef/hsa_respiration_data_gen.go
@@ -48,6 +48,7 @@ func NewHsaRespirationData(mesg *proto.Message) *HsaRespirationData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -99,6 +100,7 @@ func (m *HsaRespirationData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -173,7 +175,7 @@ func (m *HsaRespirationData) SetRespirationRateScaled(vs []float64) *HsaRespirat
 	return m
 }
 
-// SetDeveloperFields HsaRespirationData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HsaRespirationData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaRespirationData) SetUnknownFields(unknownFields ...proto.Field) *HsaRespirationData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hsa_spo2_data_gen.go
+++ b/profile/mesgdef/hsa_spo2_data_gen.go
@@ -48,6 +48,7 @@ func NewHsaSpo2Data(mesg *proto.Message) *HsaSpo2Data {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -105,6 +106,7 @@ func (m *HsaSpo2Data) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -147,7 +149,7 @@ func (m *HsaSpo2Data) SetConfidence(v []uint8) *HsaSpo2Data {
 	return m
 }
 
-// SetDeveloperFields HsaSpo2Data's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HsaSpo2Data's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaSpo2Data) SetUnknownFields(unknownFields ...proto.Field) *HsaSpo2Data {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hsa_spo2_data_gen.go
+++ b/profile/mesgdef/hsa_spo2_data_gen.go
@@ -149,13 +149,13 @@ func (m *HsaSpo2Data) SetConfidence(v []uint8) *HsaSpo2Data {
 	return m
 }
 
-// SetUnknownFields HsaSpo2Data's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaSpo2Data) SetUnknownFields(unknownFields ...proto.Field) *HsaSpo2Data {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HsaSpo2Data's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HsaSpo2Data) SetDeveloperFields(developerFields ...proto.DeveloperField) *HsaSpo2Data {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hsa_step_data_gen.go
+++ b/profile/mesgdef/hsa_step_data_gen.go
@@ -134,13 +134,13 @@ func (m *HsaStepData) SetSteps(v []uint32) *HsaStepData {
 	return m
 }
 
-// SetUnknownFields HsaStepData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaStepData) SetUnknownFields(unknownFields ...proto.Field) *HsaStepData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HsaStepData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HsaStepData) SetDeveloperFields(developerFields ...proto.DeveloperField) *HsaStepData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hsa_step_data_gen.go
+++ b/profile/mesgdef/hsa_step_data_gen.go
@@ -47,6 +47,7 @@ func NewHsaStepData(mesg *proto.Message) *HsaStepData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -98,6 +99,7 @@ func (m *HsaStepData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -132,7 +134,7 @@ func (m *HsaStepData) SetSteps(v []uint32) *HsaStepData {
 	return m
 }
 
-// SetDeveloperFields HsaStepData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HsaStepData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaStepData) SetUnknownFields(unknownFields ...proto.Field) *HsaStepData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hsa_stress_data_gen.go
+++ b/profile/mesgdef/hsa_stress_data_gen.go
@@ -47,6 +47,7 @@ func NewHsaStressData(mesg *proto.Message) *HsaStressData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -98,6 +99,7 @@ func (m *HsaStressData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -130,7 +132,7 @@ func (m *HsaStressData) SetStressLevel(v []int8) *HsaStressData {
 	return m
 }
 
-// SetDeveloperFields HsaStressData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HsaStressData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaStressData) SetUnknownFields(unknownFields ...proto.Field) *HsaStressData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hsa_stress_data_gen.go
+++ b/profile/mesgdef/hsa_stress_data_gen.go
@@ -132,13 +132,13 @@ func (m *HsaStressData) SetStressLevel(v []int8) *HsaStressData {
 	return m
 }
 
-// SetUnknownFields HsaStressData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaStressData) SetUnknownFields(unknownFields ...proto.Field) *HsaStressData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HsaStressData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HsaStressData) SetDeveloperFields(developerFields ...proto.DeveloperField) *HsaStressData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/hsa_wrist_temperature_data_gen.go
+++ b/profile/mesgdef/hsa_wrist_temperature_data_gen.go
@@ -48,6 +48,7 @@ func NewHsaWristTemperatureData(mesg *proto.Message) *HsaWristTemperatureData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -99,6 +100,7 @@ func (m *HsaWristTemperatureData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -173,7 +175,7 @@ func (m *HsaWristTemperatureData) SetValueScaled(vs []float64) *HsaWristTemperat
 	return m
 }
 
-// SetDeveloperFields HsaWristTemperatureData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields HsaWristTemperatureData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaWristTemperatureData) SetUnknownFields(unknownFields ...proto.Field) *HsaWristTemperatureData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/hsa_wrist_temperature_data_gen.go
+++ b/profile/mesgdef/hsa_wrist_temperature_data_gen.go
@@ -175,13 +175,13 @@ func (m *HsaWristTemperatureData) SetValueScaled(vs []float64) *HsaWristTemperat
 	return m
 }
 
-// SetUnknownFields HsaWristTemperatureData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *HsaWristTemperatureData) SetUnknownFields(unknownFields ...proto.Field) *HsaWristTemperatureData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields HsaWristTemperatureData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *HsaWristTemperatureData) SetDeveloperFields(developerFields ...proto.DeveloperField) *HsaWristTemperatureData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/jump_gen.go
+++ b/profile/mesgdef/jump_gen.go
@@ -327,13 +327,13 @@ func (m *Jump) SetEnhancedSpeedScaled(v float64) *Jump {
 	return m
 }
 
-// SetUnknownFields Jump's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Jump) SetUnknownFields(unknownFields ...proto.Field) *Jump {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Jump's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Jump) SetDeveloperFields(developerFields ...proto.DeveloperField) *Jump {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/jump_gen.go
+++ b/profile/mesgdef/jump_gen.go
@@ -63,6 +63,7 @@ func NewJump(mesg *proto.Message) *Jump {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -161,6 +162,7 @@ func (m *Jump) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -325,7 +327,7 @@ func (m *Jump) SetEnhancedSpeedScaled(v float64) *Jump {
 	return m
 }
 
-// SetDeveloperFields Jump's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Jump's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Jump) SetUnknownFields(unknownFields ...proto.Field) *Jump {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/lap_gen.go
+++ b/profile/mesgdef/lap_gen.go
@@ -3841,13 +3841,13 @@ func (m *Lap) SetMaxCoreTemperatureScaled(v float64) *Lap {
 	return m
 }
 
-// SetUnknownFields Lap's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Lap) SetUnknownFields(unknownFields ...proto.Field) *Lap {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Lap's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Lap) SetDeveloperFields(developerFields ...proto.DeveloperField) *Lap {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/lap_gen.go
+++ b/profile/mesgdef/lap_gen.go
@@ -176,6 +176,7 @@ func NewLap(mesg *proto.Message) *Lap {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -970,6 +971,7 @@ func (m *Lap) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -3839,7 +3841,7 @@ func (m *Lap) SetMaxCoreTemperatureScaled(v float64) *Lap {
 	return m
 }
 
-// SetDeveloperFields Lap's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Lap's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Lap) SetUnknownFields(unknownFields ...proto.Field) *Lap {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/length_gen.go
+++ b/profile/mesgdef/length_gen.go
@@ -541,13 +541,13 @@ func (m *Length) SetMaxRespirationRate(v uint8) *Length {
 	return m
 }
 
-// SetUnknownFields Length's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Length) SetUnknownFields(unknownFields ...proto.Field) *Length {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Length's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Length) SetDeveloperFields(developerFields ...proto.DeveloperField) *Length {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/length_gen.go
+++ b/profile/mesgdef/length_gen.go
@@ -74,6 +74,7 @@ func NewLength(mesg *proto.Message) *Length {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -247,6 +248,7 @@ func (m *Length) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -539,7 +541,7 @@ func (m *Length) SetMaxRespirationRate(v uint8) *Length {
 	return m
 }
 
-// SetDeveloperFields Length's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Length's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Length) SetUnknownFields(unknownFields ...proto.Field) *Length {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/magnetometer_data_gen.go
+++ b/profile/mesgdef/magnetometer_data_gen.go
@@ -224,13 +224,13 @@ func (m *MagnetometerData) SetCalibratedMagZ(v []float32) *MagnetometerData {
 	return m
 }
 
-// SetUnknownFields MagnetometerData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MagnetometerData) SetUnknownFields(unknownFields ...proto.Field) *MagnetometerData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields MagnetometerData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *MagnetometerData) SetDeveloperFields(developerFields ...proto.DeveloperField) *MagnetometerData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/magnetometer_data_gen.go
+++ b/profile/mesgdef/magnetometer_data_gen.go
@@ -53,6 +53,7 @@ func NewMagnetometerData(mesg *proto.Message) *MagnetometerData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -140,6 +141,7 @@ func (m *MagnetometerData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -222,7 +224,7 @@ func (m *MagnetometerData) SetCalibratedMagZ(v []float32) *MagnetometerData {
 	return m
 }
 
-// SetDeveloperFields MagnetometerData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields MagnetometerData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MagnetometerData) SetUnknownFields(unknownFields ...proto.Field) *MagnetometerData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/max_met_data_gen.go
+++ b/profile/mesgdef/max_met_data_gen.go
@@ -229,13 +229,13 @@ func (m *MaxMetData) SetSpeedSource(v typedef.MaxMetSpeedSource) *MaxMetData {
 	return m
 }
 
-// SetUnknownFields MaxMetData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MaxMetData) SetUnknownFields(unknownFields ...proto.Field) *MaxMetData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields MaxMetData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *MaxMetData) SetDeveloperFields(developerFields ...proto.DeveloperField) *MaxMetData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/max_met_data_gen.go
+++ b/profile/mesgdef/max_met_data_gen.go
@@ -53,6 +53,7 @@ func NewMaxMetData(mesg *proto.Message) *MaxMetData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -134,6 +135,7 @@ func (m *MaxMetData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -227,7 +229,7 @@ func (m *MaxMetData) SetSpeedSource(v typedef.MaxMetSpeedSource) *MaxMetData {
 	return m
 }
 
-// SetDeveloperFields MaxMetData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields MaxMetData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MaxMetData) SetUnknownFields(unknownFields ...proto.Field) *MaxMetData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/memo_glob_gen.go
+++ b/profile/mesgdef/memo_glob_gen.go
@@ -48,6 +48,7 @@ func NewMemoGlob(mesg *proto.Message) *MemoGlob {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -117,6 +118,7 @@ func (m *MemoGlob) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -172,7 +174,7 @@ func (m *MemoGlob) SetData(v []uint8) *MemoGlob {
 	return m
 }
 
-// SetDeveloperFields MemoGlob's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields MemoGlob's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MemoGlob) SetUnknownFields(unknownFields ...proto.Field) *MemoGlob {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/memo_glob_gen.go
+++ b/profile/mesgdef/memo_glob_gen.go
@@ -174,13 +174,13 @@ func (m *MemoGlob) SetData(v []uint8) *MemoGlob {
 	return m
 }
 
-// SetUnknownFields MemoGlob's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MemoGlob) SetUnknownFields(unknownFields ...proto.Field) *MemoGlob {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields MemoGlob's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *MemoGlob) SetDeveloperFields(developerFields ...proto.DeveloperField) *MemoGlob {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/mesg_capabilities_gen.go
+++ b/profile/mesgdef/mesg_capabilities_gen.go
@@ -170,13 +170,13 @@ func (m *MesgCapabilities) SetCount(v uint16) *MesgCapabilities {
 	return m
 }
 
-// SetUnknownFields MesgCapabilities's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MesgCapabilities) SetUnknownFields(unknownFields ...proto.Field) *MesgCapabilities {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields MesgCapabilities's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *MesgCapabilities) SetDeveloperFields(developerFields ...proto.DeveloperField) *MesgCapabilities {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/mesg_capabilities_gen.go
+++ b/profile/mesgdef/mesg_capabilities_gen.go
@@ -47,6 +47,7 @@ func NewMesgCapabilities(mesg *proto.Message) *MesgCapabilities {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -110,6 +111,7 @@ func (m *MesgCapabilities) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -168,7 +170,7 @@ func (m *MesgCapabilities) SetCount(v uint16) *MesgCapabilities {
 	return m
 }
 
-// SetDeveloperFields MesgCapabilities's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields MesgCapabilities's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MesgCapabilities) SetUnknownFields(unknownFields ...proto.Field) *MesgCapabilities {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/met_zone_gen.go
+++ b/profile/mesgdef/met_zone_gen.go
@@ -47,6 +47,7 @@ func NewMetZone(mesg *proto.Message) *MetZone {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -104,6 +105,7 @@ func (m *MetZone) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -189,7 +191,7 @@ func (m *MetZone) SetFatCaloriesScaled(v float64) *MetZone {
 	return m
 }
 
-// SetDeveloperFields MetZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields MetZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MetZone) SetUnknownFields(unknownFields ...proto.Field) *MetZone {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/met_zone_gen.go
+++ b/profile/mesgdef/met_zone_gen.go
@@ -191,13 +191,13 @@ func (m *MetZone) SetFatCaloriesScaled(v float64) *MetZone {
 	return m
 }
 
-// SetUnknownFields MetZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MetZone) SetUnknownFields(unknownFields ...proto.Field) *MetZone {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields MetZone's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *MetZone) SetDeveloperFields(developerFields ...proto.DeveloperField) *MetZone {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/monitoring_gen.go
+++ b/profile/mesgdef/monitoring_gen.go
@@ -803,13 +803,13 @@ func (m *Monitoring) SetVigorousActivityMinutes(v uint16) *Monitoring {
 	return m
 }
 
-// SetUnknownFields Monitoring's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Monitoring) SetUnknownFields(unknownFields ...proto.Field) *Monitoring {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Monitoring's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Monitoring) SetDeveloperFields(developerFields ...proto.DeveloperField) *Monitoring {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/monitoring_gen.go
+++ b/profile/mesgdef/monitoring_gen.go
@@ -81,6 +81,7 @@ func NewMonitoring(mesg *proto.Message) *Monitoring {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -319,6 +320,7 @@ func (m *Monitoring) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -801,7 +803,7 @@ func (m *Monitoring) SetVigorousActivityMinutes(v uint16) *Monitoring {
 	return m
 }
 
-// SetDeveloperFields Monitoring's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Monitoring's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Monitoring) SetUnknownFields(unknownFields ...proto.Field) *Monitoring {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/monitoring_hr_data_gen.go
+++ b/profile/mesgdef/monitoring_hr_data_gen.go
@@ -47,6 +47,7 @@ func NewMonitoringHrData(mesg *proto.Message) *MonitoringHrData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -98,6 +99,7 @@ func (m *MonitoringHrData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -132,7 +134,7 @@ func (m *MonitoringHrData) SetCurrentDayRestingHeartRate(v uint8) *MonitoringHrD
 	return m
 }
 
-// SetDeveloperFields MonitoringHrData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields MonitoringHrData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MonitoringHrData) SetUnknownFields(unknownFields ...proto.Field) *MonitoringHrData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/monitoring_hr_data_gen.go
+++ b/profile/mesgdef/monitoring_hr_data_gen.go
@@ -134,13 +134,13 @@ func (m *MonitoringHrData) SetCurrentDayRestingHeartRate(v uint8) *MonitoringHrD
 	return m
 }
 
-// SetUnknownFields MonitoringHrData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MonitoringHrData) SetUnknownFields(unknownFields ...proto.Field) *MonitoringHrData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields MonitoringHrData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *MonitoringHrData) SetDeveloperFields(developerFields ...proto.DeveloperField) *MonitoringHrData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/monitoring_info_gen.go
+++ b/profile/mesgdef/monitoring_info_gen.go
@@ -52,6 +52,7 @@ func NewMonitoringInfo(mesg *proto.Message) *MonitoringInfo {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -125,6 +126,7 @@ func (m *MonitoringInfo) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -266,7 +268,7 @@ func (m *MonitoringInfo) SetRestingMetabolicRate(v uint16) *MonitoringInfo {
 	return m
 }
 
-// SetDeveloperFields MonitoringInfo's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields MonitoringInfo's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MonitoringInfo) SetUnknownFields(unknownFields ...proto.Field) *MonitoringInfo {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/monitoring_info_gen.go
+++ b/profile/mesgdef/monitoring_info_gen.go
@@ -268,13 +268,13 @@ func (m *MonitoringInfo) SetRestingMetabolicRate(v uint16) *MonitoringInfo {
 	return m
 }
 
-// SetUnknownFields MonitoringInfo's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *MonitoringInfo) SetUnknownFields(unknownFields ...proto.Field) *MonitoringInfo {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields MonitoringInfo's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *MonitoringInfo) SetDeveloperFields(developerFields ...proto.DeveloperField) *MonitoringInfo {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/nmea_sentence_gen.go
+++ b/profile/mesgdef/nmea_sentence_gen.go
@@ -47,6 +47,7 @@ func NewNmeaSentence(mesg *proto.Message) *NmeaSentence {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -98,6 +99,7 @@ func (m *NmeaSentence) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -132,7 +134,7 @@ func (m *NmeaSentence) SetSentence(v string) *NmeaSentence {
 	return m
 }
 
-// SetDeveloperFields NmeaSentence's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields NmeaSentence's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *NmeaSentence) SetUnknownFields(unknownFields ...proto.Field) *NmeaSentence {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/nmea_sentence_gen.go
+++ b/profile/mesgdef/nmea_sentence_gen.go
@@ -134,13 +134,13 @@ func (m *NmeaSentence) SetSentence(v string) *NmeaSentence {
 	return m
 }
 
-// SetUnknownFields NmeaSentence's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *NmeaSentence) SetUnknownFields(unknownFields ...proto.Field) *NmeaSentence {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields NmeaSentence's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *NmeaSentence) SetDeveloperFields(developerFields ...proto.DeveloperField) *NmeaSentence {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/obdii_data_gen.go
+++ b/profile/mesgdef/obdii_data_gen.go
@@ -53,6 +53,7 @@ func NewObdiiData(mesg *proto.Message) *ObdiiData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -140,6 +141,7 @@ func (m *ObdiiData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -225,7 +227,7 @@ func (m *ObdiiData) SetStartTimestampMs(v uint16) *ObdiiData {
 	return m
 }
 
-// SetDeveloperFields ObdiiData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields ObdiiData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ObdiiData) SetUnknownFields(unknownFields ...proto.Field) *ObdiiData {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/obdii_data_gen.go
+++ b/profile/mesgdef/obdii_data_gen.go
@@ -227,13 +227,13 @@ func (m *ObdiiData) SetStartTimestampMs(v uint16) *ObdiiData {
 	return m
 }
 
-// SetUnknownFields ObdiiData's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ObdiiData) SetUnknownFields(unknownFields ...proto.Field) *ObdiiData {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields ObdiiData's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *ObdiiData) SetDeveloperFields(developerFields ...proto.DeveloperField) *ObdiiData {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/ohr_settings_gen.go
+++ b/profile/mesgdef/ohr_settings_gen.go
@@ -116,13 +116,13 @@ func (m *OhrSettings) SetEnabled(v typedef.Switch) *OhrSettings {
 	return m
 }
 
-// SetUnknownFields OhrSettings's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *OhrSettings) SetUnknownFields(unknownFields ...proto.Field) *OhrSettings {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields OhrSettings's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *OhrSettings) SetDeveloperFields(developerFields ...proto.DeveloperField) *OhrSettings {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/ohr_settings_gen.go
+++ b/profile/mesgdef/ohr_settings_gen.go
@@ -45,6 +45,7 @@ func NewOhrSettings(mesg *proto.Message) *OhrSettings {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -90,6 +91,7 @@ func (m *OhrSettings) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -114,7 +116,7 @@ func (m *OhrSettings) SetEnabled(v typedef.Switch) *OhrSettings {
 	return m
 }
 
-// SetDeveloperFields OhrSettings's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields OhrSettings's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *OhrSettings) SetUnknownFields(unknownFields ...proto.Field) *OhrSettings {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/one_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/one_d_sensor_calibration_gen.go
@@ -50,6 +50,7 @@ func NewOneDSensorCalibration(mesg *proto.Message) *OneDSensorCalibration {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -119,6 +120,7 @@ func (m *OneDSensorCalibration) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -192,7 +194,7 @@ func (m *OneDSensorCalibration) SetOffsetCal(v int32) *OneDSensorCalibration {
 	return m
 }
 
-// SetDeveloperFields OneDSensorCalibration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields OneDSensorCalibration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *OneDSensorCalibration) SetUnknownFields(unknownFields ...proto.Field) *OneDSensorCalibration {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/one_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/one_d_sensor_calibration_gen.go
@@ -194,13 +194,13 @@ func (m *OneDSensorCalibration) SetOffsetCal(v int32) *OneDSensorCalibration {
 	return m
 }
 
-// SetUnknownFields OneDSensorCalibration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *OneDSensorCalibration) SetUnknownFields(unknownFields ...proto.Field) *OneDSensorCalibration {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields OneDSensorCalibration's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *OneDSensorCalibration) SetDeveloperFields(developerFields ...proto.DeveloperField) *OneDSensorCalibration {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/power_zone_gen.go
+++ b/profile/mesgdef/power_zone_gen.go
@@ -125,13 +125,13 @@ func (m *PowerZone) SetName(v string) *PowerZone {
 	return m
 }
 
-// SetUnknownFields PowerZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *PowerZone) SetUnknownFields(unknownFields ...proto.Field) *PowerZone {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields PowerZone's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *PowerZone) SetDeveloperFields(developerFields ...proto.DeveloperField) *PowerZone {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/power_zone_gen.go
+++ b/profile/mesgdef/power_zone_gen.go
@@ -45,6 +45,7 @@ func NewPowerZone(mesg *proto.Message) *PowerZone {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -96,6 +97,7 @@ func (m *PowerZone) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -123,7 +125,7 @@ func (m *PowerZone) SetName(v string) *PowerZone {
 	return m
 }
 
-// SetDeveloperFields PowerZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields PowerZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *PowerZone) SetUnknownFields(unknownFields ...proto.Field) *PowerZone {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/raw_bbi_gen.go
+++ b/profile/mesgdef/raw_bbi_gen.go
@@ -57,6 +57,7 @@ func NewRawBbi(mesg *proto.Message) *RawBbi {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -137,6 +138,7 @@ func (m *RawBbi) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -193,7 +195,7 @@ func (m *RawBbi) SetGap(v []uint8) *RawBbi {
 	return m
 }
 
-// SetDeveloperFields RawBbi's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields RawBbi's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *RawBbi) SetUnknownFields(unknownFields ...proto.Field) *RawBbi {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/raw_bbi_gen.go
+++ b/profile/mesgdef/raw_bbi_gen.go
@@ -195,13 +195,13 @@ func (m *RawBbi) SetGap(v []uint8) *RawBbi {
 	return m
 }
 
-// SetUnknownFields RawBbi's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *RawBbi) SetUnknownFields(unknownFields ...proto.Field) *RawBbi {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields RawBbi's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *RawBbi) SetDeveloperFields(developerFields ...proto.DeveloperField) *RawBbi {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/record_gen.go
+++ b/profile/mesgdef/record_gen.go
@@ -137,6 +137,7 @@ func NewRecord(mesg *proto.Message) *Record {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -710,6 +711,7 @@ func (m *Record) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -2658,7 +2660,7 @@ func (m *Record) SetCoreTemperatureScaled(v float64) *Record {
 	return m
 }
 
-// SetDeveloperFields Record's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Record's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Record) SetUnknownFields(unknownFields ...proto.Field) *Record {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/record_gen.go
+++ b/profile/mesgdef/record_gen.go
@@ -2660,13 +2660,13 @@ func (m *Record) SetCoreTemperatureScaled(v float64) *Record {
 	return m
 }
 
-// SetUnknownFields Record's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Record) SetUnknownFields(unknownFields ...proto.Field) *Record {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Record's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Record) SetDeveloperFields(developerFields ...proto.DeveloperField) *Record {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/respiration_rate_gen.go
+++ b/profile/mesgdef/respiration_rate_gen.go
@@ -47,6 +47,7 @@ func NewRespirationRate(mesg *proto.Message) *RespirationRate {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -92,6 +93,7 @@ func (m *RespirationRate) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -141,7 +143,7 @@ func (m *RespirationRate) SetRespirationRateScaled(v float64) *RespirationRate {
 	return m
 }
 
-// SetDeveloperFields RespirationRate's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields RespirationRate's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *RespirationRate) SetUnknownFields(unknownFields ...proto.Field) *RespirationRate {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/respiration_rate_gen.go
+++ b/profile/mesgdef/respiration_rate_gen.go
@@ -143,13 +143,13 @@ func (m *RespirationRate) SetRespirationRateScaled(v float64) *RespirationRate {
 	return m
 }
 
-// SetUnknownFields RespirationRate's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *RespirationRate) SetUnknownFields(unknownFields ...proto.Field) *RespirationRate {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields RespirationRate's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *RespirationRate) SetDeveloperFields(developerFields ...proto.DeveloperField) *RespirationRate {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/schedule_gen.go
+++ b/profile/mesgdef/schedule_gen.go
@@ -211,13 +211,13 @@ func (m *Schedule) SetScheduledTime(v time.Time) *Schedule {
 	return m
 }
 
-// SetUnknownFields Schedule's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Schedule) SetUnknownFields(unknownFields ...proto.Field) *Schedule {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Schedule's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Schedule) SetDeveloperFields(developerFields ...proto.DeveloperField) *Schedule {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/schedule_gen.go
+++ b/profile/mesgdef/schedule_gen.go
@@ -51,6 +51,7 @@ func NewSchedule(mesg *proto.Message) *Schedule {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -126,6 +127,7 @@ func (m *Schedule) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -209,7 +211,7 @@ func (m *Schedule) SetScheduledTime(v time.Time) *Schedule {
 	return m
 }
 
-// SetDeveloperFields Schedule's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Schedule's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Schedule) SetUnknownFields(unknownFields ...proto.Field) *Schedule {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/sdm_profile_gen.go
+++ b/profile/mesgdef/sdm_profile_gen.go
@@ -51,6 +51,7 @@ func NewSdmProfile(mesg *proto.Message) *SdmProfile {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -132,6 +133,7 @@ func (m *SdmProfile) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -249,7 +251,7 @@ func (m *SdmProfile) SetOdometerRollover(v uint8) *SdmProfile {
 	return m
 }
 
-// SetDeveloperFields SdmProfile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields SdmProfile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SdmProfile) SetUnknownFields(unknownFields ...proto.Field) *SdmProfile {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/sdm_profile_gen.go
+++ b/profile/mesgdef/sdm_profile_gen.go
@@ -251,13 +251,13 @@ func (m *SdmProfile) SetOdometerRollover(v uint8) *SdmProfile {
 	return m
 }
 
-// SetUnknownFields SdmProfile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SdmProfile) SetUnknownFields(unknownFields ...proto.Field) *SdmProfile {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields SdmProfile's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *SdmProfile) SetDeveloperFields(developerFields ...proto.DeveloperField) *SdmProfile {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/segment_file_gen.go
+++ b/profile/mesgdef/segment_file_gen.go
@@ -52,6 +52,7 @@ func NewSegmentFile(mesg *proto.Message) *SegmentFile {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -143,6 +144,7 @@ func (m *SegmentFile) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -220,7 +222,7 @@ func (m *SegmentFile) SetDefaultRaceLeader(v uint8) *SegmentFile {
 	return m
 }
 
-// SetDeveloperFields SegmentFile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields SegmentFile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SegmentFile) SetUnknownFields(unknownFields ...proto.Field) *SegmentFile {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/segment_file_gen.go
+++ b/profile/mesgdef/segment_file_gen.go
@@ -222,13 +222,13 @@ func (m *SegmentFile) SetDefaultRaceLeader(v uint8) *SegmentFile {
 	return m
 }
 
-// SetUnknownFields SegmentFile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SegmentFile) SetUnknownFields(unknownFields ...proto.Field) *SegmentFile {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields SegmentFile's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *SegmentFile) SetDeveloperFields(developerFields ...proto.DeveloperField) *SegmentFile {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/segment_id_gen.go
+++ b/profile/mesgdef/segment_id_gen.go
@@ -51,6 +51,7 @@ func NewSegmentId(mesg *proto.Message) *SegmentId {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -138,6 +139,7 @@ func (m *SegmentId) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -217,7 +219,7 @@ func (m *SegmentId) SetSelectionType(v typedef.SegmentSelectionType) *SegmentId 
 	return m
 }
 
-// SetDeveloperFields SegmentId's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields SegmentId's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SegmentId) SetUnknownFields(unknownFields ...proto.Field) *SegmentId {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/segment_id_gen.go
+++ b/profile/mesgdef/segment_id_gen.go
@@ -219,13 +219,13 @@ func (m *SegmentId) SetSelectionType(v typedef.SegmentSelectionType) *SegmentId 
 	return m
 }
 
-// SetUnknownFields SegmentId's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SegmentId) SetUnknownFields(unknownFields ...proto.Field) *SegmentId {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields SegmentId's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *SegmentId) SetDeveloperFields(developerFields ...proto.DeveloperField) *SegmentId {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/segment_lap_gen.go
+++ b/profile/mesgdef/segment_lap_gen.go
@@ -2769,13 +2769,13 @@ func (m *SegmentLap) SetEnhancedMinAltitudeScaled(v float64) *SegmentLap {
 	return m
 }
 
-// SetUnknownFields SegmentLap's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SegmentLap) SetUnknownFields(unknownFields ...proto.Field) *SegmentLap {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields SegmentLap's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *SegmentLap) SetDeveloperFields(developerFields ...proto.DeveloperField) *SegmentLap {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/segment_lap_gen.go
+++ b/profile/mesgdef/segment_lap_gen.go
@@ -148,6 +148,7 @@ func NewSegmentLap(mesg *proto.Message) *SegmentLap {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -762,6 +763,7 @@ func (m *SegmentLap) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -2767,7 +2769,7 @@ func (m *SegmentLap) SetEnhancedMinAltitudeScaled(v float64) *SegmentLap {
 	return m
 }
 
-// SetDeveloperFields SegmentLap's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields SegmentLap's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SegmentLap) SetUnknownFields(unknownFields ...proto.Field) *SegmentLap {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/segment_leaderboard_entry_gen.go
+++ b/profile/mesgdef/segment_leaderboard_entry_gen.go
@@ -50,6 +50,7 @@ func NewSegmentLeaderboardEntry(mesg *proto.Message) *SegmentLeaderboardEntry {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -125,6 +126,7 @@ func (m *SegmentLeaderboardEntry) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -211,7 +213,7 @@ func (m *SegmentLeaderboardEntry) SetActivityIdString(v string) *SegmentLeaderbo
 	return m
 }
 
-// SetDeveloperFields SegmentLeaderboardEntry's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields SegmentLeaderboardEntry's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SegmentLeaderboardEntry) SetUnknownFields(unknownFields ...proto.Field) *SegmentLeaderboardEntry {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/segment_leaderboard_entry_gen.go
+++ b/profile/mesgdef/segment_leaderboard_entry_gen.go
@@ -213,13 +213,13 @@ func (m *SegmentLeaderboardEntry) SetActivityIdString(v string) *SegmentLeaderbo
 	return m
 }
 
-// SetUnknownFields SegmentLeaderboardEntry's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SegmentLeaderboardEntry) SetUnknownFields(unknownFields ...proto.Field) *SegmentLeaderboardEntry {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields SegmentLeaderboardEntry's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *SegmentLeaderboardEntry) SetDeveloperFields(developerFields ...proto.DeveloperField) *SegmentLeaderboardEntry {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/segment_point_gen.go
+++ b/profile/mesgdef/segment_point_gen.go
@@ -342,13 +342,13 @@ func (m *SegmentPoint) SetEnhancedAltitudeScaled(v float64) *SegmentPoint {
 	return m
 }
 
-// SetUnknownFields SegmentPoint's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SegmentPoint) SetUnknownFields(unknownFields ...proto.Field) *SegmentPoint {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields SegmentPoint's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *SegmentPoint) SetDeveloperFields(developerFields ...proto.DeveloperField) *SegmentPoint {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/segment_point_gen.go
+++ b/profile/mesgdef/segment_point_gen.go
@@ -58,6 +58,7 @@ func NewSegmentPoint(mesg *proto.Message) *SegmentPoint {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -138,6 +139,7 @@ func (m *SegmentPoint) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -340,7 +342,7 @@ func (m *SegmentPoint) SetEnhancedAltitudeScaled(v float64) *SegmentPoint {
 	return m
 }
 
-// SetDeveloperFields SegmentPoint's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields SegmentPoint's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SegmentPoint) SetUnknownFields(unknownFields ...proto.Field) *SegmentPoint {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/session_gen.go
+++ b/profile/mesgdef/session_gen.go
@@ -4666,13 +4666,13 @@ func (m *Session) SetMaxCoreTemperatureScaled(v float64) *Session {
 	return m
 }
 
-// SetUnknownFields Session's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Session) SetUnknownFields(unknownFields ...proto.Field) *Session {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Session's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Session) SetDeveloperFields(developerFields ...proto.DeveloperField) *Session {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/session_gen.go
+++ b/profile/mesgdef/session_gen.go
@@ -209,6 +209,7 @@ func NewSession(mesg *proto.Message) *Session {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -1204,6 +1205,7 @@ func (m *Session) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -4664,7 +4666,7 @@ func (m *Session) SetMaxCoreTemperatureScaled(v float64) *Session {
 	return m
 }
 
-// SetDeveloperFields Session's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Session's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Session) SetUnknownFields(unknownFields ...proto.Field) *Session {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/set_gen.go
+++ b/profile/mesgdef/set_gen.go
@@ -57,6 +57,7 @@ func NewSet(mesg *proto.Message) *Set {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -160,6 +161,7 @@ func (m *Set) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -303,7 +305,7 @@ func (m *Set) SetWktStepIndex(v typedef.MessageIndex) *Set {
 	return m
 }
 
-// SetDeveloperFields Set's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Set's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Set) SetUnknownFields(unknownFields ...proto.Field) *Set {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/set_gen.go
+++ b/profile/mesgdef/set_gen.go
@@ -305,13 +305,13 @@ func (m *Set) SetWktStepIndex(v typedef.MessageIndex) *Set {
 	return m
 }
 
-// SetUnknownFields Set's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Set) SetUnknownFields(unknownFields ...proto.Field) *Set {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Set's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Set) SetDeveloperFields(developerFields ...proto.DeveloperField) *Set {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/skin_temp_overnight_gen.go
+++ b/profile/mesgdef/skin_temp_overnight_gen.go
@@ -50,6 +50,7 @@ func NewSkinTempOvernight(mesg *proto.Message) *SkinTempOvernight {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -113,6 +114,7 @@ func (m *SkinTempOvernight) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -162,7 +164,7 @@ func (m *SkinTempOvernight) SetNightlyValue(v float32) *SkinTempOvernight {
 	return m
 }
 
-// SetDeveloperFields SkinTempOvernight's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields SkinTempOvernight's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SkinTempOvernight) SetUnknownFields(unknownFields ...proto.Field) *SkinTempOvernight {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/skin_temp_overnight_gen.go
+++ b/profile/mesgdef/skin_temp_overnight_gen.go
@@ -164,13 +164,13 @@ func (m *SkinTempOvernight) SetNightlyValue(v float32) *SkinTempOvernight {
 	return m
 }
 
-// SetUnknownFields SkinTempOvernight's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SkinTempOvernight) SetUnknownFields(unknownFields ...proto.Field) *SkinTempOvernight {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields SkinTempOvernight's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *SkinTempOvernight) SetDeveloperFields(developerFields ...proto.DeveloperField) *SkinTempOvernight {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/slave_device_gen.go
+++ b/profile/mesgdef/slave_device_gen.go
@@ -44,6 +44,7 @@ func NewSlaveDevice(mesg *proto.Message) *SlaveDevice {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -89,6 +90,7 @@ func (m *SlaveDevice) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -126,7 +128,7 @@ func (m *SlaveDevice) SetProduct(v uint16) *SlaveDevice {
 	return m
 }
 
-// SetDeveloperFields SlaveDevice's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields SlaveDevice's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SlaveDevice) SetUnknownFields(unknownFields ...proto.Field) *SlaveDevice {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/slave_device_gen.go
+++ b/profile/mesgdef/slave_device_gen.go
@@ -128,13 +128,13 @@ func (m *SlaveDevice) SetProduct(v uint16) *SlaveDevice {
 	return m
 }
 
-// SetUnknownFields SlaveDevice's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SlaveDevice) SetUnknownFields(unknownFields ...proto.Field) *SlaveDevice {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields SlaveDevice's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *SlaveDevice) SetDeveloperFields(developerFields ...proto.DeveloperField) *SlaveDevice {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/sleep_assessment_gen.go
+++ b/profile/mesgdef/sleep_assessment_gen.go
@@ -320,13 +320,13 @@ func (m *SleepAssessment) SetAverageStressDuringSleepScaled(v float64) *SleepAss
 	return m
 }
 
-// SetUnknownFields SleepAssessment's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SleepAssessment) SetUnknownFields(unknownFields ...proto.Field) *SleepAssessment {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields SleepAssessment's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *SleepAssessment) SetDeveloperFields(developerFields ...proto.DeveloperField) *SleepAssessment {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/sleep_assessment_gen.go
+++ b/profile/mesgdef/sleep_assessment_gen.go
@@ -57,6 +57,7 @@ func NewSleepAssessment(mesg *proto.Message) *SleepAssessment {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -174,6 +175,7 @@ func (m *SleepAssessment) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -318,7 +320,7 @@ func (m *SleepAssessment) SetAverageStressDuringSleepScaled(v float64) *SleepAss
 	return m
 }
 
-// SetDeveloperFields SleepAssessment's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields SleepAssessment's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SleepAssessment) SetUnknownFields(unknownFields ...proto.Field) *SleepAssessment {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/sleep_level_gen.go
+++ b/profile/mesgdef/sleep_level_gen.go
@@ -45,6 +45,7 @@ func NewSleepLevel(mesg *proto.Message) *SleepLevel {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -90,6 +91,7 @@ func (m *SleepLevel) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -114,7 +116,7 @@ func (m *SleepLevel) SetSleepLevel(v typedef.SleepLevel) *SleepLevel {
 	return m
 }
 
-// SetDeveloperFields SleepLevel's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields SleepLevel's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SleepLevel) SetUnknownFields(unknownFields ...proto.Field) *SleepLevel {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/sleep_level_gen.go
+++ b/profile/mesgdef/sleep_level_gen.go
@@ -116,13 +116,13 @@ func (m *SleepLevel) SetSleepLevel(v typedef.SleepLevel) *SleepLevel {
 	return m
 }
 
-// SetUnknownFields SleepLevel's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SleepLevel) SetUnknownFields(unknownFields ...proto.Field) *SleepLevel {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields SleepLevel's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *SleepLevel) SetDeveloperFields(developerFields ...proto.DeveloperField) *SleepLevel {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/software_gen.go
+++ b/profile/mesgdef/software_gen.go
@@ -46,6 +46,7 @@ func NewSoftware(mesg *proto.Message) *Software {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -97,6 +98,7 @@ func (m *Software) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -149,7 +151,7 @@ func (m *Software) SetPartNumber(v string) *Software {
 	return m
 }
 
-// SetDeveloperFields Software's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Software's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Software) SetUnknownFields(unknownFields ...proto.Field) *Software {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/software_gen.go
+++ b/profile/mesgdef/software_gen.go
@@ -151,13 +151,13 @@ func (m *Software) SetPartNumber(v string) *Software {
 	return m
 }
 
-// SetUnknownFields Software's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Software) SetUnknownFields(unknownFields ...proto.Field) *Software {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Software's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Software) SetDeveloperFields(developerFields ...proto.DeveloperField) *Software {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/speed_zone_gen.go
+++ b/profile/mesgdef/speed_zone_gen.go
@@ -151,13 +151,13 @@ func (m *SpeedZone) SetName(v string) *SpeedZone {
 	return m
 }
 
-// SetUnknownFields SpeedZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SpeedZone) SetUnknownFields(unknownFields ...proto.Field) *SpeedZone {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields SpeedZone's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *SpeedZone) SetDeveloperFields(developerFields ...proto.DeveloperField) *SpeedZone {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/speed_zone_gen.go
+++ b/profile/mesgdef/speed_zone_gen.go
@@ -46,6 +46,7 @@ func NewSpeedZone(mesg *proto.Message) *SpeedZone {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -97,6 +98,7 @@ func (m *SpeedZone) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -149,7 +151,7 @@ func (m *SpeedZone) SetName(v string) *SpeedZone {
 	return m
 }
 
-// SetDeveloperFields SpeedZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields SpeedZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SpeedZone) SetUnknownFields(unknownFields ...proto.Field) *SpeedZone {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/split_gen.go
+++ b/profile/mesgdef/split_gen.go
@@ -623,13 +623,13 @@ func (m *Split) SetTotalMovingTimeScaled(v float64) *Split {
 	return m
 }
 
-// SetUnknownFields Split's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Split) SetUnknownFields(unknownFields ...proto.Field) *Split {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Split's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Split) SetDeveloperFields(developerFields ...proto.DeveloperField) *Split {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/split_gen.go
+++ b/profile/mesgdef/split_gen.go
@@ -65,6 +65,7 @@ func NewSplit(mesg *proto.Message) *Split {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -212,6 +213,7 @@ func (m *Split) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -621,7 +623,7 @@ func (m *Split) SetTotalMovingTimeScaled(v float64) *Split {
 	return m
 }
 
-// SetDeveloperFields Split's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Split's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Split) SetUnknownFields(unknownFields ...proto.Field) *Split {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/split_summary_gen.go
+++ b/profile/mesgdef/split_summary_gen.go
@@ -57,6 +57,7 @@ func NewSplitSummary(mesg *proto.Message) *SplitSummary {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -174,6 +175,7 @@ func (m *SplitSummary) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -437,7 +439,7 @@ func (m *SplitSummary) SetTotalMovingTimeScaled(v float64) *SplitSummary {
 	return m
 }
 
-// SetDeveloperFields SplitSummary's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields SplitSummary's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SplitSummary) SetUnknownFields(unknownFields ...proto.Field) *SplitSummary {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/split_summary_gen.go
+++ b/profile/mesgdef/split_summary_gen.go
@@ -439,13 +439,13 @@ func (m *SplitSummary) SetTotalMovingTimeScaled(v float64) *SplitSummary {
 	return m
 }
 
-// SetUnknownFields SplitSummary's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *SplitSummary) SetUnknownFields(unknownFields ...proto.Field) *SplitSummary {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields SplitSummary's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *SplitSummary) SetDeveloperFields(developerFields ...proto.DeveloperField) *SplitSummary {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/spo2_data_gen.go
+++ b/profile/mesgdef/spo2_data_gen.go
@@ -48,6 +48,7 @@ func NewSpo2Data(mesg *proto.Message) *Spo2Data {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -105,6 +106,7 @@ func (m *Spo2Data) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -145,7 +147,7 @@ func (m *Spo2Data) SetMode(v typedef.Spo2MeasurementType) *Spo2Data {
 	return m
 }
 
-// SetDeveloperFields Spo2Data's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Spo2Data's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Spo2Data) SetUnknownFields(unknownFields ...proto.Field) *Spo2Data {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/spo2_data_gen.go
+++ b/profile/mesgdef/spo2_data_gen.go
@@ -147,13 +147,13 @@ func (m *Spo2Data) SetMode(v typedef.Spo2MeasurementType) *Spo2Data {
 	return m
 }
 
-// SetUnknownFields Spo2Data's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Spo2Data) SetUnknownFields(unknownFields ...proto.Field) *Spo2Data {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Spo2Data's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Spo2Data) SetDeveloperFields(developerFields ...proto.DeveloperField) *Spo2Data {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/sport_gen.go
+++ b/profile/mesgdef/sport_gen.go
@@ -45,6 +45,7 @@ func NewSport(mesg *proto.Message) *Sport {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -96,6 +97,7 @@ func (m *Sport) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -121,7 +123,7 @@ func (m *Sport) SetName(v string) *Sport {
 	return m
 }
 
-// SetDeveloperFields Sport's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Sport's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Sport) SetUnknownFields(unknownFields ...proto.Field) *Sport {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/sport_gen.go
+++ b/profile/mesgdef/sport_gen.go
@@ -123,13 +123,13 @@ func (m *Sport) SetName(v string) *Sport {
 	return m
 }
 
-// SetUnknownFields Sport's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Sport) SetUnknownFields(unknownFields ...proto.Field) *Sport {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Sport's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Sport) SetDeveloperFields(developerFields ...proto.DeveloperField) *Sport {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/stress_level_gen.go
+++ b/profile/mesgdef/stress_level_gen.go
@@ -46,6 +46,7 @@ func NewStressLevel(mesg *proto.Message) *StressLevel {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -91,6 +92,7 @@ func (m *StressLevel) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -115,7 +117,7 @@ func (m *StressLevel) SetStressLevelTime(v time.Time) *StressLevel {
 	return m
 }
 
-// SetDeveloperFields StressLevel's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields StressLevel's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *StressLevel) SetUnknownFields(unknownFields ...proto.Field) *StressLevel {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/stress_level_gen.go
+++ b/profile/mesgdef/stress_level_gen.go
@@ -117,13 +117,13 @@ func (m *StressLevel) SetStressLevelTime(v time.Time) *StressLevel {
 	return m
 }
 
-// SetUnknownFields StressLevel's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *StressLevel) SetUnknownFields(unknownFields ...proto.Field) *StressLevel {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields StressLevel's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *StressLevel) SetDeveloperFields(developerFields ...proto.DeveloperField) *StressLevel {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/tank_summary_gen.go
+++ b/profile/mesgdef/tank_summary_gen.go
@@ -240,13 +240,13 @@ func (m *TankSummary) SetVolumeUsedScaled(v float64) *TankSummary {
 	return m
 }
 
-// SetUnknownFields TankSummary's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *TankSummary) SetUnknownFields(unknownFields ...proto.Field) *TankSummary {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields TankSummary's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *TankSummary) SetDeveloperFields(developerFields ...proto.DeveloperField) *TankSummary {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/tank_summary_gen.go
+++ b/profile/mesgdef/tank_summary_gen.go
@@ -50,6 +50,7 @@ func NewTankSummary(mesg *proto.Message) *TankSummary {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -113,6 +114,7 @@ func (m *TankSummary) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -238,7 +240,7 @@ func (m *TankSummary) SetVolumeUsedScaled(v float64) *TankSummary {
 	return m
 }
 
-// SetDeveloperFields TankSummary's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields TankSummary's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *TankSummary) SetUnknownFields(unknownFields ...proto.Field) *TankSummary {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/tank_update_gen.go
+++ b/profile/mesgdef/tank_update_gen.go
@@ -48,6 +48,7 @@ func NewTankUpdate(mesg *proto.Message) *TankUpdate {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -99,6 +100,7 @@ func (m *TankUpdate) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -158,7 +160,7 @@ func (m *TankUpdate) SetPressureScaled(v float64) *TankUpdate {
 	return m
 }
 
-// SetDeveloperFields TankUpdate's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields TankUpdate's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *TankUpdate) SetUnknownFields(unknownFields ...proto.Field) *TankUpdate {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/tank_update_gen.go
+++ b/profile/mesgdef/tank_update_gen.go
@@ -160,13 +160,13 @@ func (m *TankUpdate) SetPressureScaled(v float64) *TankUpdate {
 	return m
 }
 
-// SetUnknownFields TankUpdate's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *TankUpdate) SetUnknownFields(unknownFields ...proto.Field) *TankUpdate {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields TankUpdate's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *TankUpdate) SetDeveloperFields(developerFields ...proto.DeveloperField) *TankUpdate {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/three_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/three_d_sensor_calibration_gen.go
@@ -52,6 +52,7 @@ func NewThreeDSensorCalibration(mesg *proto.Message) *ThreeDSensorCalibration {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -165,6 +166,7 @@ func (m *ThreeDSensorCalibration) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -314,7 +316,7 @@ func (m *ThreeDSensorCalibration) SetOrientationMatrixScaled(vs [9]float64) *Thr
 	return m
 }
 
-// SetDeveloperFields ThreeDSensorCalibration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields ThreeDSensorCalibration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ThreeDSensorCalibration) SetUnknownFields(unknownFields ...proto.Field) *ThreeDSensorCalibration {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/three_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/three_d_sensor_calibration_gen.go
@@ -316,13 +316,13 @@ func (m *ThreeDSensorCalibration) SetOrientationMatrixScaled(vs [9]float64) *Thr
 	return m
 }
 
-// SetUnknownFields ThreeDSensorCalibration's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ThreeDSensorCalibration) SetUnknownFields(unknownFields ...proto.Field) *ThreeDSensorCalibration {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields ThreeDSensorCalibration's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *ThreeDSensorCalibration) SetDeveloperFields(developerFields ...proto.DeveloperField) *ThreeDSensorCalibration {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/time_in_zone_gen.go
+++ b/profile/mesgdef/time_in_zone_gen.go
@@ -529,13 +529,13 @@ func (m *TimeInZone) SetFunctionalThresholdPower(v uint16) *TimeInZone {
 	return m
 }
 
-// SetUnknownFields TimeInZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *TimeInZone) SetUnknownFields(unknownFields ...proto.Field) *TimeInZone {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields TimeInZone's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *TimeInZone) SetDeveloperFields(developerFields ...proto.DeveloperField) *TimeInZone {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/time_in_zone_gen.go
+++ b/profile/mesgdef/time_in_zone_gen.go
@@ -62,6 +62,7 @@ func NewTimeInZone(mesg *proto.Message) *TimeInZone {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -197,6 +198,7 @@ func (m *TimeInZone) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -527,7 +529,7 @@ func (m *TimeInZone) SetFunctionalThresholdPower(v uint16) *TimeInZone {
 	return m
 }
 
-// SetDeveloperFields TimeInZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields TimeInZone's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *TimeInZone) SetUnknownFields(unknownFields ...proto.Field) *TimeInZone {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/timestamp_correlation_gen.go
+++ b/profile/mesgdef/timestamp_correlation_gen.go
@@ -255,13 +255,13 @@ func (m *TimestampCorrelation) SetSystemTimestampMs(v uint16) *TimestampCorrelat
 	return m
 }
 
-// SetUnknownFields TimestampCorrelation's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *TimestampCorrelation) SetUnknownFields(unknownFields ...proto.Field) *TimestampCorrelation {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields TimestampCorrelation's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *TimestampCorrelation) SetDeveloperFields(developerFields ...proto.DeveloperField) *TimestampCorrelation {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/timestamp_correlation_gen.go
+++ b/profile/mesgdef/timestamp_correlation_gen.go
@@ -52,6 +52,7 @@ func NewTimestampCorrelation(mesg *proto.Message) *TimestampCorrelation {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -127,6 +128,7 @@ func (m *TimestampCorrelation) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -253,7 +255,7 @@ func (m *TimestampCorrelation) SetSystemTimestampMs(v uint16) *TimestampCorrelat
 	return m
 }
 
-// SetDeveloperFields TimestampCorrelation's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields TimestampCorrelation's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *TimestampCorrelation) SetUnknownFields(unknownFields ...proto.Field) *TimestampCorrelation {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/totals_gen.go
+++ b/profile/mesgdef/totals_gen.go
@@ -54,6 +54,7 @@ func NewTotals(mesg *proto.Message) *Totals {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -147,6 +148,7 @@ func (m *Totals) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -229,7 +231,7 @@ func (m *Totals) SetSportIndex(v uint8) *Totals {
 	return m
 }
 
-// SetDeveloperFields Totals's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Totals's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Totals) SetUnknownFields(unknownFields ...proto.Field) *Totals {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/totals_gen.go
+++ b/profile/mesgdef/totals_gen.go
@@ -231,13 +231,13 @@ func (m *Totals) SetSportIndex(v uint8) *Totals {
 	return m
 }
 
-// SetUnknownFields Totals's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Totals) SetUnknownFields(unknownFields ...proto.Field) *Totals {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Totals's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Totals) SetDeveloperFields(developerFields ...proto.DeveloperField) *Totals {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/training_file_gen.go
+++ b/profile/mesgdef/training_file_gen.go
@@ -190,13 +190,13 @@ func (m *TrainingFile) SetTimeCreated(v time.Time) *TrainingFile {
 	return m
 }
 
-// SetUnknownFields TrainingFile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *TrainingFile) SetUnknownFields(unknownFields ...proto.Field) *TrainingFile {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields TrainingFile's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *TrainingFile) SetDeveloperFields(developerFields ...proto.DeveloperField) *TrainingFile {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/training_file_gen.go
+++ b/profile/mesgdef/training_file_gen.go
@@ -50,6 +50,7 @@ func NewTrainingFile(mesg *proto.Message) *TrainingFile {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -119,6 +120,7 @@ func (m *TrainingFile) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -188,7 +190,7 @@ func (m *TrainingFile) SetTimeCreated(v time.Time) *TrainingFile {
 	return m
 }
 
-// SetDeveloperFields TrainingFile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields TrainingFile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *TrainingFile) SetUnknownFields(unknownFields ...proto.Field) *TrainingFile {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/user_profile_gen.go
+++ b/profile/mesgdef/user_profile_gen.go
@@ -607,13 +607,13 @@ func (m *UserProfile) SetDiveCount(v uint32) *UserProfile {
 	return m
 }
 
-// SetUnknownFields UserProfile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *UserProfile) SetUnknownFields(unknownFields ...proto.Field) *UserProfile {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields UserProfile's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *UserProfile) SetDeveloperFields(developerFields ...proto.DeveloperField) *UserProfile {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/user_profile_gen.go
+++ b/profile/mesgdef/user_profile_gen.go
@@ -72,6 +72,7 @@ func NewUserProfile(mesg *proto.Message) *UserProfile {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -298,6 +299,7 @@ func (m *UserProfile) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -605,7 +607,7 @@ func (m *UserProfile) SetDiveCount(v uint32) *UserProfile {
 	return m
 }
 
-// SetDeveloperFields UserProfile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields UserProfile's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *UserProfile) SetUnknownFields(unknownFields ...proto.Field) *UserProfile {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/video_clip_gen.go
+++ b/profile/mesgdef/video_clip_gen.go
@@ -51,6 +51,7 @@ func NewVideoClip(mesg *proto.Message) *VideoClip {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -126,6 +127,7 @@ func (m *VideoClip) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -185,7 +187,7 @@ func (m *VideoClip) SetClipEnd(v uint32) *VideoClip {
 	return m
 }
 
-// SetDeveloperFields VideoClip's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields VideoClip's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *VideoClip) SetUnknownFields(unknownFields ...proto.Field) *VideoClip {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/video_clip_gen.go
+++ b/profile/mesgdef/video_clip_gen.go
@@ -187,13 +187,13 @@ func (m *VideoClip) SetClipEnd(v uint32) *VideoClip {
 	return m
 }
 
-// SetUnknownFields VideoClip's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *VideoClip) SetUnknownFields(unknownFields ...proto.Field) *VideoClip {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields VideoClip's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *VideoClip) SetDeveloperFields(developerFields ...proto.DeveloperField) *VideoClip {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/video_description_gen.go
+++ b/profile/mesgdef/video_description_gen.go
@@ -45,6 +45,7 @@ func NewVideoDescription(mesg *proto.Message) *VideoDescription {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -96,6 +97,7 @@ func (m *VideoDescription) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -125,7 +127,7 @@ func (m *VideoDescription) SetText(v string) *VideoDescription {
 	return m
 }
 
-// SetDeveloperFields VideoDescription's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields VideoDescription's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *VideoDescription) SetUnknownFields(unknownFields ...proto.Field) *VideoDescription {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/video_description_gen.go
+++ b/profile/mesgdef/video_description_gen.go
@@ -127,13 +127,13 @@ func (m *VideoDescription) SetText(v string) *VideoDescription {
 	return m
 }
 
-// SetUnknownFields VideoDescription's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *VideoDescription) SetUnknownFields(unknownFields ...proto.Field) *VideoDescription {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields VideoDescription's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *VideoDescription) SetDeveloperFields(developerFields ...proto.DeveloperField) *VideoDescription {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/video_frame_gen.go
+++ b/profile/mesgdef/video_frame_gen.go
@@ -47,6 +47,7 @@ func NewVideoFrame(mesg *proto.Message) *VideoFrame {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -98,6 +99,7 @@ func (m *VideoFrame) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -132,7 +134,7 @@ func (m *VideoFrame) SetFrameNumber(v uint32) *VideoFrame {
 	return m
 }
 
-// SetDeveloperFields VideoFrame's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields VideoFrame's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *VideoFrame) SetUnknownFields(unknownFields ...proto.Field) *VideoFrame {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/video_frame_gen.go
+++ b/profile/mesgdef/video_frame_gen.go
@@ -134,13 +134,13 @@ func (m *VideoFrame) SetFrameNumber(v uint32) *VideoFrame {
 	return m
 }
 
-// SetUnknownFields VideoFrame's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *VideoFrame) SetUnknownFields(unknownFields ...proto.Field) *VideoFrame {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields VideoFrame's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *VideoFrame) SetDeveloperFields(developerFields ...proto.DeveloperField) *VideoFrame {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/video_gen.go
+++ b/profile/mesgdef/video_gen.go
@@ -45,6 +45,7 @@ func NewVideo(mesg *proto.Message) *Video {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -96,6 +97,7 @@ func (m *Video) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -123,7 +125,7 @@ func (m *Video) SetDuration(v uint32) *Video {
 	return m
 }
 
-// SetDeveloperFields Video's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Video's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Video) SetUnknownFields(unknownFields ...proto.Field) *Video {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/video_gen.go
+++ b/profile/mesgdef/video_gen.go
@@ -125,13 +125,13 @@ func (m *Video) SetDuration(v uint32) *Video {
 	return m
 }
 
-// SetUnknownFields Video's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Video) SetUnknownFields(unknownFields ...proto.Field) *Video {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Video's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Video) SetDeveloperFields(developerFields ...proto.DeveloperField) *Video {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/video_title_gen.go
+++ b/profile/mesgdef/video_title_gen.go
@@ -45,6 +45,7 @@ func NewVideoTitle(mesg *proto.Message) *VideoTitle {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -96,6 +97,7 @@ func (m *VideoTitle) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -125,7 +127,7 @@ func (m *VideoTitle) SetText(v string) *VideoTitle {
 	return m
 }
 
-// SetDeveloperFields VideoTitle's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields VideoTitle's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *VideoTitle) SetUnknownFields(unknownFields ...proto.Field) *VideoTitle {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/video_title_gen.go
+++ b/profile/mesgdef/video_title_gen.go
@@ -127,13 +127,13 @@ func (m *VideoTitle) SetText(v string) *VideoTitle {
 	return m
 }
 
-// SetUnknownFields VideoTitle's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *VideoTitle) SetUnknownFields(unknownFields ...proto.Field) *VideoTitle {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields VideoTitle's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *VideoTitle) SetDeveloperFields(developerFields ...proto.DeveloperField) *VideoTitle {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/watchface_settings_gen.go
+++ b/profile/mesgdef/watchface_settings_gen.go
@@ -45,6 +45,7 @@ func NewWatchfaceSettings(mesg *proto.Message) *WatchfaceSettings {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -96,6 +97,7 @@ func (m *WatchfaceSettings) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -139,7 +141,7 @@ func (m *WatchfaceSettings) SetLayout(v byte) *WatchfaceSettings {
 	return m
 }
 
-// SetDeveloperFields WatchfaceSettings's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields WatchfaceSettings's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *WatchfaceSettings) SetUnknownFields(unknownFields ...proto.Field) *WatchfaceSettings {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/watchface_settings_gen.go
+++ b/profile/mesgdef/watchface_settings_gen.go
@@ -141,13 +141,13 @@ func (m *WatchfaceSettings) SetLayout(v byte) *WatchfaceSettings {
 	return m
 }
 
-// SetUnknownFields WatchfaceSettings's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *WatchfaceSettings) SetUnknownFields(unknownFields ...proto.Field) *WatchfaceSettings {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields WatchfaceSettings's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *WatchfaceSettings) SetDeveloperFields(developerFields ...proto.DeveloperField) *WatchfaceSettings {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/weather_alert_gen.go
+++ b/profile/mesgdef/weather_alert_gen.go
@@ -50,6 +50,7 @@ func NewWeatherAlert(mesg *proto.Message) *WeatherAlert {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -119,6 +120,7 @@ func (m *WeatherAlert) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -181,7 +183,7 @@ func (m *WeatherAlert) SetType(v typedef.WeatherSevereType) *WeatherAlert {
 	return m
 }
 
-// SetDeveloperFields WeatherAlert's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields WeatherAlert's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *WeatherAlert) SetUnknownFields(unknownFields ...proto.Field) *WeatherAlert {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/weather_alert_gen.go
+++ b/profile/mesgdef/weather_alert_gen.go
@@ -183,13 +183,13 @@ func (m *WeatherAlert) SetType(v typedef.WeatherSevereType) *WeatherAlert {
 	return m
 }
 
-// SetUnknownFields WeatherAlert's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *WeatherAlert) SetUnknownFields(unknownFields ...proto.Field) *WeatherAlert {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields WeatherAlert's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *WeatherAlert) SetDeveloperFields(developerFields ...proto.DeveloperField) *WeatherAlert {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/weather_conditions_gen.go
+++ b/profile/mesgdef/weather_conditions_gen.go
@@ -62,6 +62,7 @@ func NewWeatherConditions(mesg *proto.Message) *WeatherConditions {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -191,6 +192,7 @@ func (m *WeatherConditions) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -377,7 +379,7 @@ func (m *WeatherConditions) SetLowTemperature(v int8) *WeatherConditions {
 	return m
 }
 
-// SetDeveloperFields WeatherConditions's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields WeatherConditions's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *WeatherConditions) SetUnknownFields(unknownFields ...proto.Field) *WeatherConditions {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/weather_conditions_gen.go
+++ b/profile/mesgdef/weather_conditions_gen.go
@@ -379,13 +379,13 @@ func (m *WeatherConditions) SetLowTemperature(v int8) *WeatherConditions {
 	return m
 }
 
-// SetUnknownFields WeatherConditions's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *WeatherConditions) SetUnknownFields(unknownFields ...proto.Field) *WeatherConditions {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields WeatherConditions's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *WeatherConditions) SetDeveloperFields(developerFields ...proto.DeveloperField) *WeatherConditions {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/weight_scale_gen.go
+++ b/profile/mesgdef/weight_scale_gen.go
@@ -59,6 +59,7 @@ func NewWeightScale(mesg *proto.Message) *WeightScale {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -176,6 +177,7 @@ func (m *WeightScale) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -519,7 +521,7 @@ func (m *WeightScale) SetBmiScaled(v float64) *WeightScale {
 	return m
 }
 
-// SetDeveloperFields WeightScale's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields WeightScale's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *WeightScale) SetUnknownFields(unknownFields ...proto.Field) *WeightScale {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/weight_scale_gen.go
+++ b/profile/mesgdef/weight_scale_gen.go
@@ -521,13 +521,13 @@ func (m *WeightScale) SetBmiScaled(v float64) *WeightScale {
 	return m
 }
 
-// SetUnknownFields WeightScale's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *WeightScale) SetUnknownFields(unknownFields ...proto.Field) *WeightScale {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields WeightScale's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *WeightScale) SetDeveloperFields(developerFields ...proto.DeveloperField) *WeightScale {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/workout_gen.go
+++ b/profile/mesgdef/workout_gen.go
@@ -51,6 +51,7 @@ func NewWorkout(mesg *proto.Message) *Workout {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -132,6 +133,7 @@ func (m *Workout) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -218,7 +220,7 @@ func (m *Workout) SetPoolLengthUnit(v typedef.DisplayMeasure) *Workout {
 	return m
 }
 
-// SetDeveloperFields Workout's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields Workout's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Workout) SetUnknownFields(unknownFields ...proto.Field) *Workout {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/workout_gen.go
+++ b/profile/mesgdef/workout_gen.go
@@ -220,13 +220,13 @@ func (m *Workout) SetPoolLengthUnit(v typedef.DisplayMeasure) *Workout {
 	return m
 }
 
-// SetUnknownFields Workout's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *Workout) SetUnknownFields(unknownFields ...proto.Field) *Workout {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields Workout's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *Workout) SetDeveloperFields(developerFields ...proto.DeveloperField) *Workout {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/workout_session_gen.go
+++ b/profile/mesgdef/workout_session_gen.go
@@ -203,13 +203,13 @@ func (m *WorkoutSession) SetPoolLengthUnit(v typedef.DisplayMeasure) *WorkoutSes
 	return m
 }
 
-// SetUnknownFields WorkoutSession's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *WorkoutSession) SetUnknownFields(unknownFields ...proto.Field) *WorkoutSession {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields WorkoutSession's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *WorkoutSession) SetDeveloperFields(developerFields ...proto.DeveloperField) *WorkoutSession {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/workout_session_gen.go
+++ b/profile/mesgdef/workout_session_gen.go
@@ -50,6 +50,7 @@ func NewWorkoutSession(mesg *proto.Message) *WorkoutSession {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -125,6 +126,7 @@ func (m *WorkoutSession) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -201,7 +203,7 @@ func (m *WorkoutSession) SetPoolLengthUnit(v typedef.DisplayMeasure) *WorkoutSes
 	return m
 }
 
-// SetDeveloperFields WorkoutSession's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields WorkoutSession's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *WorkoutSession) SetUnknownFields(unknownFields ...proto.Field) *WorkoutSession {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/workout_step_gen.go
+++ b/profile/mesgdef/workout_step_gen.go
@@ -62,6 +62,7 @@ func NewWorkoutStep(mesg *proto.Message) *WorkoutStep {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -209,6 +210,7 @@ func (m *WorkoutStep) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -562,7 +564,7 @@ func (m *WorkoutStep) SetSecondaryCustomTargetValueHigh(v uint32) *WorkoutStep {
 	return m
 }
 
-// SetDeveloperFields WorkoutStep's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields WorkoutStep's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *WorkoutStep) SetUnknownFields(unknownFields ...proto.Field) *WorkoutStep {
 	m.UnknownFields = unknownFields
 	return m

--- a/profile/mesgdef/workout_step_gen.go
+++ b/profile/mesgdef/workout_step_gen.go
@@ -564,13 +564,13 @@ func (m *WorkoutStep) SetSecondaryCustomTargetValueHigh(v uint32) *WorkoutStep {
 	return m
 }
 
-// SetUnknownFields WorkoutStep's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *WorkoutStep) SetUnknownFields(unknownFields ...proto.Field) *WorkoutStep {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields WorkoutStep's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *WorkoutStep) SetDeveloperFields(developerFields ...proto.DeveloperField) *WorkoutStep {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/zones_target_gen.go
+++ b/profile/mesgdef/zones_target_gen.go
@@ -149,13 +149,13 @@ func (m *ZonesTarget) SetPwrCalcType(v typedef.PwrZoneCalc) *ZonesTarget {
 	return m
 }
 
-// SetUnknownFields ZonesTarget's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields sets UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ZonesTarget) SetUnknownFields(unknownFields ...proto.Field) *ZonesTarget {
 	m.UnknownFields = unknownFields
 	return m
 }
 
-// SetDeveloperFields ZonesTarget's DeveloperFields.
+// SetDeveloperFields sets DeveloperFields.
 func (m *ZonesTarget) SetDeveloperFields(developerFields ...proto.DeveloperField) *ZonesTarget {
 	m.DeveloperFields = developerFields
 	return m

--- a/profile/mesgdef/zones_target_gen.go
+++ b/profile/mesgdef/zones_target_gen.go
@@ -47,6 +47,7 @@ func NewZonesTarget(mesg *proto.Message) *ZonesTarget {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
+		clear(arr[:len(unknownFields)])
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -110,6 +111,7 @@ func (m *ZonesTarget) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
+	clear(fields)
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields
@@ -147,7 +149,7 @@ func (m *ZonesTarget) SetPwrCalcType(v typedef.PwrZoneCalc) *ZonesTarget {
 	return m
 }
 
-// SetDeveloperFields ZonesTarget's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
+// SetUnknownFields ZonesTarget's UnknownFields (fields that are exist but they are not defined in Profile.xlsx)
 func (m *ZonesTarget) SetUnknownFields(unknownFields ...proto.Field) *ZonesTarget {
 	m.UnknownFields = unknownFields
 	return m


### PR DESCRIPTION
- Clear fields' array pool after we are done using it. A field may be an unknown field and field's Value may contains pointer to a slice. In the case of unknown field, its FieldBase object is newly created, it's not referencing factory's defined object, so it needs to be freed. Previously, those objects can only be freed after the array pool is freed first since the array pool is still referencing them. Now those objects can be freed right after we clear the array pool.
- Minor clean code, update mesgdef code documentation for `SetUnknownFields` and `SetDeveloperFields`.