### PR TITLE
chore: vet non-constant format string

### DIFF
--- a/internal/cmd/fitgen/main.go
+++ b/internal/cmd/fitgen/main.go
@@ -28,23 +28,23 @@ import (
 )
 
 var aboutFitgen = `
-The FIT SDK for Go Generator, also known as "fitgen", is a program designed to create 
+The FIT SDK for Go Generator, also known as "fitgen", is a program designed to create
 several *.go files using Garmin SDK specifications (Profile.xlsx). These generated files
 enable this FIT SDK to carry out the decoding and encoding process of FIT files.
 
 The files are organized into distinct packages under profile folder:
  - factory, mesgdef, typedef, untyped/fieldnum, untyped/mesgnum
 
-To define your manufacturer specifications, duplicate the Profile.xlsx file and 
-incorporate your specifications within it. Afterward, utilize the provided command-line 
-interface (CLI) to generate a customized SDK. When executing the CLI command, specify 
+To define your manufacturer specifications, duplicate the Profile.xlsx file and
+incorporate your specifications within it. Afterward, utilize the provided command-line
+interface (CLI) to generate a customized SDK. When executing the CLI command, specify
 the path to the edited-file such as "Profile-copy.xlsx" using the "--path" option.
 
-Example: 
+Example:
  - "./fitgen --profile-file Profile-copy.xlsx --path ../../../ --builders all --profile-version 21.115 -v -y"
  - "./fitgen -f Profile-copy.xlsx -p ../../../ -b all --profile-version 21.115 -v -y"
 
-Note: The existing Garmin SDK specifications must not be altered, as such modifications 
+Note: The existing Garmin SDK specifications must not be altered, as such modifications
 could lead to data that does not align with the terms and conditions of the FIT Protocol.
 `
 
@@ -119,11 +119,11 @@ func main() {
 
 	parsedtypes, err := ps.ParseTypes()
 	if err != nil {
-		fatalf(fmt.Sprintf("could no parse types: %v\n", err))
+		fatalf("could no parse types: %v\n", err)
 	}
 	parsedmesgs, err := ps.ParseMessages()
 	if err != nil {
-		fatalf(fmt.Sprintf("could no parse message: %v\n", err))
+		fatalf("could no parse message: %v\n", err)
 	}
 
 	lookup := lookup.New(parsedtypes, parsedmesgs)


### PR DESCRIPTION
go v.1.24.0 and above will fail the test when we have non-constant format string in `fmt` func call.