### PR TITLE
refactor!:  make error wrapping more concise

### DIFF
--- a/cmd/fitactivity/main.go
+++ b/cmd/fitactivity/main.go
@@ -610,7 +610,7 @@ func conceal(ctx context.Context, fs *flag.FlagSet, args []string) (err error) {
 			}
 		})
 		if err != nil {
-			return fmt.Errorf("could not conceal %q: %v", path, err)
+			return fmt.Errorf("conceal %q: %v", path, err)
 		}
 	}
 	return nil

--- a/cmd/fitconv/fitcsv/csv_to_fit.go
+++ b/cmd/fitconv/fitcsv/csv_to_fit.go
@@ -132,7 +132,7 @@ func (c *CSVToFITConv) convert() error {
 				// Unknown has number, try parsing it as MesgNum.
 				v, err := strconv.ParseUint(digits, 10, 16)
 				if err != nil {
-					return fmt.Errorf("could not parse unknown mesgNum %q: %w", mesgName, err)
+					return fmt.Errorf("parse unknown mesgNum %q: %w", mesgName, err)
 				}
 				mesgNum = typedef.MesgNum(v)
 			}
@@ -140,7 +140,7 @@ func (c *CSVToFITConv) convert() error {
 			if mesgNum == mesgnum.FileId {
 				if c.seq != 0 {
 					if err := c.finalize(); err != nil {
-						return fmt.Errorf("could not finalize: %w", err)
+						return fmt.Errorf("finalize: %w", err)
 					}
 				}
 				c.seq++
@@ -148,7 +148,7 @@ func (c *CSVToFITConv) convert() error {
 
 			mesg, err := c.createMesg(mesgNum, record)
 			if err != nil {
-				return fmt.Errorf("could not create mesg: num: %q (%d): %w", mesgNum, mesgNum, err)
+				return fmt.Errorf("create mesg: num: %q (%d): %w", mesgNum, mesgNum, err)
 			}
 			if len(mesg.Fields) == 0 && len(mesg.DeveloperFields) == 0 {
 				continue
@@ -239,7 +239,7 @@ func (c *CSVToFITConv) createMesg(num typedef.MesgNum, record []string) (proto.M
 				}
 				v, err := strconv.ParseUint(digits, 10, 8)
 				if err != nil {
-					return proto.Message{}, fmt.Errorf("could not parse unknown fieldNum %q: %w", fieldName, err)
+					return proto.Message{}, fmt.Errorf("parse unknown fieldNum %q: %w", fieldName, err)
 				}
 				fieldNum = byte(v)
 				recoverableUnknownField = true
@@ -250,7 +250,7 @@ func (c *CSVToFITConv) createMesg(num typedef.MesgNum, record []string) (proto.M
 		if ok {
 			field, err := c.createField(num, fieldNum, strValue, units, recoverableUnknownField)
 			if err != nil {
-				return proto.Message{}, fmt.Errorf("could not create field: num: %q (%d): %w", fieldName, fieldNum, err)
+				return proto.Message{}, fmt.Errorf("create field: num: %q (%d): %w", fieldName, fieldNum, err)
 			}
 			mesg.Fields = append(mesg.Fields, field)
 			continue
@@ -258,7 +258,7 @@ func (c *CSVToFITConv) createMesg(num typedef.MesgNum, record []string) (proto.M
 
 		devField, err := c.createDeveloperField(fieldName, strValue, units)
 		if err != nil {
-			return proto.Message{}, fmt.Errorf("could not create developer field: %w", err)
+			return proto.Message{}, fmt.Errorf("create developer field: %w", err)
 		}
 		if devField.Value.Type() != proto.TypeInvalid {
 			mesg.DeveloperFields = append(mesg.DeveloperFields, devField)
@@ -337,7 +337,7 @@ func (c *CSVToFITConv) createField(mesgNum typedef.MesgNum, num byte, strValue, 
 		units,
 	)
 	if err != nil {
-		err = fmt.Errorf("could not parse %q into %s: %v",
+		err = fmt.Errorf("parse %q into %s: %v",
 			strValue, field.BaseType.GoType(), err)
 	}
 

--- a/cmd/fitconv/main.go
+++ b/cmd/fitconv/main.go
@@ -160,7 +160,7 @@ func main() {
 func fitToCsv(path string, decoderOptions []decoder.Option, opts ...fitcsv.Option) error {
 	ff, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("could not open file: %s: %w", path, err)
+		return fmt.Errorf("open file: %s: %w", path, err)
 	}
 	defer ff.Close()
 
@@ -178,7 +178,7 @@ func fitToCsv(path string, decoderOptions []decoder.Option, opts ...fitcsv.Optio
 
 	cf, err := os.OpenFile(pathcsv, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
-		return fmt.Errorf("could not open file: %s: %w", pathcsv, err)
+		return fmt.Errorf("open file: %s: %w", pathcsv, err)
 	}
 	defer cf.Close()
 
@@ -221,7 +221,7 @@ func fitToCsv(path string, decoderOptions []decoder.Option, opts ...fitcsv.Optio
 func csvToFit(path string) error {
 	cf, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("could not open file: %s: %w", path, err)
+		return fmt.Errorf("open file: %s: %w", path, err)
 	}
 	defer cf.Close()
 

--- a/cmd/fitprint/printer/printer.go
+++ b/cmd/fitprint/printer/printer.go
@@ -35,7 +35,7 @@ func Print(path string) error {
 
 	f, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("could not open file %s: %w", path, err)
+		return fmt.Errorf("open file %s: %w", path, err)
 	}
 	defer f.Close()
 
@@ -104,7 +104,7 @@ File Header:
 
 		fit, err := dec.Decode()
 		if err != nil {
-			return fmt.Errorf("could not decode: %w", err)
+			return fmt.Errorf("decode: %w", err)
 		}
 
 		p.Wait()

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -375,7 +375,7 @@ func TestEncode(t *testing.T) {
 		fit  *proto.FIT
 		err  error
 	}{
-		{name: "encode with nil", w: nil, fit: &fitOK, err: ErrNilWriter},
+		{name: "encode with nil", w: nil, fit: &fitOK, err: ErrInvalidWriter},
 		{name: "encode with writer", w: fnWriteOK, fit: &fitOK},
 		{name: "encode with writerAt", w: mockWriterAt{fnWriteOK, fnWriteAtOK}, fit: &fitOK},
 		{name: "encode with writeSeeker", w: mockWriteSeeker{fnWriteOK, fnSeekOK}, fit: &fitOK},
@@ -392,7 +392,7 @@ func TestEncode(t *testing.T) {
 				},
 			},
 			w:   fnWriteOK,
-			err: ErrExceedMaxAllowed,
+			err: errExceedMaxAllowed,
 		},
 		{
 			name: "encode return error protocol violation since proto.V1 does not allow Int64",
@@ -452,7 +452,7 @@ func TestValidateMessages(t *testing.T) {
 			name:            "empty messages",
 			protocolVersion: proto.V1,
 			messages:        []proto.Message{},
-			err:             ErrEmptyMessages,
+			err:             errEmptyMessages,
 		},
 		{
 			name:            "protocol validation failed",
@@ -476,7 +476,7 @@ func TestValidateMessages(t *testing.T) {
 				{Num: mesgnum.Record, Fields: []proto.Field{
 					factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed1S).WithValue(make([]uint8, 256)),
 				}}},
-			err: ErrExceedMaxAllowed,
+			err: errExceedMaxAllowed,
 		},
 	}
 
@@ -1704,7 +1704,7 @@ func TestStreamEncoder(t *testing.T) {
 		{
 			name: "writer is pure io.Writer",
 			w:    fnWriteOK,
-			err:  ErrWriterAtOrWriteSeekerIsExpected,
+			err:  ErrInvalidWriter,
 		},
 	}
 

--- a/encoder/stream.go
+++ b/encoder/stream.go
@@ -27,18 +27,18 @@ func (e *StreamEncoder) WriteMessage(mesg *proto.Message) error {
 	if !e.fileHeaderWritten {
 		e.enc.selectProtocolVersion(&e.fileHeader)
 		if err := e.enc.encodeFileHeader(&e.fileHeader); err != nil {
-			return fmt.Errorf("could not encode file header: %w", err)
+			return fmt.Errorf("encode file header: %w", err)
 		}
 		e.fileHeaderWritten = true
 	}
 	if err := e.enc.protocolValidator.ValidateMessage(mesg); err != nil {
-		return fmt.Errorf("protocol validate message failed: %d (%s): %w", mesg.Num, mesg.Num, err)
+		return fmt.Errorf("protocol validation: mesgNum: %d (%s): %w", mesg.Num, mesg.Num, err)
 	}
 	if err := e.enc.options.messageValidator.Validate(mesg); err != nil {
-		return fmt.Errorf("message validation failed: mesgNum: %d (%s): %w", mesg.Num, mesg.Num, err)
+		return fmt.Errorf("message validation: mesgNum: %d (%s): %w", mesg.Num, mesg.Num, err)
 	}
 	if err := e.enc.encodeMessage(mesg); err != nil {
-		return fmt.Errorf("could not encode mesg: mesgNum: %d (%q): %w", mesg.Num, mesg.Num, err)
+		return fmt.Errorf("encode message: mesgNum: %d (%q): %w", mesg.Num, mesg.Num, err)
 	}
 	return nil
 }
@@ -47,10 +47,10 @@ func (e *StreamEncoder) WriteMessage(mesg *proto.Message) error {
 // This will also reset variables so that the StreamEncoder can be used for the next sequence of FIT file.
 func (e *StreamEncoder) SequenceCompleted() error {
 	if err := e.enc.encodeCRC(); err != nil {
-		return fmt.Errorf("could not encode crc: %w", err)
+		return fmt.Errorf("encode crc: %w", err)
 	}
 	if err := e.enc.updateFileHeader(&e.fileHeader); err != nil {
-		return fmt.Errorf("could not update header: %w", err)
+		return fmt.Errorf("update header: %w", err)
 	}
 	e.fileHeaderWritten = false
 	e.enc.reset()
@@ -72,5 +72,5 @@ func (e *StreamEncoder) Reset(w io.Writer, opts ...Option) error {
 		e.fileHeaderWritten = false
 		return nil
 	}
-	return fmt.Errorf("could not reset: %w", ErrWriterAtOrWriteSeekerIsExpected)
+	return fmt.Errorf("io.WriterAt or io.WriteSeeker is expected: %w", ErrInvalidWriter)
 }

--- a/encoder/stream_test.go
+++ b/encoder/stream_test.go
@@ -161,8 +161,8 @@ func TestStreamEncoderUnhappyFlow(t *testing.T) {
 	err = streamEnc.WriteMessage(&proto.Message{Fields: []proto.Field{
 		factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed1S).WithValue(make([]uint8, 256))}},
 	)
-	if !errors.Is(err, ErrExceedMaxAllowed) {
-		t.Fatalf("expected err: %v, got: %v", ErrExceedMaxAllowed, err)
+	if !errors.Is(err, errExceedMaxAllowed) {
+		t.Fatalf("expected err: %v, got: %v", errExceedMaxAllowed, err)
 	}
 }
 
@@ -207,7 +207,7 @@ func TestStreamEncoderReset(t *testing.T) {
 			name: "io.WriteSeeker reset with io.Writer",
 			w1:   mockWriteSeeker{fnWriteOK, fnSeekOK},
 			w2:   fnWriteOK,
-			err:  ErrWriterAtOrWriteSeekerIsExpected,
+			err:  ErrInvalidWriter,
 		},
 	}
 

--- a/encoder/validator_test.go
+++ b/encoder/validator_test.go
@@ -161,7 +161,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 					factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed).WithValue(uint32(1000)), // should be uint16
 				}},
 			},
-			errs: []error{ErrValueTypeMismatch},
+			errs: []error{errValueTypeMismatch},
 		},
 		{
 			name: "valid message with developer data index not found in previous message sequence",
@@ -206,7 +206,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 					factory.CreateField(mesgnum.FileId, fieldnum.FileIdProductName).WithValue("\xbd"),
 				}},
 			},
-			errs: []error{ErrInvalidUTF8String},
+			errs: []error{errInvalidUTF8String},
 		},
 		{
 			name: "invalid utf-8 []string",
@@ -218,7 +218,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 					factory.CreateField(mesgnum.SegmentFile, fieldnum.SegmentFileLeaderActivityIdString).WithValue([]string{"valid utf-8", "\xbd"}), // valid and invalid string in array
 				}},
 			},
