### PR TITLE
chore: update workflow schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,9 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,9 +10,9 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '0 0 * * 2'
+    - cron: "0 0 1 * *"
   push:
-    branches: [ "master" ]
+    branches: ["master"]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-We include only the essential dependencies to minimize the chance of a supply-chain attack. To ensure that we don’t expose ourselves to that vulnerability, all commits will be scanned by [OpenSSF Scorecard](https://github.com/ossf/scorecard) during PR reviews, upon merging to the master branch, and on a weekly basis (every Tuesday).
+We include only the essential dependencies to minimize the chance of a supply-chain attack. To minimize the risk of exposing ourselves to that vulnerability, all commits will be scanned by [OpenSSF Scorecard](https://github.com/ossf/scorecard) during PR reviews, upon merging to the master branch, and on a monthly basis.
 
 ## Supported Versions
 


### PR DESCRIPTION
The project has reach a "stable" phase as the features, more or less, have been completed. The project is now entering maintenance mode. I don't think we need to update the dependencies too often for both GitHub Actions or Go modules since we will rarely push new PR compare to before. New releases might be less frequent as well unless there is a Profile update, bug fixes or improvements. So I update schedules from weekly basis to monthly basis.

SECURITY.md: 
- Change the doc that we are now scanning on monthly basis.
- Change the word "ensure" to "minimize" as the word "ensure" is tricky here. All we can do is minimizing risk, not eliminate it entirely.