### PR TITLE
fix: build issue on 386 arch

### DIFF
--- a/decoder/readbuffer.go
+++ b/decoder/readbuffer.go
@@ -16,7 +16,7 @@ const (
 	reservedbuf = 765
 
 	minReadBufferSize     = reservedbuf // should not less than this
-	maxReadBufferSize     = math.MaxInt32
+	maxReadBufferSize     = math.MaxUint32 & math.MaxInt
 	defaultReadBufferSize = 4096
 )
 

--- a/decoder/readbuffer.go
+++ b/decoder/readbuffer.go
@@ -16,7 +16,7 @@ const (
 	reservedbuf = 765
 
 	minReadBufferSize     = reservedbuf // should not less than this
-	maxReadBufferSize     = math.MaxUint32
+	maxReadBufferSize     = math.MaxInt32
 	defaultReadBufferSize = 4096
 )
 


### PR DESCRIPTION
Thanks for the great library!

Fixed the comparison of int32 with MaxUInt32. Breaks the 386 build.
https://github.com/muktihari/fit/blob/f1f12ed2fc900cd2d2b77060e3c5d1611f5d2fbd/decoder/readbuffer.go#L49-L56