### PR TITLE
fix: expanding field that has only one component

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -877,9 +877,11 @@ func (d *Decoder) expandComponents(mesg *proto.Message, containingField *proto.F
 		componentField = d.factory.CreateField(mesg.Num, component.FieldNum)
 		componentField.IsExpandedField = true
 
-		// A component can only have max 32 bits value
+		// A component can only have max 32 bits value.
+		// If a field has only one component, expand it even if its value is zero
+		// e.g. speed (0) -> enhanced_speed (0).
 		val, ok := vbits.Pull(component.Bits)
-		if !ok {
+		if !ok && len(components) > 1 {
 			break
 		}
 

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -2127,6 +2127,16 @@ func TestExpandComponents(t *testing.T) {
 			},
 		},
 		{
+			name: "expand field that only has one component and its value is zero",
+			mesg: proto.Message{Num: mesgnum.Record, Fields: []proto.Field{
+				factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed).WithValue(uint16(0)),
+			}},
+			fieldsAfterExpansion: []proto.Field{
+				factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed).WithValue(uint16(0)),
+				{FieldBase: factory.CreateField(mesgnum.Record, fieldnum.RecordEnhancedSpeed).FieldBase, Value: proto.Uint32(0), IsExpandedField: true},
+			},
+		},
+		{
 			// Real world use case from "testdata/from_official_sdk/activity_poolswim_with_hr.csv"
 			// prior Hr message event_timestamp value: 3.6201171875 -> 3707
 			// event_timestamp_12:  "158|114|57|159|6|167|29|142|25|244|228|130"


### PR DESCRIPTION
If a field has only one component and its value is not an invalid value, expand it even if its value is zero e.g. `speed (0)` -> `enhanced_speed (0)`.