### PR TITLE
refactor(encoder): make errors private

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -23,8 +23,7 @@ type errorString string
 func (e errorString) Error() string { return string(e) }
 
 const (
-	ErrInvalidWriter = errorString("invalid writer")
-
+	errInvalidWriter = errorString("invalid writer")
 	errEmptyMessages = errorString("empty messages")
 )
 
@@ -245,7 +244,7 @@ func (e *Encoder) Encode(fit *proto.FIT) (err error) {
 	case io.Writer:
 		err = e.encodeWithEarlyCheckStrategy(fit)
 	default:
-		err = fmt.Errorf("writer is nil: %w", ErrInvalidWriter)
+		err = fmt.Errorf("writer is nil: %w", errInvalidWriter)
 	}
 	e.reset()
 	if err != nil {
@@ -590,7 +589,7 @@ func (e *Encoder) EncodeWithContext(ctx context.Context, fit *proto.FIT) (err er
 	case io.Writer:
 		err = e.encodeWithEarlyCheckStrategyWithContext(ctx, fit)
 	default:
-		err = fmt.Errorf("writer is nil: %w", ErrInvalidWriter)
+		err = fmt.Errorf("writer is nil: %w", errInvalidWriter)
 	}
 	e.reset()
 	if err != nil {
@@ -679,5 +678,5 @@ func (e *Encoder) StreamEncoder() (*StreamEncoder, error) {
 	case io.WriterAt, io.WriteSeeker:
 		return &StreamEncoder{enc: e}, nil
 	}
-	return nil, fmt.Errorf("io.WriterAt or io.WriteSeeker is expected: %w", ErrInvalidWriter)
+	return nil, fmt.Errorf("io.WriterAt or io.WriteSeeker is expected: %w", errInvalidWriter)
 }

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -375,7 +375,7 @@ func TestEncode(t *testing.T) {
 		fit  *proto.FIT
 		err  error
 	}{
-		{name: "encode with nil", w: nil, fit: &fitOK, err: ErrInvalidWriter},
+		{name: "encode with nil", w: nil, fit: &fitOK, err: errInvalidWriter},
 		{name: "encode with writer", w: fnWriteOK, fit: &fitOK},
 		{name: "encode with writerAt", w: mockWriterAt{fnWriteOK, fnWriteAtOK}, fit: &fitOK},
 		{name: "encode with writeSeeker", w: mockWriteSeeker{fnWriteOK, fnSeekOK}, fit: &fitOK},
@@ -1704,7 +1704,7 @@ func TestStreamEncoder(t *testing.T) {
 		{
 			name: "writer is pure io.Writer",
 			w:    fnWriteOK,
-			err:  ErrInvalidWriter,
+			err:  errInvalidWriter,
 		},
 	}
 

--- a/encoder/stream.go
+++ b/encoder/stream.go
@@ -72,5 +72,5 @@ func (e *StreamEncoder) Reset(w io.Writer, opts ...Option) error {
 		e.fileHeaderWritten = false
 		return nil
 	}
-	return fmt.Errorf("io.WriterAt or io.WriteSeeker is expected: %w", ErrInvalidWriter)
+	return fmt.Errorf("io.WriterAt or io.WriteSeeker is expected: %w", errInvalidWriter)
 }

--- a/encoder/stream_test.go
+++ b/encoder/stream_test.go
@@ -207,7 +207,7 @@ func TestStreamEncoderReset(t *testing.T) {
 			name: "io.WriteSeeker reset with io.Writer",
 			w1:   mockWriteSeeker{fnWriteOK, fnSeekOK},
 			w2:   fnWriteOK,
-			err:  ErrInvalidWriter,
+			err:  errInvalidWriter,
 		},
 	}
 

--- a/encoder/validator.go
+++ b/encoder/validator.go
@@ -19,13 +19,12 @@ import (
 )
 
 const (
-	ErrMissingDeveloperDataId  = errorString("missing developer data id")
-	ErrMissingFieldDescription = errorString("missing field description")
-
-	errNoFields          = errorString("no fields")
-	errInvalidUTF8String = errorString("invalid UTF-8 string")
-	errValueTypeMismatch = errorString("value type mismatch")
-	errExceedMaxAllowed  = errorString("exceed max allowed")
+	errNoFields                = errorString("no fields")
+	errValueTypeMismatch       = errorString("value type mismatch")
+	errInvalidUTF8String       = errorString("invalid UTF-8 string")
+	errExceedMaxAllowed        = errorString("exceed max allowed")
+	errMissingDeveloperDataId  = errorString("missing developer data id")
+	errMissingFieldDescription = errorString("missing field description")
 )
 
 // MessageValidator is an interface for implementing message validation before encoding the message.
@@ -168,7 +167,7 @@ func (v *messageValidator) Validate(mesg *proto.Message) error {
 		}
 		if !ok {
 			return fmt.Errorf("developer field index: %d, num: %d: %w",
-				i, developerField.Num, ErrMissingDeveloperDataId)
+				i, developerField.Num, errMissingDeveloperDataId)
 		}
 
 		var fieldDesc *mesgdef.FieldDescription
@@ -182,7 +181,7 @@ func (v *messageValidator) Validate(mesg *proto.Message) error {
 
 		if fieldDesc == nil {
 			return fmt.Errorf("developer field index: %d, num: %d: %w",
-				i, developerField.Num, ErrMissingFieldDescription)
+				i, developerField.Num, errMissingFieldDescription)
 		}
 
 		// Restore any scaled float64 value back into its corresponding integer representation.

--- a/encoder/validator_test.go
+++ b/encoder/validator_test.go
@@ -179,7 +179,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 					},
 				},
 			},
-			errs: []error{nil, ErrMissingDeveloperDataId},
+			errs: []error{nil, errMissingDeveloperDataId},
 		},
 		{
 			name: "valid message with field description not found in previous message sequence",
@@ -197,7 +197,7 @@ func TestMessageValidatorValidate(t *testing.T) {
 					},
 				},
 			},
-			errs: []error{nil, ErrMissingFieldDescription},
+			errs: []error{nil, errMissingFieldDescription},
 		},
 		{
 			name: "invalid utf-8 string",


### PR DESCRIPTION
After careful consideration, I decide to make sentinel errors into private errors. I don't think we can use it to take a specific action with those errors, I think it's uncommon and maybe on special case only. For example, `ErrInvalidWriter` is actually not needed since user can just check the writer before passing to the encoder. Next case is `ErrMissingDeveloperDataId`, users are expected to write good fit's messages, having that error does not help users to take specific action since users still need to edit fit's messages before proceeding again.