-			errs: []error{nil, ErrInvalidUTF8String},
+			errs: []error{nil, errInvalidUTF8String},
 		},
 		{
 			name: "n fields exceed allowed",
@@ -243,7 +243,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 					}(),
 				},
 			},
-			errs: []error{ErrExceedMaxAllowed},
+			errs: []error{errExceedMaxAllowed},
 		},
 		{
 			name: "n developer fields exceed allowed",
@@ -277,7 +277,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 					}(),
 				},
 			},
-			errs: []error{nil, nil, ErrExceedMaxAllowed},
+			errs: []error{nil, nil, errExceedMaxAllowed},
 		},
 		{
 			name: "field value size exceed max allowed",
@@ -286,7 +286,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 					factory.CreateField(mesgnum.FileId, fieldnum.FileIdProductName).WithValue(strings.Repeat("a", 256)),
 				}},
 			},
-			errs: []error{ErrExceedMaxAllowed},
+			errs: []error{errExceedMaxAllowed},
 		},
 		{
 			name: "developer field value size exceed max allowed",
@@ -316,7 +316,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 					},
 				}},
 			},
-			errs: []error{ErrExceedMaxAllowed},
+			errs: []error{errExceedMaxAllowed},
 		},
 		{
 			name: "valid message with developer fields invalid value",
@@ -436,7 +436,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 					},
 				},
 			},
