### PR TITLE
revert(proto): disallow Value equality

### DIFF
--- a/proto/value.go
+++ b/proto/value.go
@@ -84,6 +84,7 @@ func (t Type) String() string {
 // Value is a zero alloc implementation value that hold any FIT protocol value
 // (value of primitive-types or slice of primitive-types).
 type Value struct {
+	_   [0]func()      // disallow ==
 	num uint64         // num holds either a numeric value or a slice's len + type identifier (5 msb).
 	ptr unsafe.Pointer // ptr holds either a pointer to type identifier or a pointer to slice's data.
 }
@@ -260,7 +261,7 @@ var _ fmt.Formatter = (*Value)(nil)
 // is used to return string value, rather than the Value formatted as a string.
 func (v Value) Format(p fmt.State, verb rune) {
 	switch {
-	case v == Value{}:
+	case v.num == 0 && v.ptr == nil:
 		fmt.Fprintf(p, "<invalid proto.Value>")
 	case verb != 'v':
 		fmt.Fprintf(p, fmt.FormatString(p, verb), v.Any())


### PR DESCRIPTION
This is not a clean revert.

In #522, we allow Value equality, however, this turn out to be wrong decision, we expect the equality to cover the value equality as well, but we don't deliver it with previous changes:

If we do this, it will result different behavior:
```go
var a = "abcd"
var b = "bcd"
aa := String(a[1:]) // "bcd"
bb := String(b)     // "bcd"
fmt.Println(aa == bb)             // false 
fmt.Println(aa.Any() == bb.Any()) // true
```
The equality return `false` since we only compare the address and the len, meanwhile, if we compare the actual value, it should return true.

Let's revert to previous behavior to disallow such equality.