### PR TITLE
refactor(encoder)!:  add NewStream to replace StreamEncoder() method

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1271,7 +1271,7 @@ func main() {
     }
     defer f.Close()
 
-    streamEnc, err := encoder.New(f).StreamEncoder()
+    enc, err := encoder.NewStream(f)
     if err != nil {
         panic(err)
     }
@@ -1287,14 +1287,14 @@ func main() {
     // Write per message, we can use this to write message as it arrives.
     // For example, message retrieved from decoder's Listener can be
     // write right away without waiting all messages to be received.
-    if err := streamEnc.WriteMessage(&mesg); err != nil {
+    if err := enc.WriteMessage(&mesg); err != nil {
         panic(err)
     }
 
     /* Write more messages */
 
     // After all messages have been written, invoke this to finalize.
-    if err := streamEnc.SequenceCompleted(); err != nil {
+    if err := enc.SequenceCompleted(); err != nil {
         panic(err)
     }
 }

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -669,14 +669,3 @@ func (e *Encoder) encodeMessagesWithContext(ctx context.Context, messages []prot
 	}
 	return nil
 }
-
-// StreamEncoder turns this Encoder into StreamEncoder to encode per message basis or in streaming fashion.
-// It returns an error if the Encoder's Writer does not implement io.WriterAt or io.WriteSeeker.
-// After invoking this method, it is recommended not to use the Encoder to avoid undefined behavior.
-func (e *Encoder) StreamEncoder() (*StreamEncoder, error) {
-	switch e.w.(type) {
-	case io.WriterAt, io.WriteSeeker:
-		return &StreamEncoder{enc: e}, nil
-	}
-	return nil, fmt.Errorf("io.WriterAt or io.WriteSeeker is expected: %w", errInvalidWriter)
-}

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -1687,41 +1687,6 @@ func TestEncodeMessagesWithContext(t *testing.T) {
 	}
 }
 
-func TestStreamEncoder(t *testing.T) {
-	tt := []struct {
-		name string
-		w    io.Writer
-		err  error
-	}{
-		{
-			name: "writer is io.WriterAt",
-			w:    mockWriterAt{},
-		},
-		{
-			name: "writer is io.WriteSeeker",
-			w:    mockWriteSeeker{},
-		},
-		{
-			name: "writer is pure io.Writer",
-			w:    fnWriteOK,
-			err:  errInvalidWriter,
-		},
-	}
-
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := New(tc.w, WithWriteBufferSize(0)).StreamEncoder()
-			if !errors.Is(err, tc.err) {
-				t.Errorf("expected err: %v, got: %v", tc.err, err)
-			}
-			if err != nil {
-				return
-			}
-
-		})
-	}
-}
-
 func TestReset(t *testing.T) {
 	tt := []struct {
 		name     string

--- a/encoder/stream.go
+++ b/encoder/stream.go
@@ -13,11 +13,20 @@ import (
 
 // StreamEncoder is one layer above Encoder to enable encoding in streaming fashion.
 // This will only valid when the Writer given to the Encoder should either implement io.WriterAt or io.WriteSeeker.
-// This can only be created using (*Encoder).StreamEncoder() method.
 type StreamEncoder struct {
 	enc               *Encoder
 	fileHeader        proto.FileHeader
 	fileHeaderWritten bool
+}
+
+// NewStream returns a FIT stream encoder that enables message-by-message encoding.
+// The given w must also implement either io.WriterAt or io.WriteSeeker, otherwise, it returns error.
+func NewStream(w io.Writer, opts ...Option) (*StreamEncoder, error) {
+	switch w.(type) {
+	case io.WriterAt, io.WriteSeeker:
+		return &StreamEncoder{enc: New(w, opts...)}, nil
+	}
+	return nil, fmt.Errorf("io.WriterAt or io.WriteSeeker is expected: %w", ErrInvalidWriter)
 }
 
 // WriteMessage writes message to the writer, it will auto write FileHeader when

--- a/encoder/stream.go
+++ b/encoder/stream.go
@@ -11,8 +11,7 @@ import (
 	"github.com/muktihari/fit/proto"
 )
 
-// StreamEncoder is one layer above Encoder to enable encoding in streaming fashion.
-// This will only valid when the Writer given to the Encoder should either implement io.WriterAt or io.WriteSeeker.
+// StreamEncoder is one layer above Encoder to enable encoding in streaming fashion (message-by-message encoding).
 type StreamEncoder struct {
 	enc               *Encoder
 	fileHeader        proto.FileHeader
@@ -20,13 +19,13 @@ type StreamEncoder struct {
 }
 
 // NewStream returns a FIT stream encoder that enables message-by-message encoding.
-// The given w must also implement either io.WriterAt or io.WriteSeeker, otherwise, it returns error.
+// The given w must implement either io.WriterAt or io.WriteSeeker, otherwise, it returns error.
 func NewStream(w io.Writer, opts ...Option) (*StreamEncoder, error) {
 	switch w.(type) {
 	case io.WriterAt, io.WriteSeeker:
 		return &StreamEncoder{enc: New(w, opts...)}, nil
 	}
-	return nil, fmt.Errorf("io.WriterAt or io.WriteSeeker is expected: %w", ErrInvalidWriter)
+	return nil, fmt.Errorf("io.WriterAt or io.WriteSeeker is expected: %w", errInvalidWriter)
 }
 
 // WriteMessage writes message to the writer, it will auto write FileHeader when


### PR DESCRIPTION
`StreamEncoder()` method in my opinion is less discoverable, it's a bit weird to instantiate new different object through a method. The new func constructor `NewStream` is explicit and clearer.