### PR TITLE
fix(proto): implement fmt.Formatter for Field and Value

### DIFF
--- a/proto/proto.go
+++ b/proto/proto.go
@@ -157,6 +157,26 @@ type Field struct {
 	IsExpandedField bool
 }
 
+var _ fmt.Formatter = (*Field)(nil)
+
+// Format controls how Field is formatted when using fmt. Instead of only printing
+// FieldBase's pointer, it also include the value, making it easier to debug.
+func (f Field) Format(p fmt.State, verb rune) {
+	switch {
+	case verb != 'v':
+		fmt.Fprintf(p, "%%!%c(%T=%v)", verb, f, f)
+	case p.Flag('+'):
+		fmt.Fprintf(p, "{FieldBase:(%p)(%+v) Value:%+v IsExpandedField:%t}",
+			f.FieldBase, f.FieldBase, f.Value, f.IsExpandedField)
+	case p.Flag('#'):
+		fmt.Fprintf(p, "{FieldBase:(%p)(%#v), Value:%#v, IsExpandedField:%t}",
+			f.FieldBase, f.FieldBase, f.Value, f.IsExpandedField)
+	default: // %v
+		fmt.Fprintf(p, "{(%p)(%v) %v %t}",
+			f.FieldBase, f.FieldBase, f.Value, f.IsExpandedField)
+	}
+}
+
 // WithValue returns a Field containing v value.
 func (f Field) WithValue(v any) Field {
 	f.Value = Any(v)

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -6,6 +6,7 @@ package proto_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -190,6 +191,51 @@ func TestMessageRemoveFieldByNum(t *testing.T) {
 			}
 			if len(tc.mesg.Fields) != tc.size {
 				t.Fatalf("expected len after removal: %d, got: %d", tc.size, len(tc.mesg.Fields))
+			}
+		})
+	}
+}
+
+func TestFieldFormat(t *testing.T) {
+	field := factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(7))
+
+	tt := []struct {
+		format   string
+		expected string
+	}{
+		{
+			format: "%f",
+			expected: fmt.Sprintf("%%!f(proto.Field={(%p)(%v) %v %t})",
+				field.FieldBase, field.FieldBase, field.Value, field.IsExpandedField),
+		},
+		{
+			format: "%s",
+			expected: fmt.Sprintf("%%!s(proto.Field={(%p)(%v) %v %t})",
+				field.FieldBase, field.FieldBase, field.Value, field.IsExpandedField),
+		},
+		{
+			format: "%v",
+			expected: fmt.Sprintf("{(%p)(%v) %v %t}",
+				field.FieldBase, field.FieldBase, field.Value, field.IsExpandedField),
+		},
+		{
+			format: "%+v",
+			expected: fmt.Sprintf("{FieldBase:(%p)(%+v) Value:%+v IsExpandedField:%t}",
+				field.FieldBase, field.FieldBase, field.Value, field.IsExpandedField),
+		},
+		{
+			format: "%#v",
+			expected: fmt.Sprintf("{FieldBase:(%p)(%#v), Value:%#v, IsExpandedField:%t}",
+				field.FieldBase, field.FieldBase, field.Value, field.IsExpandedField),
+		},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.format), func(t *testing.T) {
+			var buf strings.Builder
+			fmt.Fprintf(&buf, tc.format, field)
+			if str := buf.String(); str != tc.expected {
+				t.Fatalf("expected:\n%q,\ngot:\n%q", tc.expected, str)
 			}
 		})
 	}

--- a/proto/value.go
+++ b/proto/value.go
@@ -5,6 +5,7 @@
 package proto
 
 import (
+	"fmt"
 	"math"
 	"reflect"
 	"strconv"
@@ -222,6 +223,23 @@ func (v Value) String() string {
 		return basetype.StringInvalid
 	}
 	return unsafe.String((*byte)(v.ptr), v.num)
+}
+
+var _ fmt.Formatter = (*Value)(nil)
+
+// Format controls how Value is formatted when using fmt. It overrides the String method, as the String method
+// is used to return string value, rather than the Value formatted as a string.
+func (v Value) Format(p fmt.State, verb rune) {
+	switch {
+	case v.typ == TypeInvalid:
+		fmt.Fprintf(p, "<invalid proto.Value>")
+	case verb != 'v':
+		fmt.Fprintf(p, fmt.FormatString(p, verb), v.Any())
+	case p.Flag('#'):
+		fmt.Fprintf(p, "%#v", v.Any())
+	default:
+		fmt.Fprintf(p, "%v", v.Any())
+	}
 }
 
 // SliceBool returns Value as []typedef.Bool, if it's not a valid []typedef.Bool value, it returns nil.

--- a/proto/value_test.go
+++ b/proto/value_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 	"unsafe"
@@ -301,6 +302,49 @@ func TestString(t *testing.T) {
 			t.Fatalf("expected: %v, got: %v", basetype.StringInvalid, v.String())
 		}
 	})
