### PR TITLE
fix: mesgdef should clear array pool directly

### DIFF
--- a/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
+++ b/internal/cmd/fitgen/profile/mesgdef/mesgdef.tmpl
@@ -68,7 +68,7 @@ func New{{ .Name }}(mesg *proto.Message) *{{ .Name }} {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)]) {{/* In case of unknown field or field.Value contains pointer to a slice */}}
+		*arr = [poolsize]proto.Field{} {{/* In case of unknown field or field.Value contains pointer to a slice */}}
 		pool.Put(arr)
 		{{- if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}
 			developerFields = mesg.DeveloperFields
@@ -133,7 +133,7 @@ func (m *{{ .Name }}) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields) {{/* In case of unknown field or field.Value contains pointer to a slice */}}
+	*arr = [poolsize]proto.Field{} {{/* In case of unknown field or field.Value contains pointer to a slice */}}
 	pool.Put(arr)
 
 	{{ if and (not (eq .Name "FileId")) (not (eq .Name "DeveloperDataId")) (not (eq .Name "FieldDescription"))  }}

--- a/profile/mesgdef/aad_accel_features_gen.go
+++ b/profile/mesgdef/aad_accel_features_gen.go
@@ -51,7 +51,7 @@ func NewAadAccelFeatures(mesg *proto.Message) *AadAccelFeatures {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -121,7 +121,7 @@ func (m *AadAccelFeatures) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/accelerometer_data_gen.go
+++ b/profile/mesgdef/accelerometer_data_gen.go
@@ -56,7 +56,7 @@ func NewAccelerometerData(mesg *proto.Message) *AccelerometerData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -162,7 +162,7 @@ func (m *AccelerometerData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/activity_gen.go
+++ b/profile/mesgdef/activity_gen.go
@@ -53,7 +53,7 @@ func NewActivity(mesg *proto.Message) *Activity {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -135,7 +135,7 @@ func (m *Activity) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/ant_channel_id_gen.go
+++ b/profile/mesgdef/ant_channel_id_gen.go
@@ -47,7 +47,7 @@ func NewAntChannelId(mesg *proto.Message) *AntChannelId {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -111,7 +111,7 @@ func (m *AntChannelId) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/ant_rx_gen.go
+++ b/profile/mesgdef/ant_rx_gen.go
@@ -58,7 +58,7 @@ func NewAntRx(mesg *proto.Message) *AntRx {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -136,7 +136,7 @@ func (m *AntRx) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/ant_tx_gen.go
+++ b/profile/mesgdef/ant_tx_gen.go
@@ -58,7 +58,7 @@ func NewAntTx(mesg *proto.Message) *AntTx {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -136,7 +136,7 @@ func (m *AntTx) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/aviation_attitude_gen.go
+++ b/profile/mesgdef/aviation_attitude_gen.go
@@ -58,7 +58,7 @@ func NewAviationAttitude(mesg *proto.Message) *AviationAttitude {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -172,7 +172,7 @@ func (m *AviationAttitude) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/barometer_data_gen.go
+++ b/profile/mesgdef/barometer_data_gen.go
@@ -48,7 +48,7 @@ func NewBarometerData(mesg *proto.Message) *BarometerData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -106,7 +106,7 @@ func (m *BarometerData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/beat_intervals_gen.go
+++ b/profile/mesgdef/beat_intervals_gen.go
@@ -47,7 +47,7 @@ func NewBeatIntervals(mesg *proto.Message) *BeatIntervals {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -99,7 +99,7 @@ func (m *BeatIntervals) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/bike_profile_gen.go
+++ b/profile/mesgdef/bike_profile_gen.go
@@ -75,7 +75,7 @@ func NewBikeProfile(mesg *proto.Message) *BikeProfile {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -301,7 +301,7 @@ func (m *BikeProfile) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/blood_pressure_gen.go
+++ b/profile/mesgdef/blood_pressure_gen.go
@@ -55,7 +55,7 @@ func NewBloodPressure(mesg *proto.Message) *BloodPressure {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -155,7 +155,7 @@ func (m *BloodPressure) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/cadence_zone_gen.go
+++ b/profile/mesgdef/cadence_zone_gen.go
@@ -45,7 +45,7 @@ func NewCadenceZone(mesg *proto.Message) *CadenceZone {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -97,7 +97,7 @@ func (m *CadenceZone) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/camera_event_gen.go
+++ b/profile/mesgdef/camera_event_gen.go
@@ -49,7 +49,7 @@ func NewCameraEvent(mesg *proto.Message) *CameraEvent {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -113,7 +113,7 @@ func (m *CameraEvent) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/capabilities_gen.go
+++ b/profile/mesgdef/capabilities_gen.go
@@ -46,7 +46,7 @@ func NewCapabilities(mesg *proto.Message) *Capabilities {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -108,7 +108,7 @@ func (m *Capabilities) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/chrono_shot_data_gen.go
+++ b/profile/mesgdef/chrono_shot_data_gen.go
@@ -48,7 +48,7 @@ func NewChronoShotData(mesg *proto.Message) *ChronoShotData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -100,7 +100,7 @@ func (m *ChronoShotData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/chrono_shot_session_gen.go
+++ b/profile/mesgdef/chrono_shot_session_gen.go
@@ -52,7 +52,7 @@ func NewChronoShotSession(mesg *proto.Message) *ChronoShotSession {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -128,7 +128,7 @@ func (m *ChronoShotSession) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/climb_pro_gen.go
+++ b/profile/mesgdef/climb_pro_gen.go
@@ -53,7 +53,7 @@ func NewClimbPro(mesg *proto.Message) *ClimbPro {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -129,7 +129,7 @@ func (m *ClimbPro) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/connectivity_gen.go
+++ b/profile/mesgdef/connectivity_gen.go
@@ -55,7 +55,7 @@ func NewConnectivity(mesg *proto.Message) *Connectivity {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -167,7 +167,7 @@ func (m *Connectivity) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/course_gen.go
+++ b/profile/mesgdef/course_gen.go
@@ -46,7 +46,7 @@ func NewCourse(mesg *proto.Message) *Course {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -104,7 +104,7 @@ func (m *Course) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/course_point_gen.go
+++ b/profile/mesgdef/course_point_gen.go
@@ -54,7 +54,7 @@ func NewCoursePoint(mesg *proto.Message) *CoursePoint {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -136,7 +136,7 @@ func (m *CoursePoint) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/developer_data_id_gen.go
+++ b/profile/mesgdef/developer_data_id_gen.go
@@ -45,7 +45,7 @@ func NewDeveloperDataId(mesg *proto.Message) *DeveloperDataId {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 	}
 
@@ -107,7 +107,7 @@ func (m *DeveloperDataId) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	return mesg

--- a/profile/mesgdef/device_aux_battery_info_gen.go
+++ b/profile/mesgdef/device_aux_battery_info_gen.go
@@ -50,7 +50,7 @@ func NewDeviceAuxBatteryInfo(mesg *proto.Message) *DeviceAuxBatteryInfo {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -114,7 +114,7 @@ func (m *DeviceAuxBatteryInfo) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/device_info_gen.go
+++ b/profile/mesgdef/device_info_gen.go
@@ -64,7 +64,7 @@ func NewDeviceInfo(mesg *proto.Message) *DeviceInfo {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -212,7 +212,7 @@ func (m *DeviceInfo) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/device_settings_gen.go
+++ b/profile/mesgdef/device_settings_gen.go
@@ -70,7 +70,7 @@ func NewDeviceSettings(mesg *proto.Message) *DeviceSettings {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -252,7 +252,7 @@ func (m *DeviceSettings) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/dive_alarm_gen.go
+++ b/profile/mesgdef/dive_alarm_gen.go
@@ -57,7 +57,7 @@ func NewDiveAlarm(mesg *proto.Message) *DiveAlarm {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -173,7 +173,7 @@ func (m *DiveAlarm) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/dive_apnea_alarm_gen.go
+++ b/profile/mesgdef/dive_apnea_alarm_gen.go
@@ -57,7 +57,7 @@ func NewDiveApneaAlarm(mesg *proto.Message) *DiveApneaAlarm {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -173,7 +173,7 @@ func (m *DiveApneaAlarm) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/dive_gas_gen.go
+++ b/profile/mesgdef/dive_gas_gen.go
@@ -47,7 +47,7 @@ func NewDiveGas(mesg *proto.Message) *DiveGas {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -111,7 +111,7 @@ func (m *DiveGas) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/dive_settings_gen.go
+++ b/profile/mesgdef/dive_settings_gen.go
@@ -80,7 +80,7 @@ func NewDiveSettings(mesg *proto.Message) *DiveSettings {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -324,7 +324,7 @@ func (m *DiveSettings) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/dive_summary_gen.go
+++ b/profile/mesgdef/dive_summary_gen.go
@@ -68,7 +68,7 @@ func NewDiveSummary(mesg *proto.Message) *DiveSummary {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -240,7 +240,7 @@ func (m *DiveSummary) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/event_gen.go
+++ b/profile/mesgdef/event_gen.go
@@ -71,7 +71,7 @@ func NewEvent(mesg *proto.Message) *Event {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -254,7 +254,7 @@ func (m *Event) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/exd_data_concept_configuration_gen.go
+++ b/profile/mesgdef/exd_data_concept_configuration_gen.go
@@ -60,7 +60,7 @@ func NewExdDataConceptConfiguration(mesg *proto.Message) *ExdDataConceptConfigur
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -168,7 +168,7 @@ func (m *ExdDataConceptConfiguration) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/exd_data_field_configuration_gen.go
+++ b/profile/mesgdef/exd_data_field_configuration_gen.go
@@ -55,7 +55,7 @@ func NewExdDataFieldConfiguration(mesg *proto.Message) *ExdDataFieldConfiguratio
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -204,7 +204,7 @@ func (m *ExdDataFieldConfiguration) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/exd_screen_configuration_gen.go
+++ b/profile/mesgdef/exd_screen_configuration_gen.go
@@ -46,7 +46,7 @@ func NewExdScreenConfiguration(mesg *proto.Message) *ExdScreenConfiguration {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -104,7 +104,7 @@ func (m *ExdScreenConfiguration) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/exercise_title_gen.go
+++ b/profile/mesgdef/exercise_title_gen.go
@@ -46,7 +46,7 @@ func NewExerciseTitle(mesg *proto.Message) *ExerciseTitle {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -104,7 +104,7 @@ func (m *ExerciseTitle) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/field_capabilities_gen.go
+++ b/profile/mesgdef/field_capabilities_gen.go
@@ -47,7 +47,7 @@ func NewFieldCapabilities(mesg *proto.Message) *FieldCapabilities {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -111,7 +111,7 @@ func (m *FieldCapabilities) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/field_description_gen.go
+++ b/profile/mesgdef/field_description_gen.go
@@ -54,7 +54,7 @@ func NewFieldDescription(mesg *proto.Message) *FieldDescription {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 	}
 
@@ -170,7 +170,7 @@ func (m *FieldDescription) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	return mesg

--- a/profile/mesgdef/file_capabilities_gen.go
+++ b/profile/mesgdef/file_capabilities_gen.go
@@ -48,7 +48,7 @@ func NewFileCapabilities(mesg *proto.Message) *FileCapabilities {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -118,7 +118,7 @@ func (m *FileCapabilities) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/file_creator_gen.go
+++ b/profile/mesgdef/file_creator_gen.go
@@ -44,7 +44,7 @@ func NewFileCreator(mesg *proto.Message) *FileCreator {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -90,7 +90,7 @@ func (m *FileCreator) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/file_id_gen.go
+++ b/profile/mesgdef/file_id_gen.go
@@ -49,7 +49,7 @@ func NewFileId(mesg *proto.Message) *FileId {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 	}
 
@@ -123,7 +123,7 @@ func (m *FileId) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	return mesg

--- a/profile/mesgdef/goal_gen.go
+++ b/profile/mesgdef/goal_gen.go
@@ -57,7 +57,7 @@ func NewGoal(mesg *proto.Message) *Goal {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -169,7 +169,7 @@ func (m *Goal) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/gps_metadata_gen.go
+++ b/profile/mesgdef/gps_metadata_gen.go
@@ -55,7 +55,7 @@ func NewGpsMetadata(mesg *proto.Message) *GpsMetadata {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -156,7 +156,7 @@ func (m *GpsMetadata) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/gyroscope_data_gen.go
+++ b/profile/mesgdef/gyroscope_data_gen.go
@@ -53,7 +53,7 @@ func NewGyroscopeData(mesg *proto.Message) *GyroscopeData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -141,7 +141,7 @@ func (m *GyroscopeData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hr_gen.go
+++ b/profile/mesgdef/hr_gen.go
@@ -58,7 +58,7 @@ func NewHr(mesg *proto.Message) *Hr {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -136,7 +136,7 @@ func (m *Hr) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hr_zone_gen.go
+++ b/profile/mesgdef/hr_zone_gen.go
@@ -45,7 +45,7 @@ func NewHrZone(mesg *proto.Message) *HrZone {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -97,7 +97,7 @@ func (m *HrZone) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hrm_profile_gen.go
+++ b/profile/mesgdef/hrm_profile_gen.go
@@ -47,7 +47,7 @@ func NewHrmProfile(mesg *proto.Message) *HrmProfile {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -111,7 +111,7 @@ func (m *HrmProfile) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hrv_gen.go
+++ b/profile/mesgdef/hrv_gen.go
@@ -44,7 +44,7 @@ func NewHrv(mesg *proto.Message) *Hrv {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -84,7 +84,7 @@ func (m *Hrv) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hrv_status_summary_gen.go
+++ b/profile/mesgdef/hrv_status_summary_gen.go
@@ -53,7 +53,7 @@ func NewHrvStatusSummary(mesg *proto.Message) *HrvStatusSummary {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -135,7 +135,7 @@ func (m *HrvStatusSummary) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hrv_value_gen.go
+++ b/profile/mesgdef/hrv_value_gen.go
@@ -47,7 +47,7 @@ func NewHrvValue(mesg *proto.Message) *HrvValue {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -93,7 +93,7 @@ func (m *HrvValue) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hsa_accelerometer_data_gen.go
+++ b/profile/mesgdef/hsa_accelerometer_data_gen.go
@@ -52,7 +52,7 @@ func NewHsaAccelerometerData(mesg *proto.Message) *HsaAccelerometerData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -128,7 +128,7 @@ func (m *HsaAccelerometerData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hsa_body_battery_data_gen.go
+++ b/profile/mesgdef/hsa_body_battery_data_gen.go
@@ -49,7 +49,7 @@ func NewHsaBodyBatteryData(mesg *proto.Message) *HsaBodyBatteryData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -113,7 +113,7 @@ func (m *HsaBodyBatteryData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hsa_configuration_data_gen.go
+++ b/profile/mesgdef/hsa_configuration_data_gen.go
@@ -47,7 +47,7 @@ func NewHsaConfigurationData(mesg *proto.Message) *HsaConfigurationData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -99,7 +99,7 @@ func (m *HsaConfigurationData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hsa_event_gen.go
+++ b/profile/mesgdef/hsa_event_gen.go
@@ -46,7 +46,7 @@ func NewHsaEvent(mesg *proto.Message) *HsaEvent {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -92,7 +92,7 @@ func (m *HsaEvent) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hsa_gyroscope_data_gen.go
+++ b/profile/mesgdef/hsa_gyroscope_data_gen.go
@@ -52,7 +52,7 @@ func NewHsaGyroscopeData(mesg *proto.Message) *HsaGyroscopeData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -128,7 +128,7 @@ func (m *HsaGyroscopeData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hsa_heart_rate_data_gen.go
+++ b/profile/mesgdef/hsa_heart_rate_data_gen.go
@@ -48,7 +48,7 @@ func NewHsaHeartRateData(mesg *proto.Message) *HsaHeartRateData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -106,7 +106,7 @@ func (m *HsaHeartRateData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hsa_respiration_data_gen.go
+++ b/profile/mesgdef/hsa_respiration_data_gen.go
@@ -48,7 +48,7 @@ func NewHsaRespirationData(mesg *proto.Message) *HsaRespirationData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -100,7 +100,7 @@ func (m *HsaRespirationData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hsa_spo2_data_gen.go
+++ b/profile/mesgdef/hsa_spo2_data_gen.go
@@ -48,7 +48,7 @@ func NewHsaSpo2Data(mesg *proto.Message) *HsaSpo2Data {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -106,7 +106,7 @@ func (m *HsaSpo2Data) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hsa_step_data_gen.go
+++ b/profile/mesgdef/hsa_step_data_gen.go
@@ -47,7 +47,7 @@ func NewHsaStepData(mesg *proto.Message) *HsaStepData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -99,7 +99,7 @@ func (m *HsaStepData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hsa_stress_data_gen.go
+++ b/profile/mesgdef/hsa_stress_data_gen.go
@@ -47,7 +47,7 @@ func NewHsaStressData(mesg *proto.Message) *HsaStressData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -99,7 +99,7 @@ func (m *HsaStressData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/hsa_wrist_temperature_data_gen.go
+++ b/profile/mesgdef/hsa_wrist_temperature_data_gen.go
@@ -48,7 +48,7 @@ func NewHsaWristTemperatureData(mesg *proto.Message) *HsaWristTemperatureData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -100,7 +100,7 @@ func (m *HsaWristTemperatureData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/jump_gen.go
+++ b/profile/mesgdef/jump_gen.go
@@ -63,7 +63,7 @@ func NewJump(mesg *proto.Message) *Jump {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -162,7 +162,7 @@ func (m *Jump) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/lap_gen.go
+++ b/profile/mesgdef/lap_gen.go
@@ -176,7 +176,7 @@ func NewLap(mesg *proto.Message) *Lap {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -971,7 +971,7 @@ func (m *Lap) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/length_gen.go
+++ b/profile/mesgdef/length_gen.go
@@ -74,7 +74,7 @@ func NewLength(mesg *proto.Message) *Length {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -248,7 +248,7 @@ func (m *Length) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/magnetometer_data_gen.go
+++ b/profile/mesgdef/magnetometer_data_gen.go
@@ -53,7 +53,7 @@ func NewMagnetometerData(mesg *proto.Message) *MagnetometerData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -141,7 +141,7 @@ func (m *MagnetometerData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/max_met_data_gen.go
+++ b/profile/mesgdef/max_met_data_gen.go
@@ -53,7 +53,7 @@ func NewMaxMetData(mesg *proto.Message) *MaxMetData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -135,7 +135,7 @@ func (m *MaxMetData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/memo_glob_gen.go
+++ b/profile/mesgdef/memo_glob_gen.go
@@ -48,7 +48,7 @@ func NewMemoGlob(mesg *proto.Message) *MemoGlob {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -118,7 +118,7 @@ func (m *MemoGlob) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/mesg_capabilities_gen.go
+++ b/profile/mesgdef/mesg_capabilities_gen.go
@@ -47,7 +47,7 @@ func NewMesgCapabilities(mesg *proto.Message) *MesgCapabilities {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -111,7 +111,7 @@ func (m *MesgCapabilities) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/met_zone_gen.go
+++ b/profile/mesgdef/met_zone_gen.go
@@ -47,7 +47,7 @@ func NewMetZone(mesg *proto.Message) *MetZone {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -105,7 +105,7 @@ func (m *MetZone) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/monitoring_gen.go
+++ b/profile/mesgdef/monitoring_gen.go
@@ -81,7 +81,7 @@ func NewMonitoring(mesg *proto.Message) *Monitoring {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -320,7 +320,7 @@ func (m *Monitoring) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/monitoring_hr_data_gen.go
+++ b/profile/mesgdef/monitoring_hr_data_gen.go
@@ -47,7 +47,7 @@ func NewMonitoringHrData(mesg *proto.Message) *MonitoringHrData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -99,7 +99,7 @@ func (m *MonitoringHrData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/monitoring_info_gen.go
+++ b/profile/mesgdef/monitoring_info_gen.go
@@ -52,7 +52,7 @@ func NewMonitoringInfo(mesg *proto.Message) *MonitoringInfo {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -126,7 +126,7 @@ func (m *MonitoringInfo) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/nmea_sentence_gen.go
+++ b/profile/mesgdef/nmea_sentence_gen.go
@@ -47,7 +47,7 @@ func NewNmeaSentence(mesg *proto.Message) *NmeaSentence {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -99,7 +99,7 @@ func (m *NmeaSentence) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/obdii_data_gen.go
+++ b/profile/mesgdef/obdii_data_gen.go
@@ -53,7 +53,7 @@ func NewObdiiData(mesg *proto.Message) *ObdiiData {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -141,7 +141,7 @@ func (m *ObdiiData) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/ohr_settings_gen.go
+++ b/profile/mesgdef/ohr_settings_gen.go
@@ -45,7 +45,7 @@ func NewOhrSettings(mesg *proto.Message) *OhrSettings {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -91,7 +91,7 @@ func (m *OhrSettings) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/one_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/one_d_sensor_calibration_gen.go
@@ -50,7 +50,7 @@ func NewOneDSensorCalibration(mesg *proto.Message) *OneDSensorCalibration {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -120,7 +120,7 @@ func (m *OneDSensorCalibration) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/power_zone_gen.go
+++ b/profile/mesgdef/power_zone_gen.go
@@ -45,7 +45,7 @@ func NewPowerZone(mesg *proto.Message) *PowerZone {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -97,7 +97,7 @@ func (m *PowerZone) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/raw_bbi_gen.go
+++ b/profile/mesgdef/raw_bbi_gen.go
@@ -57,7 +57,7 @@ func NewRawBbi(mesg *proto.Message) *RawBbi {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -138,7 +138,7 @@ func (m *RawBbi) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/record_gen.go
+++ b/profile/mesgdef/record_gen.go
@@ -137,7 +137,7 @@ func NewRecord(mesg *proto.Message) *Record {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -711,7 +711,7 @@ func (m *Record) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/respiration_rate_gen.go
+++ b/profile/mesgdef/respiration_rate_gen.go
@@ -47,7 +47,7 @@ func NewRespirationRate(mesg *proto.Message) *RespirationRate {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -93,7 +93,7 @@ func (m *RespirationRate) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/schedule_gen.go
+++ b/profile/mesgdef/schedule_gen.go
@@ -51,7 +51,7 @@ func NewSchedule(mesg *proto.Message) *Schedule {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -127,7 +127,7 @@ func (m *Schedule) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/sdm_profile_gen.go
+++ b/profile/mesgdef/sdm_profile_gen.go
@@ -51,7 +51,7 @@ func NewSdmProfile(mesg *proto.Message) *SdmProfile {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -133,7 +133,7 @@ func (m *SdmProfile) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/segment_file_gen.go
+++ b/profile/mesgdef/segment_file_gen.go
@@ -52,7 +52,7 @@ func NewSegmentFile(mesg *proto.Message) *SegmentFile {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -144,7 +144,7 @@ func (m *SegmentFile) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/segment_id_gen.go
+++ b/profile/mesgdef/segment_id_gen.go
@@ -51,7 +51,7 @@ func NewSegmentId(mesg *proto.Message) *SegmentId {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -139,7 +139,7 @@ func (m *SegmentId) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/segment_lap_gen.go
+++ b/profile/mesgdef/segment_lap_gen.go
@@ -148,7 +148,7 @@ func NewSegmentLap(mesg *proto.Message) *SegmentLap {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -763,7 +763,7 @@ func (m *SegmentLap) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/segment_leaderboard_entry_gen.go
+++ b/profile/mesgdef/segment_leaderboard_entry_gen.go
@@ -50,7 +50,7 @@ func NewSegmentLeaderboardEntry(mesg *proto.Message) *SegmentLeaderboardEntry {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -126,7 +126,7 @@ func (m *SegmentLeaderboardEntry) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/segment_point_gen.go
+++ b/profile/mesgdef/segment_point_gen.go
@@ -58,7 +58,7 @@ func NewSegmentPoint(mesg *proto.Message) *SegmentPoint {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -139,7 +139,7 @@ func (m *SegmentPoint) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/session_gen.go
+++ b/profile/mesgdef/session_gen.go
@@ -209,7 +209,7 @@ func NewSession(mesg *proto.Message) *Session {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -1205,7 +1205,7 @@ func (m *Session) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/set_gen.go
+++ b/profile/mesgdef/set_gen.go
@@ -57,7 +57,7 @@ func NewSet(mesg *proto.Message) *Set {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -161,7 +161,7 @@ func (m *Set) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/skin_temp_overnight_gen.go
+++ b/profile/mesgdef/skin_temp_overnight_gen.go
@@ -50,7 +50,7 @@ func NewSkinTempOvernight(mesg *proto.Message) *SkinTempOvernight {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -114,7 +114,7 @@ func (m *SkinTempOvernight) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/slave_device_gen.go
+++ b/profile/mesgdef/slave_device_gen.go
@@ -44,7 +44,7 @@ func NewSlaveDevice(mesg *proto.Message) *SlaveDevice {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -90,7 +90,7 @@ func (m *SlaveDevice) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/sleep_assessment_gen.go
+++ b/profile/mesgdef/sleep_assessment_gen.go
@@ -57,7 +57,7 @@ func NewSleepAssessment(mesg *proto.Message) *SleepAssessment {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -175,7 +175,7 @@ func (m *SleepAssessment) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/sleep_level_gen.go
+++ b/profile/mesgdef/sleep_level_gen.go
@@ -45,7 +45,7 @@ func NewSleepLevel(mesg *proto.Message) *SleepLevel {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -91,7 +91,7 @@ func (m *SleepLevel) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/software_gen.go
+++ b/profile/mesgdef/software_gen.go
@@ -46,7 +46,7 @@ func NewSoftware(mesg *proto.Message) *Software {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -98,7 +98,7 @@ func (m *Software) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/speed_zone_gen.go
+++ b/profile/mesgdef/speed_zone_gen.go
@@ -46,7 +46,7 @@ func NewSpeedZone(mesg *proto.Message) *SpeedZone {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -98,7 +98,7 @@ func (m *SpeedZone) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/split_gen.go
+++ b/profile/mesgdef/split_gen.go
@@ -65,7 +65,7 @@ func NewSplit(mesg *proto.Message) *Split {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -213,7 +213,7 @@ func (m *Split) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/split_summary_gen.go
+++ b/profile/mesgdef/split_summary_gen.go
@@ -57,7 +57,7 @@ func NewSplitSummary(mesg *proto.Message) *SplitSummary {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -175,7 +175,7 @@ func (m *SplitSummary) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/spo2_data_gen.go
+++ b/profile/mesgdef/spo2_data_gen.go
@@ -48,7 +48,7 @@ func NewSpo2Data(mesg *proto.Message) *Spo2Data {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -106,7 +106,7 @@ func (m *Spo2Data) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/sport_gen.go
+++ b/profile/mesgdef/sport_gen.go
@@ -45,7 +45,7 @@ func NewSport(mesg *proto.Message) *Sport {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -97,7 +97,7 @@ func (m *Sport) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/stress_level_gen.go
+++ b/profile/mesgdef/stress_level_gen.go
@@ -46,7 +46,7 @@ func NewStressLevel(mesg *proto.Message) *StressLevel {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -92,7 +92,7 @@ func (m *StressLevel) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/tank_summary_gen.go
+++ b/profile/mesgdef/tank_summary_gen.go
@@ -50,7 +50,7 @@ func NewTankSummary(mesg *proto.Message) *TankSummary {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -114,7 +114,7 @@ func (m *TankSummary) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/tank_update_gen.go
+++ b/profile/mesgdef/tank_update_gen.go
@@ -48,7 +48,7 @@ func NewTankUpdate(mesg *proto.Message) *TankUpdate {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -100,7 +100,7 @@ func (m *TankUpdate) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/three_d_sensor_calibration_gen.go
+++ b/profile/mesgdef/three_d_sensor_calibration_gen.go
@@ -52,7 +52,7 @@ func NewThreeDSensorCalibration(mesg *proto.Message) *ThreeDSensorCalibration {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -166,7 +166,7 @@ func (m *ThreeDSensorCalibration) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/time_in_zone_gen.go
+++ b/profile/mesgdef/time_in_zone_gen.go
@@ -62,7 +62,7 @@ func NewTimeInZone(mesg *proto.Message) *TimeInZone {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -198,7 +198,7 @@ func (m *TimeInZone) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/timestamp_correlation_gen.go
+++ b/profile/mesgdef/timestamp_correlation_gen.go
@@ -52,7 +52,7 @@ func NewTimestampCorrelation(mesg *proto.Message) *TimestampCorrelation {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -128,7 +128,7 @@ func (m *TimestampCorrelation) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/totals_gen.go
+++ b/profile/mesgdef/totals_gen.go
@@ -54,7 +54,7 @@ func NewTotals(mesg *proto.Message) *Totals {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -148,7 +148,7 @@ func (m *Totals) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/training_file_gen.go
+++ b/profile/mesgdef/training_file_gen.go
@@ -50,7 +50,7 @@ func NewTrainingFile(mesg *proto.Message) *TrainingFile {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -120,7 +120,7 @@ func (m *TrainingFile) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/user_profile_gen.go
+++ b/profile/mesgdef/user_profile_gen.go
@@ -72,7 +72,7 @@ func NewUserProfile(mesg *proto.Message) *UserProfile {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -299,7 +299,7 @@ func (m *UserProfile) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/video_clip_gen.go
+++ b/profile/mesgdef/video_clip_gen.go
@@ -51,7 +51,7 @@ func NewVideoClip(mesg *proto.Message) *VideoClip {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -127,7 +127,7 @@ func (m *VideoClip) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/video_description_gen.go
+++ b/profile/mesgdef/video_description_gen.go
@@ -45,7 +45,7 @@ func NewVideoDescription(mesg *proto.Message) *VideoDescription {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -97,7 +97,7 @@ func (m *VideoDescription) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/video_frame_gen.go
+++ b/profile/mesgdef/video_frame_gen.go
@@ -47,7 +47,7 @@ func NewVideoFrame(mesg *proto.Message) *VideoFrame {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -99,7 +99,7 @@ func (m *VideoFrame) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/video_gen.go
+++ b/profile/mesgdef/video_gen.go
@@ -45,7 +45,7 @@ func NewVideo(mesg *proto.Message) *Video {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -97,7 +97,7 @@ func (m *Video) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/video_title_gen.go
+++ b/profile/mesgdef/video_title_gen.go
@@ -45,7 +45,7 @@ func NewVideoTitle(mesg *proto.Message) *VideoTitle {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -97,7 +97,7 @@ func (m *VideoTitle) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/watchface_settings_gen.go
+++ b/profile/mesgdef/watchface_settings_gen.go
@@ -45,7 +45,7 @@ func NewWatchfaceSettings(mesg *proto.Message) *WatchfaceSettings {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -97,7 +97,7 @@ func (m *WatchfaceSettings) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/weather_alert_gen.go
+++ b/profile/mesgdef/weather_alert_gen.go
@@ -50,7 +50,7 @@ func NewWeatherAlert(mesg *proto.Message) *WeatherAlert {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -120,7 +120,7 @@ func (m *WeatherAlert) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/weather_conditions_gen.go
+++ b/profile/mesgdef/weather_conditions_gen.go
@@ -62,7 +62,7 @@ func NewWeatherConditions(mesg *proto.Message) *WeatherConditions {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -192,7 +192,7 @@ func (m *WeatherConditions) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/weight_scale_gen.go
+++ b/profile/mesgdef/weight_scale_gen.go
@@ -59,7 +59,7 @@ func NewWeightScale(mesg *proto.Message) *WeightScale {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -177,7 +177,7 @@ func (m *WeightScale) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/workout_gen.go
+++ b/profile/mesgdef/workout_gen.go
@@ -51,7 +51,7 @@ func NewWorkout(mesg *proto.Message) *Workout {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -133,7 +133,7 @@ func (m *Workout) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/workout_session_gen.go
+++ b/profile/mesgdef/workout_session_gen.go
@@ -50,7 +50,7 @@ func NewWorkoutSession(mesg *proto.Message) *WorkoutSession {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -126,7 +126,7 @@ func (m *WorkoutSession) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/workout_step_gen.go
+++ b/profile/mesgdef/workout_step_gen.go
@@ -62,7 +62,7 @@ func NewWorkoutStep(mesg *proto.Message) *WorkoutStep {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -210,7 +210,7 @@ func (m *WorkoutStep) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields

--- a/profile/mesgdef/zones_target_gen.go
+++ b/profile/mesgdef/zones_target_gen.go
@@ -47,7 +47,7 @@ func NewZonesTarget(mesg *proto.Message) *ZonesTarget {
 			vals[mesg.Fields[i].Num] = mesg.Fields[i].Value
 		}
 		unknownFields = sliceutil.Clone(unknownFields)
-		clear(arr[:len(unknownFields)])
+		*arr = [poolsize]proto.Field{}
 		pool.Put(arr)
 		developerFields = mesg.DeveloperFields
 	}
@@ -111,7 +111,7 @@ func (m *ZonesTarget) ToMesg(options *Options) proto.Message {
 
 	mesg.Fields = make([]proto.Field, len(fields))
 	copy(mesg.Fields, fields)
-	clear(fields)
+	*arr = [poolsize]proto.Field{}
 	pool.Put(arr)
 
 	mesg.DeveloperFields = m.DeveloperFields


### PR DESCRIPTION
- Since we use append on field array pool, it may grow more than the size of the field array pool. New underlying array will be created, leave behind field array pool data untouched when doing clear.
- There is also bug on clearing field array pool on creating unknown messages, if we end up creating new slice, `clear(arr[:len(unknownFields)])` may panic as the len of `unknownFields` is more than `arr`.