-			errs: []error{nil, nil, ErrValueTypeMismatch},
+			errs: []error{nil, nil, errValueTypeMismatch},
 		},
 		{
 			// in Profile.xlsx (v21.133) there is no field with scale 1 and offset other than 0, but just in case in future update.
@@ -496,7 +496,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 		{
 			name:  "error no fields",
 			mesgs: []proto.Message{{Fields: []proto.Field{}}},
-			errs:  []error{ErrNoFields},
+			errs:  []error{errNoFields},
 		},
 	}
 

--- a/internal/cmd/fitgen/profile/factory/factory.tmpl
+++ b/internal/cmd/fitgen/profile/factory/factory.tmpl
@@ -149,11 +149,11 @@ func (f *Factory) RegisterMesg(mesg proto.Message) error {
 		f.registeredMesgs = make(map[typedef.MesgNum]proto.Message) // only alloc when needed
 	}
 	if mesg.Num > typedef.MesgNumMfgRangeMax {
-		return fmt.Errorf("could not register outside max range: %d: %w", 
-			typedef.MesgNumMfgRangeMax, ErrRegisterForbidden)
+		return fmt.Errorf("mesg.Num %d is outside max range %d: %w", 
+			mesg.Num, typedef.MesgNumMfgRangeMax, ErrRegisterForbidden)
 	}
 	if mesg.Num < {{ .LenMesgs }} && mesgs[mesg.Num] != nil {
-		return fmt.Errorf("could not register on reserved predefined message, mesg.Num %d (%s) is already exist: %w",
+		return fmt.Errorf("mesg.Num %d is reserved for %q: %w",
 			mesg.Num, mesg.Num, ErrRegisterForbidden)
 	}
 	f.registeredMesgs[mesg.Num] = mesg

--- a/internal/cmd/fitgen/profile/mesgdef/builder.go
+++ b/internal/cmd/fitgen/profile/mesgdef/builder.go
@@ -91,7 +91,7 @@ func (b *Builder) Build() ([]generator.Data, error) {
 				})
 				v, err := strconv.ParseInt(n, 10, 8)
 				if err != nil {
-					return nil, fmt.Errorf("could not parse array size: %w", err)
+					return nil, fmt.Errorf("parse array size: %w", err)
 				}
 				fixedArraySize = uint8(v)
 			}