+}
+
+func TestValueFormat(t *testing.T) {
+	tt := []struct {
+		value    Value
+		format   string
+		expected string
+	}{
+		{value: Value{}, format: "%v", expected: "<invalid proto.Value>"},
+		{value: String("FIT"), format: "%d", expected: "%!d(string=FIT)"},
+		{value: String("FIT"), format: "%s", expected: "FIT"},
+		{value: String("FIT"), format: "%5s", expected: "  FIT"},
+		{value: String("FIT"), format: "%-5s", expected: "FIT  "},
+		{value: String("FIT"), format: "%v", expected: "FIT"},
+		{value: String("FIT"), format: "%5v", expected: "FIT"},
+		{value: Uint64(11), format: "%d", expected: "11"},
+		{value: Uint64(11), format: "%f", expected: "%!f(uint64=11)"},
+		{value: Uint64(1), format: "%v", expected: "1"},
+		{value: Uint64(1), format: "%+v", expected: "1"},
+		{value: Uint64(1), format: "%#v", expected: "0x1"},
+		{value: Int64(1), format: "%v", expected: "1"},
+		{value: Int64(1), format: "%+v", expected: "1"},
+		{value: Int64(1), format: "%#v", expected: "1"},
+		{value: Float32(10.500001), format: "%.2f", expected: "10.50"},
+		{value: SliceUint64([]uint64{1, 2}), format: "%v", expected: "[1 2]"},
+		{value: SliceUint64([]uint64{1, 2}), format: "%+v", expected: "[1 2]"},
+		{value: SliceUint64([]uint64{1, 2}), format: "%#v", expected: "[]uint64{0x1, 0x2}"},
+		{value: SliceBool([]typedef.Bool{typedef.BoolTrue, typedef.BoolFalse}), format: "%v", expected: "[true false]"},
+		{value: SliceBool([]typedef.Bool{typedef.BoolTrue, typedef.BoolFalse}), format: "%+v", expected: "[true false]"},
+		{value: SliceBool([]typedef.Bool{typedef.BoolTrue, typedef.BoolFalse}), format: "%#v", expected: "[]typedef.Bool{0x1, 0x0}"},
+		{value: SliceBool(nil), format: "%v", expected: "[]"},
+		{value: SliceBool(nil), format: "%#v", expected: "[]typedef.Bool(nil)"},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s(%v)", i, tc.format, tc.value.Any()), func(t *testing.T) {
+			var buf strings.Builder
+			fmt.Fprintf(&buf, tc.format, tc.value)
+			if str := buf.String(); str != tc.expected {
+				t.Fatalf("expected: %q, got: %q", tc.expected, str)
+			}
+		})
+	}
 }
 
 func TestSliceBool(t *testing.T) {


### PR DESCRIPTION
 There are two objectives that this PR solves by implementing [fmt.Formatter](https://pkg.go.dev/fmt#Formatter) for `proto.Field` and `proto.Value`.
1. Reduce gotcha when printing `proto.Value`, as `proto.Value` has the same implementation of [fmt.Stringer](https://pkg.go.dev/fmt#Stringer), but we treat it as a special case method to retrive string value, rather than the underlying value formatted as a string. Example:
    ```go
    val := proto.Uint8(10)
    fmt.Println(val)       // We might expect 10, but it prints "" since it's not a string
    fmt.Println(val.Any()) // Previous workaround, we must call Any() method
    ```

    And thing gets trickier when we print a type containing `proto.Value` such as `proto.Field` or maybe if we print the whole `proto.FIT` itself, as it will trigger `fmt` to call `(proto.Value) String() string` method. Related issue: #520 

    Now we can just do:
    ```go
    val := proto.Uint8(10)
    fmt.Println(val)
    // Output:
    // 10
    ```

2. Enable more verbose printing format for `proto.Field` for debugging purposes. Since `proto.FieldBase` is embedded in `proto.Field` as a pointer, `fmt` prints the pointer address to `proto.FieldBase` instead of its value. In general, we need to know the description of the field such as field number, field name, type etc when printing `proto.Field`. Now, we have it:
    ```go
    field := factory.CreateField(mesgnum.Record, fieldnum.RecordDistance).WithValue(uint32(7))
    
    fmt.Println(field)
    // Output:
    // old: {0x59ee20 7 false}
    // new: {(0x59ee20)(&{distance 5 uint32 uint32 false true 100 0 m [] []}) 7 false}

    fmt.Printf("%+v\n", field)
    // Output:
    // old: {FieldBase:0x59ee20 Value:7 IsExpandedField:false}
    // new: {FieldBase:(0x59ee20)(&{Name:distance Num:5 Type:uint32 BaseType:uint32 Array:false Accumulate:true Scale:100 Offset:0 Units:m Components:[] SubFields:[]}) Value:7 IsExpandedField:false}
    ```
    We keep the pointer address in the formatted string in case it matters.