### PR TITLE
feat: decoder preallocate messages

### DIFF
--- a/decoder/readbuffer.go
+++ b/decoder/readbuffer.go
@@ -68,7 +68,7 @@ func (b *readBuffer) Reset(r io.Reader, size int) {
 //
 // NOTE: n should be >= 0 and n <= reservedbuf, however, we don't enforce it for efficiency.
 func (b *readBuffer) ReadN(n int) ([]byte, error) {
-	remaining := b.last - b.cur
+	remaining := b.Remaining()
 	if n > remaining { // fill buf
 		cur := reservedbuf
 		if remaining != 0 {
@@ -88,3 +88,10 @@ func (b *readBuffer) ReadN(n int) ([]byte, error) {
 	b.cur += n
 	return buf, nil
 }
+
+// Remaining returns the number of bytes that can be read from the current buffer
+// without triggering read to underlying reader.
+func (b *readBuffer) Remaining() int { return b.last - b.cur }
+
+// Reader returns underlying reader.
+func (b *readBuffer) Reader() io.Reader { return b.r }


### PR DESCRIPTION
Add decode option to precalculate messages first before the actual decoding to avoid re-allocation when appending each decoded message. This is only eligible if the given io.Reader is an io.ReadSeeker and WithBroadcastOnly() is unset.

How fast it is may depends on I/O performance as we need to read the file twice, but typically, it beats the cost of re-allocation especially when the FIT file contains so many messages, e.g. more than 32k messages (I measure up to 237k messages from an ultra-cycling and ultra-run activities), the more the messages we have, the greater the benefit we'll gain. But more measurements are needed since users' cases may vary. I decide to not enable this by default since I'm not confident enough that this will cover most cases and probably leaving this as an opt-in feature is the best decision, we'll see.

This PR is open for feedback. Please feel free to share your thoughts.