### PR TITLE
chore: remove bits' store zero value check

### DIFF
--- a/decoder/bits.go
+++ b/decoder/bits.go
@@ -87,15 +87,9 @@ func storeFromSlice[S []E, E numeric](s S, bitsize uint8) (store [32]uint64) {
 	return store
 }
 
-var storezero [32]uint64
-
 // Pull retrieves a value of the specified bit size from the value store and
 // the value store will be updated accordingly.
 func (v *bits) Pull(bitsize byte) (val uint32) {
-	if v.store == storezero {
-		return 0
-	}
-
 	mask := uint64(1)<<bitsize - 1  // e.g. (1 << 8) - 1     = 255
 	val = uint32(v.store[0] & mask) // e.g. 0x27010E08 & 255 = 0x08
 	v.store[0] >>= bitsize          // e.g. 0x27010E08 >> 8  = 0x27010E


### PR DESCRIPTION
Checking zero value is unnecessary as it will return zero anyway. It arguably only make Pull slightly faster for pulling the last value but its make Pull slower for the entire pulling process. 

By reducing this instruction, compiler can inline Pull method. 
```
before:
./bits.go:94:6: cannot inline (*bits).Pull: function too complex: cost 86 exceeds budget 80

after:
./bits.go:92:6: can inline (*bits).Pull with cost 79 as: method(*bits) func(byte) uint32
```