--- a/profile/factory/factory_gen.go
+++ b/profile/factory/factory_gen.go
@@ -154,11 +154,11 @@ func (f *Factory) RegisterMesg(mesg proto.Message) error {
 		f.registeredMesgs = make(map[typedef.MesgNum]proto.Message) // only alloc when needed
 	}
 	if mesg.Num > typedef.MesgNumMfgRangeMax {
-		return fmt.Errorf("could not register outside max range: %d: %w",
-			typedef.MesgNumMfgRangeMax, ErrRegisterForbidden)
+		return fmt.Errorf("mesg.Num %d is outside max range %d: %w",
+			mesg.Num, typedef.MesgNumMfgRangeMax, ErrRegisterForbidden)
 	}
 	if mesg.Num < 410 && mesgs[mesg.Num] != nil {
-		return fmt.Errorf("could not register on reserved predefined message, mesg.Num %d (%s) is already exist: %w",
+		return fmt.Errorf("mesg.Num %d is reserved for %q: %w",
 			mesg.Num, mesg.Num, ErrRegisterForbidden)
 	}
 	f.registeredMesgs[mesg.Num] = mesg

--- a/proto/validator.go
+++ b/proto/validator.go
@@ -28,7 +28,7 @@ func (p *Validator) ValidateMessageDefinition(mesgDef *MessageDefinition) error 
 		}
 		for _, fieldDef := range mesgDef.FieldDefinitions {
 			if fieldDef.BaseType&basetype.BaseTypeNumMask > basetype.Byte&basetype.BaseTypeNumMask { // byte was the last type added in 1.0
-				return fmt.Errorf("protocol version 1.0 do not support type '%s': %w", fieldDef.BaseType, ErrProtocolViolation)
+				return fmt.Errorf("protocol version 1.0 do not support type %q: %w", fieldDef.BaseType, ErrProtocolViolation)
 			}
 		}
 		return nil
