### PR TITLE
chore: move validations in encodeMessages to validateMessages

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -281,6 +281,15 @@ func (e *Encoder) selectProtocolVersion(fileHeader *proto.FileHeader) {
 }
 
 func (e *Encoder) validateMessages(messages []proto.Message) (err error) {
+	if len(messages) == 0 {
+		return ErrEmptyMessages
+	}
+
+	if messages[0].Num != mesgnum.FileId {
+		return fmt.Errorf("first message is expected to be file_id, got: %s: %w",
+			messages[0].Num, ErrMissingFileId)
+	}
+
 	defer e.options.messageValidator.Reset()
 	for i := range messages {
 		mesg := &messages[i] // Must use pointer reference since validator may update the message.
@@ -293,6 +302,7 @@ func (e *Encoder) validateMessages(messages []proto.Message) (err error) {
 				i, mesg.Num, mesg.Num.String(), err)
 		}
 	}
+
 	return nil
 }
 
@@ -435,14 +445,6 @@ func (e *Encoder) calculateDataSize(fit *proto.FIT) error {
 }
 
 func (e *Encoder) encodeMessages(messages []proto.Message) error {
-	if len(messages) == 0 {
-		return ErrEmptyMessages
-	}
-
-	if messages[0].Num != mesgnum.FileId {
-		return ErrMissingFileId
-	}
-
 	for i := range messages {
 		mesg := &messages[i]
 		if err := e.encodeMessage(mesg); err != nil {
@@ -668,14 +670,6 @@ func (e *Encoder) encodeWithEarlyCheckStrategyWithContext(ctx context.Context, f
 }
 
 func (e *Encoder) encodeMessagesWithContext(ctx context.Context, messages []proto.Message) error {
-	if len(messages) == 0 {
-		return ErrEmptyMessages
-	}
-
-	if messages[0].Num != mesgnum.FileId {
-		return ErrMissingFileId
-	}
-
 	for i := range messages {
 		select {
 		case <-ctx.Done():

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -290,18 +290,23 @@ func (e *Encoder) validateMessages(messages []proto.Message) (err error) {
 			messages[0].Num, ErrMissingFileId)
 	}
 
-	defer e.options.messageValidator.Reset()
 	for i := range messages {
-		mesg := &messages[i] // Must use pointer reference since validator may update the message.
+		mesg := &messages[i]
 		if err = e.protocolValidator.ValidateMessage(mesg); err != nil {
 			return fmt.Errorf("protocol validation failed: message index: %d, num: %d (%s): %w",
 				i, mesg.Num, mesg.Num.String(), err)
 		}
+	}
+
+	for i := range messages {
+		mesg := &messages[i] // Must use pointer reference since message validator may update the message.
 		if err = e.options.messageValidator.Validate(mesg); err != nil {
+			e.options.messageValidator.Reset()
 			return fmt.Errorf("message validation failed: message index: %d, num: %d (%s): %w",
 				i, mesg.Num, mesg.Num.String(), err)
 		}
 	}
+	e.options.messageValidator.Reset()
 
 	return nil
 }


### PR DESCRIPTION
- Move validations that are still reside in `encodeMessages` into `validateMessages` for consistency and separation of concerns.
- Improve encoder's test readability by moving table test creation from outside test function into inner test function.