### PR TITLE
fix: fitgen's factory and mesgdef on evaluating scale offset

### DIFF
--- a/factory/factory_gen.go
+++ b/factory/factory_gen.go
@@ -1000,7 +1000,7 @@ var mesgs = [...]*[256]*proto.FieldBase{
 				0: {FieldNum: 73 /* enhanced_speed */, Scale: 1000, Bits: 16},
 			}},
 		7: {Name: "power", Num: 7, Type: profile.Uint16, BaseType: basetype.Uint16, Scale: 1, Units: "watts"},
-		8: {Name: "compressed_speed_distance", Num: 8, Type: profile.Byte, BaseType: basetype.Byte, Array: true /* [3] */, Scale: 100, Units: "m/s,m",
+		8: {Name: "compressed_speed_distance", Num: 8, Type: profile.Byte, BaseType: basetype.Byte, Array: true /* [3] */, Scale: 1, Units: "m/s,m",
 			Components: []proto.Component{
 				0: {FieldNum: 6 /* speed */, Scale: 100, Bits: 12},
 				1: {FieldNum: 5 /* distance */, Scale: 16, Accumulate: true, Bits: 12},
@@ -2122,7 +2122,7 @@ var mesgs = [...]*[256]*proto.FieldBase{
 			}},
 		6: {Name: "filtered_bpm", Num: 6, Type: profile.Uint8, BaseType: basetype.Uint8, Array: true /* [N] */, Scale: 1, Units: "bpm"},
 		9: {Name: "event_timestamp", Num: 9, Type: profile.Uint32, BaseType: basetype.Uint32, Array: true /* [N] */, Scale: 1024, Accumulate: true, Units: "s"},
-		10: {Name: "event_timestamp_12", Num: 10, Type: profile.Byte, BaseType: basetype.Byte, Array: true /* [N] */, Scale: 1024, Accumulate: true, Units: "s",
+		10: {Name: "event_timestamp_12", Num: 10, Type: profile.Byte, BaseType: basetype.Byte, Array: true /* [N] */, Scale: 1, Accumulate: true, Units: "s",
 			Components: []proto.Component{
 				0: {FieldNum: 9 /* event_timestamp */, Scale: 1024, Accumulate: true, Bits: 12},
 				1: {FieldNum: 9 /* event_timestamp */, Scale: 1024, Accumulate: true, Bits: 12},

--- a/internal/cmd/fitgen/factory/builder.go
+++ b/internal/cmd/fitgen/factory/builder.go
@@ -138,9 +138,14 @@ func (b *Builder) makeFieldBases(message parser.Message) string {
 		if array := field.Array != ""; array {
 			strbuf.WriteString(fmt.Sprintf("Array: %t, %s", array, makeArrayComment(field.Array)))
 		}
-		strbuf.WriteString(fmt.Sprintf("Scale: %g,", scaleOrDefault(field.Scales, 0))) // first index or default
-		if offset := offsetOrDefault(field.Offsets, 0); offset != 0 {
-			strbuf.WriteString(fmt.Sprintf("Offset: %g,", offset)) // first index or default
+		// Scale and offset do not apply for field that has more than one components
+		if len(field.Components) > 1 {
+			strbuf.WriteString(fmt.Sprintf("Scale: %d,", 1))
+		} else {
+			strbuf.WriteString(fmt.Sprintf("Scale: %g,", scaleOrDefault(field.Scales, 0))) // first index or default
+			if offset := offsetOrDefault(field.Offsets, 0); offset != 0 {
+				strbuf.WriteString(fmt.Sprintf("Offset: %g,", offset)) // first index or default
+			}
 		}
 		if accumulate := accumulateOrDefault(field.Accumulate, 0); accumulate {
 			strbuf.WriteString(fmt.Sprintf("Accumulate: %t,", accumulate))

--- a/internal/cmd/fitgen/profile/mesgdef/builder.go
+++ b/internal/cmd/fitgen/profile/mesgdef/builder.go
@@ -136,11 +136,11 @@ func (b *Builder) Build() ([]generator.Data, error) {
 				field.InvalidValue += fmt.Sprintf("&& %s != \"\"", field.ComparableValue)
 			}
 
-			if len(parserField.Scales) <= 1 { // Multiple scales only for components
+			// Scale and offset do not apply for field that has more than one components
+			if len(parserField.Components) > 1 {
+				field.Scale, field.Offset = 1, 0
+			} else {
 				field.Scale = scaleOrDefault(parserField.Scales, 0)
-			}
-
-			if len(parserField.Offsets) <= 1 { // Multiple offsets only for components
 				field.Offset = offsetOrDefault(parserField.Offsets, 0)
 			}
 


### PR DESCRIPTION
Scale and offset do not apply for field that has more than one components, set it to default scale 1 and offset 0.