### PR TITLE
fix(fitgen): factory builder should not import generated package

### DIFF
--- a/internal/cmd/fitgen/profile/factory/builder.go
+++ b/internal/cmd/fitgen/profile/factory/builder.go
@@ -15,7 +15,6 @@ import (
 	"github.com/muktihari/fit/internal/cmd/fitgen/lookup"
 	"github.com/muktihari/fit/internal/cmd/fitgen/parser"
 	"github.com/muktihari/fit/internal/cmd/fitgen/pkg/strutil"
-	"github.com/muktihari/fit/profile/typedef"
 )
 
 type ( // type aliasing for better code reading.
@@ -86,11 +85,12 @@ func (b *Builder) Build() ([]generator.Data, error) {
 	// This way, we don't depend on generated value such as types and profile package to be able to generate factory.
 	// And also we don't need to process the data in the template which is a bit painful for complex data structure.
 
-	var maxNum typedef.MesgNum
+	var maxNum uint16
 	var strbuf strings.Builder
 	strbuf.WriteString("[...]*[256]*proto.FieldBase{\n")
+
 	for _, message := range b.messages {
-		if num := typedef.MesgNumFromString(message.Name); num > maxNum {
+		if num := b.lookup.MesgNumByName(message.Name); num > maxNum {
 			maxNum = num
 		}
 		strbuf.WriteString(b.transformMesgnum(message.Name) + ": {\n") // indexed to create fixed-size slice.
@@ -108,7 +108,7 @@ func (b *Builder) Build() ([]generator.Data, error) {
 			Data: Data{
 				Package:  "factory",
 				Messages: strbuf.String(),
-				LenMesgs: maxNum.Uint16() + 1,
+				LenMesgs: maxNum + 1,
 			},
 		},
 		{


### PR DESCRIPTION
Factory builder was importing `typedef` package, resulting mismatch data lookup since fitgen is already compiled with previous code generated `typedef` while at runtime it expects updated version of that package.