@@ -45,7 +45,7 @@ func (p *Validator) ValidateMessage(mesg *Message) error {
 		for i := range mesg.Fields {
 			field := &mesg.Fields[i]
 			if field.BaseType&basetype.BaseTypeNumMask > basetype.Byte&basetype.BaseTypeNumMask { // byte was the last type added in 1.0
-				return fmt.Errorf("protocol version 1.0 do not support type '%s': %w", field.BaseType, ErrProtocolViolation)
+				return fmt.Errorf("protocol version 1.0 do not support type %q: %w", field.BaseType, ErrProtocolViolation)
 			}
 		}
 	}


### PR DESCRIPTION
- Remove words like "could not" and "failed" on error wrapping, it's error anyway so it's expected that we "could not" do something or the operation is "failed".
- Change wording for some error wrapping for more concise error message.
- encoder: remove `ErrWriterAtOrWriteSeekerIsExpected` and `ErrNilWriter`, introduce `ErrInvalidWriter` instead
- encoder: make some sentinel errors private since the error is not an expected error. `ErrMissingDeveloperDataId` and `ErrMissingFieldDescription` is being kept in case when users receive these errors, they want to fallback the operation to encode using proto.V1 or to abort the operation altogether. `ErrMissingDeveloperDataId` is being used by fuzz test. 