### PR TITLE
refactor(crc16)!: simplify code

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -199,7 +199,7 @@ func New(r io.Reader, opts ...Option) *Decoder {
 	d := &Decoder{
 		readBuffer:  new(readBuffer),
 		accumulator: NewAccumulator(),
-		crc16:       crc16.New(nil),
+		crc16:       crc16.New(),
 	}
 	d.Reset(r, opts...)
 	return d

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -489,7 +489,7 @@ func TestCheckIntegrity(t *testing.T) {
 					DataType:        proto.DataTypeFIT,
 				}
 				b, _ := h.MarshalAppend(nil)
-				crc := crc16.New(nil)
+				crc := crc16.New()
 				crc.Write(b[:12])
 				binary.LittleEndian.PutUint16(b[12:14], crc.Sum16())
 				return bytes.NewReader(b)
@@ -654,7 +654,7 @@ func createFitForTest() (proto.FIT, []byte) {
 	bytesbuffer.Write(b)
 
 	// Marshal and calculate data size and crc checksum
-	crc16checker := crc16.New(nil)
+	crc16checker := crc16.New()
 	for i := range fit.Messages {
 		mesg := fit.Messages[i]
 		mesgDef, _ := proto.NewMessageDefinition(&mesg)

--- a/decoder/raw_test.go
+++ b/decoder/raw_test.go
@@ -32,7 +32,7 @@ var fnDecodeRawErr = func(flag RawFlag, b []byte) error {
 
 func TestRawDecoderDecode(t *testing.T) {
 	_, buf := createFitForTest()
-	hash16 := crc16.New(nil)
+	hash16 := crc16.New()
 
 	tt := []struct {
 		name string

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -847,7 +847,7 @@ func main() {
     defer f.Close()
 
     dec := decoder.NewRaw()
-    hash16 := crc16.New(nil)
+    hash16 := crc16.New()
 
     _, err = dec.Decode(bufio.NewReader(f), func(flag decoder.RawFlag, b []byte) error {
         switch flag {

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -190,7 +190,7 @@ func WithWriteBufferSize(size int) Option {
 // Encoder to do so using WithWriteBufferSize(0).
 func New(w io.Writer, opts ...Option) *Encoder {
 	e := &Encoder{
-		crc16:             crc16.New(nil),
+		crc16:             crc16.New(),
 		protocolValidator: new(proto.Validator),
 		localMesgNumLRU:   new(lru),
 		buf:               make([]byte, 0, 1536),

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -866,7 +866,7 @@ func TestEncodeHeader(t *testing.T) {
 
 				binary.LittleEndian.PutUint16(b[2:4], profile.Version)
 
-				crc := crc16.New(nil)
+				crc := crc16.New()
 				crc.Write(b[:12])
 				binary.LittleEndian.PutUint16(b[12:14], crc.Sum16())
 

--- a/kit/hash/crc16/crc16.go
+++ b/kit/hash/crc16/crc16.go
@@ -8,73 +8,45 @@ import (
 	"github.com/muktihari/fit/kit/hash"
 )
 
-// Table is [16]uint16
-type Table [16]uint16
-
-const (
-	Size = 2 // An uint16 requires 2 bytes to be represented in its binary form.
-)
-
-var fitTable = Table{
+var table = [16]uint16{
 	0x0000, 0xCC01, 0xD801, 0x1400, 0xF001, 0x3C00, 0x2800, 0xE401,
 	0xA001, 0x6C00, 0x7800, 0xB401, 0x5000, 0x9C01, 0x8801, 0x4400,
 }
 
-// MakeFITTable makes new table as defined in [https://developer.garmin.com/fit/protocol]
-func MakeFITTable() *Table {
-	t := fitTable
-	return &t
-}
+type crc16 uint16
 
-// New creates a new hash.Hash16 computing the CRC-16 checksum using the polynomial represented by the Table.
-// If table is nil, default FIT table will be used. The computing algorithm is using FIT algorithm defined in
-// [https://developer.garmin.com/fit/protocol]. Its Sum method will lay the value out in big-endian byte order.
-func New(table *Table) hash.Hash16 {
-	if table == nil {
-		table = &fitTable
-	}
-	return &crc16{table: table}
-}
-
-type crc16 struct {
-	table *Table
-	crc   uint16
-}
+// New creates a new hash.Hash16 computing the CRC-16 checksum using the polynomial represented by FIT table.
+// The computing algorithm is defined in [https://developer.garmin.com/fit/protocol].
+// Its Sum method will lay the value out in big-endian byte order.
+func New() hash.Hash16 { return new(crc16) }
 
 func (c *crc16) Write(p []byte) (n int, err error) {
-	crc := c.crc // PERF: Reduce pointer dereference every time 'c.crc' is computed.
+	crc := uint16(*c) // PERF: Reduce pointer dereference every time 'crc' is computed.
 	for _, b := range p {
 		crc = c.compute(crc, b)
 	}
-	c.crc = crc
+	*c = crc16(crc)
 	return len(p), nil
 }
-
-func (c *crc16) Sum(b []byte) []byte {
-	s := c.Sum16()
-	return append(b, byte(s>>8), byte(s))
-}
-
-func (c *crc16) Reset() { c.crc = 0 }
-
-func (c *crc16) Size() int { return Size }
-
-func (c *crc16) BlockSize() int { return 1 }
-
-func (c *crc16) Sum16() uint16 { return c.crc }
 
 func (c *crc16) compute(crc uint16, b byte) uint16 {
 	var tmp uint16
 
 	// compute checksum of lower four bits of byte
-	tmp = c.table[crc&0xF]
+	tmp = table[crc&0xF]
 	crc = (crc >> 4) & 0x0FFF
-	crc = crc ^ tmp ^ c.table[b&0xF]
+	crc = crc ^ tmp ^ table[b&0xF]
 
 	// now compute checksum of upper four bits of byte
-	tmp = c.table[crc&0xF]
+	tmp = table[crc&0xF]
 	crc = (crc >> 4) & 0x0FFF
-	crc = crc ^ tmp ^ c.table[(b>>4)&0xF]
+	crc = crc ^ tmp ^ table[(b>>4)&0xF]
 
 	return crc
 }
+
+func (c *crc16) Sum16() uint16       { return uint16(*c) }
+func (c *crc16) Sum(b []byte) []byte { return append(b, byte(*c>>8), byte(*c)) }
+func (c *crc16) Reset()              { *c = 0 }
+func (c *crc16) Size() int           { return 2 }
+func (c *crc16) BlockSize() int      { return 1 }

--- a/kit/hash/crc16/crc16_test.go
+++ b/kit/hash/crc16/crc16_test.go
@@ -5,62 +5,49 @@
 package crc16_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/muktihari/fit/kit/hash/crc16"
 )
 
 func TestCRC16(t *testing.T) {
-	tt := []struct {
-		name  string
-		table *crc16.Table
-	}{
-		{name: "nil table", table: nil},
-		{name: "crc16.MakeFITTable()", table: crc16.MakeFITTable()},
+	b := []byte{14, 32, 84, 8, 214, 204, 9, 0, 46, 70, 73, 84} // example from some fit header.
+	crc := uint16(12856)                                       // should match this checksum.
+
+	c16 := crc16.New()
+
+	if c16.BlockSize() != 1 {
+		t.Fatalf("blocksize mismatch")
 	}
 
-	for i, tc := range tt {
-		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
-			b := []byte{14, 32, 84, 8, 214, 204, 9, 0, 46, 70, 73, 84} // example from some fit header.
-			crc := uint16(12856)                                       // should match this checksum.
+	if c16.Size() != 2 {
+		t.Fatalf("size mismatch")
+	}
 
-			c16 := crc16.New(tc.table)
+	_, _ = c16.Write(b)
+	if c16.Sum16() != crc {
+		t.Fatalf("expected: %v, got: %v", crc, c16.Sum16())
+	}
 
-			if c16.BlockSize() != 1 {
-				t.Fatalf("blocksize mismatch")
-			}
+	sum := c16.Sum([]byte{10})
+	expect := []byte{10, 50, 56}
+	for i := range sum {
+		if sum[i] != expect[i] {
+			t.Fatalf("expected: %v, got: %v", expect[i], sum[i])
+		}
+	}
 
-			if c16.Size() != 2 {
-				t.Fatalf("size mismatch")
-			}
+	c16.Reset()
 
-			_, _ = c16.Write(b)
-			if c16.Sum16() != crc {
-				t.Fatalf("expected: %v, got: %v", crc, c16.Sum16())
-			}
-
-			sum := c16.Sum([]byte{10})
-			expect := []byte{10, 50, 56}
-			for i := range sum {
-				if sum[i] != expect[i] {
-					t.Fatalf("expected: %v, got: %v", expect[i], sum[i])
-				}
-			}
-
-			c16.Reset()
-
-			if c16.Sum16() != 0 {
-				t.Fatalf("expected 0 after reset, got: %v", c16.Sum16())
-			}
-		})
+	if c16.Sum16() != 0 {
+		t.Fatalf("expected 0 after reset, got: %v", c16.Sum16())
 	}
 }
 
 func BenchmarkWrite(b *testing.B) {
 	b.StopTimer()
 	buf := make([]byte, 4096)
-	h := crc16.New(nil)
+	h := crc16.New()
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
It has been over a year since the creation of this Go SDK, and I don't see the need for a custom table for crc16. The FIT protocol itself has been around for 15 years, yet the checksum table remains unchanged nor having other variants.

Removed Items:
- constant Size
- type Table
- func MakeFITTable
- func New no longer receiving params