### PR TITLE
perf(proto): reduce Value's size by one-word

### DIFF
--- a/proto/value.go
+++ b/proto/value.go
@@ -83,38 +83,66 @@ func (t Type) String() string {
 
 // Value is a zero alloc implementation value that hold any FIT protocol value
 // (value of primitive-types or slice of primitive-types).
-//
-// To compare two Values of not known type, compare the results of the Any method.
-// Using == on two Values is disallowed.
 type Value struct {
-	_   [0]func()      // disallow ==
-	num uint64         // num holds either a numeric value or a slice's len.
-	ptr unsafe.Pointer // ptr holds a pointer to slice's data only if it's a slice value.
-	typ Type           // typ holds a Type.
+	num uint64         // num holds either a numeric value or a slice's len + type identifier (5 msb).
+	ptr unsafe.Pointer // ptr holds either a pointer to type identifier or a pointer to slice's data.
 }
 
-// Return the underlying type the Value holds.
-func (v Value) Type() Type { return v.typ }
+// Type identifier only for numeric values.
+// For slices, we use 5 most significant bits (msb) of Value's num for type identifier.
+//
+// The use of pointer arithmetic in "(Value) Type" method depends on:
+//   - The pointer addresses MUST be incremented by 1 byte.
+//   - The order MUST identical with constants Types order.
+var (
+	memptr     [12]byte // we only need the addresses
+	startAddr  = uintptr(unsafe.Pointer(&memptr[TypeInvalid]))
+	ptrBool    = unsafe.Pointer(&memptr[TypeBool])
+	ptrInt8    = unsafe.Pointer(&memptr[TypeInt8])
+	ptrUint8   = unsafe.Pointer(&memptr[TypeUint8])
+	ptrInt16   = unsafe.Pointer(&memptr[TypeInt16])
+	ptrUint16  = unsafe.Pointer(&memptr[TypeUint16])
+	ptrInt32   = unsafe.Pointer(&memptr[TypeInt32])
+	ptrUint32  = unsafe.Pointer(&memptr[TypeUint32])
+	ptrInt64   = unsafe.Pointer(&memptr[TypeInt64])
+	ptrUint64  = unsafe.Pointer(&memptr[TypeUint64])
+	ptrFloat32 = unsafe.Pointer(&memptr[TypeFloat32])
+	ptrFloat64 = unsafe.Pointer(&memptr[TypeFloat64])
+)
 
-// Int8 returns Value as int8, if it's not a valid int8 value, it returns basetype.Sint8Invalid (0x7F).
-func (v Value) Int8() int8 {
-	if v.typ != TypeInt8 {
-		return basetype.Sint8Invalid
+const (
+	vbits  = 5                       // reserved bits for slice's type identifier (max value: 31, large enough to hold a Type)
+	vshift = 64 - vbits              // type identifier bits shifter only for slices.
+	vmask  = math.MaxUint64 >> vbits // mask for retrieving slice's len from Value's num, no slice's len exceed this value.
+)
+
+// Return the underlying type the Value holds.
+func (v Value) Type() Type {
+	if p := uintptr(v.ptr); p >= startAddr && p <= uintptr(ptrFloat64) {
+		return Type(p - startAddr)
 	}
-	return int8(v.num)
+	return Type(v.num >> vshift)
 }
 
 // Bool returns Value as typedef.Bool, if it's not a valid typedef.Bool value, it returns typedef.BoolInvalid.
 func (v Value) Bool() typedef.Bool {
-	if v.typ != TypeBool {
+	if v.ptr != ptrBool {
 		return typedef.BoolInvalid
 	}
 	return typedef.Bool(v.num)
 }
 
+// Int8 returns Value as int8, if it's not a valid int8 value, it returns basetype.Sint8Invalid (0x7F).
+func (v Value) Int8() int8 {
+	if v.ptr != ptrInt8 {
+		return basetype.Sint8Invalid
+	}
+	return int8(v.num)
+}
+
 // Uint8 returns Value as uint8, if it's not a valid uint8 value, it returns basetype.Uint8Invalid (0xFF).
 func (v Value) Uint8() uint8 {
-	if v.typ != TypeUint8 {
+	if v.ptr != ptrUint8 {
 		return basetype.Uint8Invalid
 	}
 	return uint8(v.num)
@@ -122,7 +150,7 @@ func (v Value) Uint8() uint8 {
 
 // Uint8z returns Value as uint8, if it's not a valid uint8 value, it returns basetype.Uint8zInvalid (0).
 func (v Value) Uint8z() uint8 {
-	if v.typ != TypeUint8 {
+	if v.ptr != ptrUint8 {
 		return basetype.Uint8zInvalid
 	}
 	return uint8(v.num)
@@ -130,7 +158,7 @@ func (v Value) Uint8z() uint8 {
 
 // Int16 returns Value as int16, if it's not a valid int16 value, it returns basetype.Sint16Invalid (0x7FFF).
 func (v Value) Int16() int16 {
-	if v.typ != TypeInt16 {
+	if v.ptr != ptrInt16 {
 		return basetype.Sint16Invalid
 	}
 	return int16(v.num)
@@ -138,7 +166,7 @@ func (v Value) Int16() int16 {
 
 // Uint16 returns Value as uint16, if it's not a valid uint16 value, it returns basetype.Uint16Invalid (0xFFFF).
 func (v Value) Uint16() uint16 {
-	if v.typ != TypeUint16 {
+	if v.ptr != ptrUint16 {
 		return basetype.Uint16Invalid
 	}
 	return uint16(v.num)
@@ -146,7 +174,7 @@ func (v Value) Uint16() uint16 {
 
 // Uint16z returns Value as uint16, if it's not a valid uint16 value, it returns basetype.Uint16zInvalid (0).
 func (v Value) Uint16z() uint16 {
-	if v.typ != TypeUint16 {
+	if v.ptr != ptrUint16 {
 		return basetype.Uint16zInvalid
 	}
 	return uint16(v.num)
@@ -154,7 +182,7 @@ func (v Value) Uint16z() uint16 {
 
 // Int32 returns Value as int32, if it's not a valid int32 value, it returns basetype.Sint32Invalid (0x7FFFFFFF).
 func (v Value) Int32() int32 {
-	if v.typ != TypeInt32 {
+	if v.ptr != ptrInt32 {
 		return basetype.Sint32Invalid
 	}
 	return int32(v.num)
@@ -162,7 +190,7 @@ func (v Value) Int32() int32 {
 
 // Uint32 returns Value as uint32, if it's not a valid uint32 value, it returns basetype.Uint32Invalid (0xFFFFFFFF).
 func (v Value) Uint32() uint32 {
-	if v.typ != TypeUint32 {
+	if v.ptr != ptrUint32 {
 		return basetype.Uint32Invalid
 	}
 	return uint32(v.num)
@@ -170,7 +198,7 @@ func (v Value) Uint32() uint32 {
 
 // Uint32z returns Value as uint32, if it's not a valid uint32 value, it returns basetype.Uint32zInvalid (0).
 func (v Value) Uint32z() uint32 {
-	if v.typ != TypeUint32 {
+	if v.ptr != ptrUint32 {
 		return basetype.Uint32zInvalid
 	}
 	return uint32(v.num)
@@ -178,7 +206,7 @@ func (v Value) Uint32z() uint32 {
 
 // Int64 returns Value as int64, if it's not a valid int64 value, it returns basetype.Sint64Invalid (0x7FFFFFFFFFFFFFFF).
 func (v Value) Int64() int64 {
-	if v.typ != TypeInt64 {
+	if v.ptr != ptrInt64 {
 		return basetype.Sint64Invalid
 	}
 	return int64(v.num)
@@ -186,7 +214,7 @@ func (v Value) Int64() int64 {
 
 // Uint64 returns Value as uint64, if it's not a valid uint64 value, it returns basetype.Uint64Invalid (0xFFFFFFFFFFFFFFFF).
 func (v Value) Uint64() uint64 {
-	if v.typ != TypeUint64 {
+	if v.ptr != ptrUint64 {
 		return basetype.Uint64Invalid
 	}
 	return v.num
@@ -194,7 +222,7 @@ func (v Value) Uint64() uint64 {
 
 // Uint64z returns Value as uint64, if it's not a valid uint64 value, it returns basetype.Uint64Invalid (0).
 func (v Value) Uint64z() uint64 {
-	if v.typ != TypeUint64 {
+	if v.ptr != ptrUint64 {
 		return basetype.Uint64zInvalid
 	}
 	return uint64(v.num)
@@ -202,7 +230,7 @@ func (v Value) Uint64z() uint64 {
 
 // Float32 returns Value as float32, if it's not a valid float32 value, it returns basetype.Float32Invalid (0xFFFFFFFF) in float32 value.
 func (v Value) Float32() float32 {
-	if v.typ != TypeFloat32 {
+	if v.ptr != ptrFloat32 {
 		return math.Float32frombits(basetype.Float32Invalid)
 	}
 	return math.Float32frombits(uint32(v.num))
@@ -210,7 +238,7 @@ func (v Value) Float32() float32 {
 
 // Float64 returns Value as float64, if it's not a valid float64 value, it returns basetype.Float64Invalid (0xFFFFFFFFFFFFFFFF) in float64 value.
 func (v Value) Float64() float64 {
-	if v.typ != TypeFloat64 {
+	if v.ptr != ptrFloat64 {
 		return math.Float64frombits(basetype.Float64Invalid)
 	}
 	return math.Float64frombits(v.num)
@@ -219,10 +247,10 @@ func (v Value) Float64() float64 {
 // String returns Value as string, if it's not a valid string value, it returns basetype.StringInvalid.
 // This should not be treated as a Go's String method, use Any() if you want to print the underlying value.
 func (v Value) String() string {
-	if v.typ != TypeString {
+	if Type(v.num>>vshift) != TypeString {
 		return basetype.StringInvalid
 	}
-	return unsafe.String((*byte)(v.ptr), v.num)
+	return unsafe.String((*byte)(v.ptr), v.num&vmask)
 }
 
 var _ fmt.Formatter = (*Value)(nil)
@@ -231,7 +259,7 @@ var _ fmt.Formatter = (*Value)(nil)
 // is used to return string value, rather than the Value formatted as a string.
 func (v Value) Format(p fmt.State, verb rune) {
 	switch {
-	case v.typ == TypeInvalid:
+	case v == Value{}:
 		fmt.Fprintf(p, "<invalid proto.Value>")
 	case verb != 'v':
 		fmt.Fprintf(p, fmt.FormatString(p, verb), v.Any())
@@ -246,126 +274,126 @@ func (v Value) Format(p fmt.State, verb rune) {
 // The caller takes ownership of the returned value, so Value should no longer be used after this call,
 // except the returned value is copied and the copied value is used instead.
 func (v Value) SliceBool() []typedef.Bool {
-	if v.typ != TypeSliceBool {
+	if Type(v.num>>vshift) != TypeSliceBool {
 		return nil
 	}
-	return unsafe.Slice((*typedef.Bool)(v.ptr), v.num)
+	return unsafe.Slice((*typedef.Bool)(v.ptr), v.num&vmask)
 }
 
 // SliceInt8 returns Value as []int8, if it's not a valid []int8 value, it returns nil.
 // The caller takes ownership of the returned value, so Value should no longer be used after this call,
 // except the returned value is copied and the copied value is used instead.
 func (v Value) SliceInt8() []int8 {
-	if v.typ != TypeSliceInt8 {
+	if Type(v.num>>vshift) != TypeSliceInt8 {
 		return nil
 	}
-	return unsafe.Slice((*int8)(v.ptr), v.num)
+	return unsafe.Slice((*int8)(v.ptr), v.num&vmask)
 }
 
 // SliceUint8 returns Value as []uint8, if it's not a valid []uint8 value, it returns nil.
 // The caller takes ownership of the returned value, so Value should no longer be used after this call,
 // except the returned value is copied and the copied value is used instead.
 func (v Value) SliceUint8() []uint8 {
-	if v.typ != TypeSliceUint8 {
+	if Type(v.num>>vshift) != TypeSliceUint8 {
 		return nil
 	}
-	return unsafe.Slice((*uint8)(v.ptr), v.num)
+	return unsafe.Slice((*uint8)(v.ptr), v.num&vmask)
 }
 
 // SliceInt16 returns Value as []int16, if it's not a valid []int16 value, it returns nil.
 // The caller takes ownership of the returned value, so Value should no longer be used after this call,
 // except the returned value is copied and the copied value is used instead.
 func (v Value) SliceInt16() []int16 {
-	if v.typ != TypeSliceInt16 {
+	if Type(v.num>>vshift) != TypeSliceInt16 {
 		return nil
 	}
-	return unsafe.Slice((*int16)(v.ptr), v.num)
+	return unsafe.Slice((*int16)(v.ptr), v.num&vmask)
 }
 
 // SliceUint16 returns Value as []uint16, if it's not a valid []uint16 value, it returns nil.
 // The caller takes ownership of the returned value, so Value should no longer be used after this call,
 // except the returned value is copied and the copied value is used instead.
 func (v Value) SliceUint16() []uint16 {
-	if v.typ != TypeSliceUint16 {
+	if Type(v.num>>vshift) != TypeSliceUint16 {
 		return nil
 	}
-	return unsafe.Slice((*uint16)(v.ptr), v.num)
+	return unsafe.Slice((*uint16)(v.ptr), v.num&vmask)
 }
 
 // SliceInt32 returns Value as []int32, if it's not a valid []int32 value, it returns nil.
 // The caller takes ownership of the returned value, so Value should no longer be used after this call,
 // except the returned value is copied and the copied value is used instead.
 func (v Value) SliceInt32() []int32 {
-	if v.typ != TypeSliceInt32 {
+	if Type(v.num>>vshift) != TypeSliceInt32 {
 		return nil
 	}
-	return unsafe.Slice((*int32)(v.ptr), v.num)
+	return unsafe.Slice((*int32)(v.ptr), v.num&vmask)
 }
 
 // SliceUint32 returns Value as []uint32, if it's not a valid []uint32 value, it returns nil.
 // The caller takes ownership of the returned value, so Value should no longer be used after this call,
 // except the returned value is copied and the copied value is used instead.
 func (v Value) SliceUint32() []uint32 {
-	if v.typ != TypeSliceUint32 {
+	if Type(v.num>>vshift) != TypeSliceUint32 {
 		return nil
 	}
-	return unsafe.Slice((*uint32)(v.ptr), v.num)
+	return unsafe.Slice((*uint32)(v.ptr), v.num&vmask)
 }
 
 // SliceInt64 returns Value as []int64, if it's not a valid []int64 value, it returns nil.
 // The caller takes ownership of the returned value, so Value should no longer be used after this call,
 // except the returned value is copied and the copied value is used instead.
 func (v Value) SliceInt64() []int64 {
-	if v.typ != TypeSliceInt64 {
+	if Type(v.num>>vshift) != TypeSliceInt64 {
 		return nil
 	}
-	return unsafe.Slice((*int64)(v.ptr), v.num)
+	return unsafe.Slice((*int64)(v.ptr), v.num&vmask)
 }
 
 // SliceUint64 returns Value as []uint64, if it's not a valid []uint64 value, it returns nil.
 // The caller takes ownership of the returned value, so Value should no longer be used after this call,
 // except the returned value is copied and the copied value is used instead.
 func (v Value) SliceUint64() []uint64 {
-	if v.typ != TypeSliceUint64 {
+	if Type(v.num>>vshift) != TypeSliceUint64 {
 		return nil
 	}
-	return unsafe.Slice((*uint64)(v.ptr), v.num)
+	return unsafe.Slice((*uint64)(v.ptr), v.num&vmask)
 }
 
 // SliceFloat32 returns Value as []float32, if it's not a valid []float32 value, it returns nil.
 // The caller takes ownership of the returned value, so Value should no longer be used after this call,
 // except the returned value is copied and the copied value is used instead.
 func (v Value) SliceFloat32() []float32 {
-	if v.typ != TypeSliceFloat32 {
+	if Type(v.num>>vshift) != TypeSliceFloat32 {
 		return nil
 	}
-	return unsafe.Slice((*float32)(v.ptr), v.num)
+	return unsafe.Slice((*float32)(v.ptr), v.num&vmask)
 }
 
 // SliceFloat64 returns Value as []float64, if it's not a valid []float64 value, it returns nil.
 // The caller takes ownership of the returned value, so Value should no longer be used after this call,
 // except the returned value is copied and the copied value is used instead.
 func (v Value) SliceFloat64() []float64 {
-	if v.typ != TypeSliceFloat64 {
+	if Type(v.num>>vshift) != TypeSliceFloat64 {
 		return nil
 	}
-	return unsafe.Slice((*float64)(v.ptr), v.num)
+	return unsafe.Slice((*float64)(v.ptr), v.num&vmask)
 }
 
 // SliceString returns Value as []string, if it's not a valid []string value, it returns nil.
 // The caller takes ownership of the returned value, so Value should no longer be used after this call,
 // except the returned value is copied and the copied value is used instead.
 func (v Value) SliceString() []string {
-	if v.typ != TypeSliceString {
+	if Type(v.num>>vshift) != TypeSliceString {
 		return nil
 	}
-	return unsafe.Slice((*string)(v.ptr), v.num)
+	return unsafe.Slice((*string)(v.ptr), v.num&vmask)
 }
 
 // Any returns Value's underlying value. If the underlying value is a slice, the caller takes ownership of that slice value,
 // so Value should no longer be used after this call, except the returned value is copied and the copied value is used instead.
 func (v Value) Any() any {
-	switch v.typ {
+	switch v.Type() {
 	case TypeBool:
 		return v.Bool()
 	case TypeInt8:
@@ -420,7 +448,7 @@ func (v Value) Any() any {
 
 // Align checks whether Value's type is align with given basetype.
 func (v Value) Align(t basetype.BaseType) bool {
-	switch v.typ {
+	switch v.Type() {
 	case TypeBool, TypeSliceBool:
 		return t == basetype.Enum
 	case TypeInt8, TypeSliceInt8:
@@ -457,7 +485,7 @@ func (v Value) Align(t basetype.BaseType) bool {
 func (v Value) Valid(t basetype.BaseType) bool {
 	var invalidCount int
 
-	switch v.typ {
+	switch v.Type() {
 	case TypeBool:
 		return v.num < 2 // Only 0 (false) and 1 (true) is valid
 	case TypeInt8:
@@ -641,122 +669,122 @@ func Bool(v typedef.Bool) Value {
 	if v > 1 {
 		num = uint64(typedef.BoolInvalid)
 	}
-	return Value{num: num, typ: TypeBool}
+	return Value{num: num, ptr: ptrBool}
 }
 
 // Int8 converts int8 as Value.
 func Int8(v int8) Value {
-	return Value{num: uint64(v), typ: TypeInt8}
+	return Value{num: uint64(v), ptr: ptrInt8}
 }
 
 // Uint8 converts uint8 as Value.
 func Uint8(v uint8) Value {
-	return Value{num: uint64(v), typ: TypeUint8}
+	return Value{num: uint64(v), ptr: ptrUint8}
 }
 
 // Int16 converts int16 as Value.
 func Int16(v int16) Value {
-	return Value{num: uint64(v), typ: TypeInt16}
+	return Value{num: uint64(v), ptr: ptrInt16}
 }
 
 // Uint16 converts uint16 as Value.
 func Uint16(v uint16) Value {
-	return Value{num: uint64(v), typ: TypeUint16}
+	return Value{num: uint64(v), ptr: ptrUint16}
 }
 
 // Int32 converts int32 as Value.
 func Int32(v int32) Value {
-	return Value{num: uint64(v), typ: TypeInt32}
+	return Value{num: uint64(v), ptr: ptrInt32}
 }
 
 // Uint32 converts uint32 as Value.
 func Uint32(v uint32) Value {
-	return Value{num: uint64(v), typ: TypeUint32}
+	return Value{num: uint64(v), ptr: ptrUint32}
 }
 
 // Int64 converts int64 as Value.
 func Int64(v int64) Value {
-	return Value{num: uint64(v), typ: TypeInt64}
+	return Value{num: uint64(v), ptr: ptrInt64}
 }
 
 // Uint64 converts uint64 as Value.
 func Uint64(v uint64) Value {
-	return Value{num: v, typ: TypeUint64}
+	return Value{num: v, ptr: ptrUint64}
 }
 
 // Float32 converts float32 as Value.
 func Float32(v float32) Value {
-	return Value{num: uint64(math.Float32bits(v)), typ: TypeFloat32}
+	return Value{num: uint64(math.Float32bits(v)), ptr: ptrFloat32}
 }
 
 // Float64 converts float64 as Value.
 func Float64(v float64) Value {
-	return Value{num: math.Float64bits(v), typ: TypeFloat64}
+	return Value{num: math.Float64bits(v), ptr: ptrFloat64}
 }
 
 // String converts string as Value.
 func String(v string) Value {
-	return Value{num: uint64(len(v)), typ: TypeString, ptr: unsafe.Pointer(unsafe.StringData(v))}
+	return Value{num: uint64(TypeString)<<vshift | uint64(len(v)), ptr: unsafe.Pointer(unsafe.StringData(v))}
 }
 
 // SliceBool converts []typedef.Bool as Value. This takes ownership of s, and the caller should not use s after this call.
 func SliceBool(s []typedef.Bool) Value {
-	return Value{num: uint64(len(s)), typ: TypeSliceBool, ptr: unsafe.Pointer(unsafe.SliceData(s))}
+	return Value{num: uint64(TypeSliceBool)<<vshift | uint64(len(s)), ptr: unsafe.Pointer(unsafe.SliceData(s))}
 }
 
 // SliceInt8 converts []int8 as Value. This takes ownership of s, and the caller should not use s after this call.
 func SliceInt8[S []E, E ~int8](s S) Value {
-	return Value{num: uint64(len(s)), typ: TypeSliceInt8, ptr: unsafe.Pointer(unsafe.SliceData(s))}
+	return Value{num: uint64(TypeSliceInt8)<<vshift | uint64(len(s)), ptr: unsafe.Pointer(unsafe.SliceData(s))}
 }
 
 // SliceUint8 converts []uint8 as Value. This takes ownership of s, and the caller should not use s after this call.
 func SliceUint8[S []E, E ~uint8](s S) Value {
-	return Value{num: uint64(len(s)), typ: TypeSliceUint8, ptr: unsafe.Pointer(unsafe.SliceData(s))}
+	return Value{num: uint64(TypeSliceUint8)<<vshift | uint64(len(s)), ptr: unsafe.Pointer(unsafe.SliceData(s))}
 }
 
 // SliceInt16 converts []int16 as Value. This takes ownership of s, and the caller should not use s after this call.
 func SliceInt16[S []E, E ~int16](s S) Value {
-	return Value{num: uint64(len(s)), typ: TypeSliceInt16, ptr: unsafe.Pointer(unsafe.SliceData(s))}
+	return Value{num: uint64(TypeSliceInt16)<<vshift | uint64(len(s)), ptr: unsafe.Pointer(unsafe.SliceData(s))}
 }
 
 // SliceUint16 converts []uint16 as Value. This takes ownership of s, and the caller should not use s after this call.
 func SliceUint16[S []E, E ~uint16](s S) Value {
-	return Value{num: uint64(len(s)), typ: TypeSliceUint16, ptr: unsafe.Pointer(unsafe.SliceData(s))}
+	return Value{num: uint64(TypeSliceUint16)<<vshift | uint64(len(s)), ptr: unsafe.Pointer(unsafe.SliceData(s))}
 }
 
 // SliceInt32 converts []int32 as Value. This takes ownership of s, and the caller should not use s after this call.
 func SliceInt32[S []E, E ~int32](s S) Value {
-	return Value{num: uint64(len(s)), typ: TypeSliceInt32, ptr: unsafe.Pointer(unsafe.SliceData(s))}
+	return Value{num: uint64(TypeSliceInt32)<<vshift | uint64(len(s)), ptr: unsafe.Pointer(unsafe.SliceData(s))}
 }
 
 // SliceUint32 converts []uint32 as Value. This takes ownership of s, and the caller should not use s after this call.
 func SliceUint32[S []E, E ~uint32](s S) Value {
-	return Value{num: uint64(len(s)), typ: TypeSliceUint32, ptr: unsafe.Pointer(unsafe.SliceData(s))}
+	return Value{num: uint64(TypeSliceUint32)<<vshift | uint64(len(s)), ptr: unsafe.Pointer(unsafe.SliceData(s))}
 }
 
 // SliceInt64 converts []int64 as Value. This takes ownership of s, and the caller should not use s after this call.
 func SliceInt64[S []E, E ~int64](s S) Value {
-	return Value{num: uint64(len(s)), typ: TypeSliceInt64, ptr: unsafe.Pointer(unsafe.SliceData(s))}
+	return Value{num: uint64(TypeSliceInt64)<<vshift | uint64(len(s)), ptr: unsafe.Pointer(unsafe.SliceData(s))}
 }
 
 // SliceUint64 converts []uint64 as Value. This takes ownership of s, and the caller should not use s after this call.
 func SliceUint64[S []E, E ~uint64](s S) Value {
-	return Value{num: uint64(len(s)), typ: TypeSliceUint64, ptr: unsafe.Pointer(unsafe.SliceData(s))}
+	return Value{num: uint64(TypeSliceUint64)<<vshift | uint64(len(s)), ptr: unsafe.Pointer(unsafe.SliceData(s))}
 }
 
 // SliceFloat32 converts []float32 as Value. This takes ownership of s, and the caller should not use s after this call.
 func SliceFloat32[S []E, E ~float32](s S) Value {
-	return Value{num: uint64(len(s)), typ: TypeSliceFloat32, ptr: unsafe.Pointer(unsafe.SliceData(s))}
+	return Value{num: uint64(TypeSliceFloat32)<<vshift | uint64(len(s)), ptr: unsafe.Pointer(unsafe.SliceData(s))}
 }
 
 // SliceFloat64 converts []float64 as Value. This takes ownership of s, and the caller should not use s after this call.
 func SliceFloat64[S []E, E ~float64](s S) Value {
-	return Value{num: uint64(len(s)), typ: TypeSliceFloat64, ptr: unsafe.Pointer(unsafe.SliceData(s))}
+	return Value{num: uint64(TypeSliceFloat64)<<vshift | uint64(len(s)), ptr: unsafe.Pointer(unsafe.SliceData(s))}
 }
 
 // SliceString converts []string as Value. This takes ownership of s, and the caller should not use s after this call.
 func SliceString[S []E, E ~string](s S) Value {
-	return Value{num: uint64(len(s)), typ: TypeSliceString, ptr: unsafe.Pointer(unsafe.SliceData(s))}
+	return Value{num: uint64(TypeSliceString)<<vshift | uint64(len(s)), ptr: unsafe.Pointer(unsafe.SliceData(s))}
 }
 
 // Any converts any value into Value. If the given v is not a primitive-type value or
@@ -928,7 +956,7 @@ var sizes = [...]int{
 
 // Sizeof returns the size of val in bytes. For every string in Value, if the last index of the string is not '\x00', size += 1.
 func Sizeof(val Value) int {
-	switch val.typ {
+	switch typ := val.Type(); typ {
 	case TypeString:
 		s := val.String()
 		n := len(s)
@@ -937,27 +965,27 @@ func Sizeof(val Value) int {
 		}
 		return n * sizes[TypeString]
 	case TypeSliceBool:
-		return int(val.num) * sizes[TypeBool]
+		return int(val.num&vmask) * sizes[TypeBool]
 	case TypeSliceInt8:
-		return int(val.num) * sizes[TypeInt8]
+		return int(val.num&vmask) * sizes[TypeInt8]
 	case TypeSliceUint8:
-		return int(val.num) * sizes[TypeUint8]
+		return int(val.num&vmask) * sizes[TypeUint8]
 	case TypeSliceInt16:
-		return int(val.num) * sizes[TypeInt16]
+		return int(val.num&vmask) * sizes[TypeInt16]
 	case TypeSliceUint16:
-		return int(val.num) * sizes[TypeUint16]
+		return int(val.num&vmask) * sizes[TypeUint16]
 	case TypeSliceInt32:
-		return int(val.num) * sizes[TypeInt32]
+		return int(val.num&vmask) * sizes[TypeInt32]
 	case TypeSliceUint32:
-		return int(val.num) * sizes[TypeUint32]
+		return int(val.num&vmask) * sizes[TypeUint32]
 	case TypeSliceInt64:
-		return int(val.num) * sizes[TypeInt64]
+		return int(val.num&vmask) * sizes[TypeInt64]
 	case TypeSliceUint64:
-		return int(val.num) * sizes[TypeUint64]
+		return int(val.num&vmask) * sizes[TypeUint64]
 	case TypeSliceFloat32:
-		return int(val.num) * sizes[TypeFloat32]
+		return int(val.num&vmask) * sizes[TypeFloat32]
 	case TypeSliceFloat64:
-		return int(val.num) * sizes[TypeFloat64]
+		return int(val.num&vmask) * sizes[TypeFloat64]
 	case TypeSliceString:
 		vs := val.SliceString()
 		var size int
@@ -973,6 +1001,6 @@ func Sizeof(val Value) int {
 		}
 		return size * sizes[TypeString]
 	default:
-		return sizes[val.typ]
+		return sizes[typ]
 	}
 }

--- a/proto/value_marshal.go
+++ b/proto/value_marshal.go
@@ -16,7 +16,7 @@ const ErrTypeNotSupported = errorString("type is not supported")
 // If arch is 0, marshal in Little-Endian, otherwise marshal in Big-Endian.
 func (v Value) MarshalAppend(b []byte, arch byte) ([]byte, error) {
 	// NOTE: The size of the resulting bytes should align with Sizeof.
-	switch v.typ {
+	switch v.Type() {
 	case TypeBool:
 		val := v.Bool()
 		if val > 1 {

--- a/proto/value_test.go
+++ b/proto/value_test.go
@@ -32,6 +32,47 @@ func TestTypeString(t *testing.T) {
 	}
 }
 
+func TestValueType(t *testing.T) {
+	tt := []struct {
+		value    Value
+		expected Type
+	}{
+		{value: Value{}, expected: TypeInvalid},
+		{value: Bool(typedef.BoolTrue), expected: TypeBool},
+		{value: Int8(1), expected: TypeInt8},
+		{value: Uint8(1), expected: TypeUint8},
+		{value: Int16(1), expected: TypeInt16},
+		{value: Uint16(1), expected: TypeUint16},
+		{value: Int32(1), expected: TypeInt32},
+		{value: Uint32(1), expected: TypeUint32},
+		{value: Int64(1), expected: TypeInt64},
+		{value: Uint64(1), expected: TypeUint64},
+		{value: Float32(1), expected: TypeFloat32},
+		{value: Float64(1), expected: TypeFloat64},
+		{value: String("FIT"), expected: TypeString},
+		{value: SliceBool([]typedef.Bool{typedef.BoolTrue}), expected: TypeSliceBool},
+		{value: SliceInt8([]int8{1}), expected: TypeSliceInt8},
+		{value: SliceUint8([]uint8{1}), expected: TypeSliceUint8},
+		{value: SliceInt16([]int16{1}), expected: TypeSliceInt16},
+		{value: SliceUint16([]uint16{1}), expected: TypeSliceUint16},
+		{value: SliceInt32([]int32{1}), expected: TypeSliceInt32},
+		{value: SliceUint32([]uint32{1}), expected: TypeSliceUint32},
+		{value: SliceInt64([]int64{1}), expected: TypeSliceInt64},
+		{value: SliceUint64([]uint64{1}), expected: TypeSliceUint64},
+		{value: SliceFloat32([]float32{1}), expected: TypeSliceFloat32},
+		{value: SliceFloat64([]float64{1}), expected: TypeSliceFloat64},
+		{value: SliceString([]string{"FIT"}), expected: TypeSliceString},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.expected), func(t *testing.T) {
+			if typ := tc.value.Type(); typ != tc.expected {
+				t.Fatalf("expected: %s, got: %s", tc.expected, typ)
+			}
+		})
+	}
+}
+
 func TestBool(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		input := typedef.BoolTrue
@@ -938,8 +979,8 @@ func TestValueAlign(t *testing.T) {
 		{value: SliceInt8([]int8{1, 2, 3}), baseType: basetype.Sint8, expected: true},
 	}
 
-	for _, tc := range tt {
-		t.Run(fmt.Sprintf("%v (%T): %s", tc.value, tc.value, tc.baseType), func(t *testing.T) {
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("[%d] %v (%T): %s", i, tc.value, tc.value, tc.baseType), func(t *testing.T) {
 			if align := tc.value.Align(tc.baseType); align != tc.expected {
 				t.Fatalf("expected: %t, got %t", tc.expected, align)
 			}
@@ -1019,7 +1060,6 @@ func TestLen(t *testing.T) {
 		sizeInBytes int
 	}{
 		{value: Value{}, sizeInBytes: 0},
-		{value: Value{typ: TypeInvalid}, sizeInBytes: 0},
 		{value: Bool(typedef.BoolTrue), sizeInBytes: 1},
 		{value: Int8(10), sizeInBytes: 1},
 		{value: Uint8(10), sizeInBytes: 1},


### PR DESCRIPTION
In general, I value simplicity over cleverness. However, in this case, I trade some simplicity for a bit of cleverness to gain a considerable performance boost. Here is my justification:

In the previous implementation, we need one more 1-byte field, `typ`, just for storing a type, resulting _one-word_ penalty for every single `Value` we have. In 64-bit machine, _one-word_ is 8 bytes, so the size of the `Value` will be 8 + 8 + (1 + 7 padding byte) = 24 bytes. If we use this SDK to handle a really large fit files, such as from a ultra-long-run or ultra-triathlon race, the _one-word_ penalty will be significantly multiplied as we have way more messages. And imagine when this SDK is used to handle multiple fit files at once.
```go
// Struct before, size 24 bytes.
type Value struct { 
 	_   [0]func()
 	num uint64
 	ptr unsafe.Pointer 
 	typ Type // <- Solely for storing the type
 } 
```

We only have [25 types](https://github.com/muktihari/fit/blob/eea67ce938eddcdf6a93ab01755b88b9a4d4232f/proto/value.go#L19-L47) for Value (extremely unlikely that we ever need to add more types), the nearest bits to hold such value is 5 bits (can hold up to 31 number). It's not even 1 byte (8 bits) yet we "waste" 8 bytes for it due to padding. So I'm thinking if we can squeeze the type identifier into `num` field instead for a slice and use pointer as an identifier for a numeric value, so we can reduce Value's size from 24 bytes to 16 bytes in 64-bit machine. 

I take a measurement from two perspectives to ensure that the changes will be reasonable and safe:

1. From safety perspective, there are two things to consider:
    1. From the FIT spec, the maximum size of value in FIT file is only 255 so we actually need only 1 byte to store slice's len yet we have uint64 (8 bytes) to hold it, slipping 1 byte in it to store a type should be okay. 
    2. From the language side (Go), there is also a limit of how many item we can store in a slice. Try run this https://go.dev/play/p/0NfG6S8XumE and it will panic (`panic: runtime error: makeslice: len out of range`). So even if people try to use Value to hold more than 255 bytes value, this can still hold huge number of items before the compiler will stop them from doing it. So again, reducing 1 byte from `num` field is okay. 

2. From code complexity perspective, the change is considerably minimal, only some bits manipulation over here and there. We use bits manipulation everywhere anyway since we handle encoding.

The result of the new Value struct with a small additional change:
```go
// Struct after, size 16 bytes.
type Value struct { 
 	num uint64
 	ptr unsafe.Pointer 
 } 
```

You might notice that now comparing two value is allowed. My justification is having two same values pointing to the same pointer should be an identical value.

#### Benchmark
The goal of this change is to enhance performance with the trade-off being more complex than before, so without a significant gain I wouldn't open this PR. 

We have fair amount of improvement, especially in memory usage. It seems like there is +6% CPU overhead for encoding protocol messages, however, it doesn't take a consideration of the creation of messages and holding it in memory, so this is actually negligible.
```js
goos: linux; goarch: amd64; pkg: benchfit
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                           │   old.txt    │               new.txt                │
                           │    sec/op    │    sec/op     vs base                │
Decode/muktihari/fit_raw-4   131.7m ±  4%   122.1m ± 10%        ~ (p=0.105 n=10)
Decode/muktihari/fit-4       107.0m ± 13%   100.2m ± 12%   -6.32% (p=0.029 n=10)
Encode/muktihari/fit_raw-4   46.90m ±  2%   49.83m ±  8%   +6.25% (p=0.000 n=10)
Encode/muktihari/fit-4       126.3m ±  2%   112.4m ±  3%  -10.99% (p=0.000 n=10)
geomean                      95.57m         90.99m         -4.80%

                           │   old.txt    │               new.txt                │
                           │     B/op     │     B/op      vs base                │
Decode/muktihari/fit_raw-4   73.52Mi ± 0%   64.36Mi ± 0%  -12.46% (p=0.000 n=10)
Decode/muktihari/fit-4       41.02Mi ± 0%   41.00Mi ± 0%   -0.05% (p=0.000 n=10)
Encode/muktihari/fit_raw-4   7.525Ki ± 0%   7.525Ki ± 0%        ~ (p=1.000 n=10)
Encode/muktihari/fit-4       41.97Mi ± 0%   32.82Mi ± 0%  -21.81% (p=0.000 n=10)
geomean                      5.523Mi        5.023Mi        -9.05%

                           │   old.txt   │               new.txt                │
                           │  allocs/op  │  allocs/op   vs base                 │
Decode/muktihari/fit_raw-4   100.0k ± 0%   100.0k ± 0%       ~ (p=1.000 n=10)
Decode/muktihari/fit-4       100.2k ± 0%   100.2k ± 0%       ~ (p=0.547 n=10)
Encode/muktihari/fit_raw-4    15.00 ± 0%    15.00 ± 0%       ~ (p=1.000 n=10) ¹
Encode/muktihari/fit-4       100.0k ± 0%   100.0k ± 0%       ~ (p=1.000 n=10) ¹
geomean                      11.07k        11.07k       -0.00%
¹ all samples are equal

```