### PR TITLE
refactor(proto)!: change func Sizeof into Value method named Size

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -540,11 +540,12 @@ func (e *Encoder) newMessageDefinition(mesg *proto.Message) *proto.MessageDefini
 	e.mesgDef.DeveloperFieldDefinitions = e.mesgDef.DeveloperFieldDefinitions[:0]
 
 	for i := range mesg.Fields {
-		e.mesgDef.FieldDefinitions = append(e.mesgDef.FieldDefinitions, proto.FieldDefinition{
-			Num:      mesg.Fields[i].Num,
-			Size:     byte(proto.Sizeof(mesg.Fields[i].Value)),
-			BaseType: mesg.Fields[i].BaseType,
-		})
+		e.mesgDef.FieldDefinitions = append(e.mesgDef.FieldDefinitions,
+			proto.FieldDefinition{
+				Num:      mesg.Fields[i].Num,
+				Size:     byte(mesg.Fields[i].Value.Size()),
+				BaseType: mesg.Fields[i].BaseType,
+			})
 	}
 
 	if len(mesg.DeveloperFields) == 0 {
@@ -553,11 +554,12 @@ func (e *Encoder) newMessageDefinition(mesg *proto.Message) *proto.MessageDefini
 
 	e.mesgDef.Header |= proto.DevDataMask
 	for i := range mesg.DeveloperFields {
-		e.mesgDef.DeveloperFieldDefinitions = append(e.mesgDef.DeveloperFieldDefinitions, proto.DeveloperFieldDefinition{
-			Num:                mesg.DeveloperFields[i].Num,
-			Size:               byte(proto.Sizeof(mesg.DeveloperFields[i].Value)),
-			DeveloperDataIndex: mesg.DeveloperFields[i].DeveloperDataIndex,
-		})
+		e.mesgDef.DeveloperFieldDefinitions = append(e.mesgDef.DeveloperFieldDefinitions,
+			proto.DeveloperFieldDefinition{
+				Num:                mesg.DeveloperFields[i].Num,
+				Size:               byte(mesg.DeveloperFields[i].Value.Size()),
+				DeveloperDataIndex: mesg.DeveloperFields[i].DeveloperDataIndex,
+			})
 	}
 
 	return &e.mesgDef

--- a/encoder/validator.go
+++ b/encoder/validator.go
@@ -259,8 +259,7 @@ func valueIntegrity(value proto.Value, baseType basetype.BaseType) error {
 	}
 
 	// Both proto.FieldDefinition's Size and proto.DeveloperFieldDefinition's Size is a type of byte.
-	size := proto.Sizeof(value)
-	if size > 255 {
+	if size := value.Size(); size > 255 {
 		return fmt.Errorf("max value size in bytes is 255, got: %d (value: %v): %w",
 			size, value.Any(), ErrExceedMaxAllowed)
 	}

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -303,7 +303,7 @@ func NewMessageDefinition(mesg *Message) (*MessageDefinition, error) {
 	}
 
 	for i := range mesg.Fields {
-		size := Sizeof(mesg.Fields[i].Value)
+		size := mesg.Fields[i].Value.Size()
 		if size > maxValueSize {
 			return nil, fmt.Errorf("Fields[%d].Value's size should be <= %d: %w",
 				i, maxValueSize, errValueSizeExceed255)
@@ -322,7 +322,7 @@ func NewMessageDefinition(mesg *Message) (*MessageDefinition, error) {
 	mesgDef.DeveloperFieldDefinitions = make([]DeveloperFieldDefinition, 0, len(mesg.DeveloperFields))
 	mesgDef.Header |= DevDataMask
 	for i := range mesg.DeveloperFields {
-		size := Sizeof(mesg.DeveloperFields[i].Value)
+		size := mesg.DeveloperFields[i].Value.Size()
 		if size > maxValueSize {
 			return nil, fmt.Errorf("Fields[%d].Value's size should be <= %d: %w",
 				i, maxValueSize, errValueSizeExceed255)

--- a/proto/proto_marshal_test.go
+++ b/proto/proto_marshal_test.go
@@ -308,9 +308,9 @@ func BenchmarkMessageMarshalAppend(b *testing.B) {
 		factory.CreateField(mesgnum.Record, fieldnum.RecordPower).WithValue(uint16(300)),
 	}}
 
-	var size = 1
+	var size int = 1
 	for i := range mesg.Fields {
-		size += proto.Sizeof(mesg.Fields[i].Value)
+		size += mesg.Fields[i].Value.Size()
 	}
 	buf := make([]byte, size)
 	b.StartTimer()

--- a/proto/value_test.go
+++ b/proto/value_test.go
@@ -1222,8 +1222,7 @@ func TestSizeof(t *testing.T) {
 	for i, tc := range tt {
 		val := tc.value.Any()
 		t.Run(fmt.Sprintf("[%d] %T(%v)", i, val, val), func(t *testing.T) {
-			size := Sizeof(tc.value)
-			if size != tc.sizeInBytes {
+			if size := tc.value.Size(); size != tc.sizeInBytes {
 				t.Fatalf("expected: %d, got: %d", tc.sizeInBytes, size)
 			}
 		})


### PR DESCRIPTION
Move func `Sizeof` as Value method named `Size`. The context of size calculation on only applies to Value, so it makes more sense to have it as method instead of function. This make `proto` package cleaner as well.