### PR TITLE
fix!: proto typo on Field's method

### DIFF
--- a/cmd/fitconv/fitcsv/fit_to_csv.go
+++ b/cmd/fitconv/fitcsv/fit_to_csv.go
@@ -400,7 +400,7 @@ func (c *FITToCSVConv) writeMesg(mesg proto.Message) {
 			name = formatUnknown(int(field.Num))
 			units = field.BaseType.String()
 		}
-		if subField := field.SubFieldSubtitution(&mesg); subField != nil {
+		if subField := field.SubFieldSubstitution(&mesg); subField != nil {
 			name, units = subField.Name, subField.Units
 		}
 

--- a/cmd/fitprint/printer/printer.go
+++ b/cmd/fitprint/printer/printer.go
@@ -275,7 +275,7 @@ func (p *printer) print(m message) {
 			flag           = '-'
 		)
 
-		if subField := field.SubFieldSubtitution(&m.Message); subField != nil {
+		if subField := field.SubFieldSubstitution(&m.Message); subField != nil {
 			isDynamicField = true
 			name = subField.Name
 			baseType = subField.Type.BaseType()

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -768,7 +768,7 @@ func (d *Decoder) decodeFields(mesgDef *proto.MessageDefinition, mesg *proto.Mes
 	// Now that all fields has been decoded, we need to expand all components and accumulate the accumulable values.
 	for i := range mesg.Fields {
 		field := &mesg.Fields[i]
-		if subField := field.SubFieldSubtitution(mesg); subField != nil {
+		if subField := field.SubFieldSubstitution(mesg); subField != nil {
 			// Expand sub-field components as the main field components
 			d.expandComponents(mesg, field.Value, field.BaseType, subField.Components)
 			continue
@@ -854,7 +854,7 @@ func (d *Decoder) expandComponents(mesg *proto.Message, containingValue proto.Va
 		// e.g. compressed_speed_distance -> (speed, distance), speed -> enhanced_speed.
 		//
 		// NOTE: We pass the 32 bits component's value to ensure we only expand this value.
-		if subField := componentField.SubFieldSubtitution(mesg); subField != nil {
+		if subField := componentField.SubFieldSubstitution(mesg); subField != nil {
 			d.expandComponents(mesg, value, componentField.BaseType, subField.Components)
 		} else {
 			d.expandComponents(mesg, value, componentField.BaseType, componentField.Components)

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -2194,7 +2194,7 @@ func TestExpandComponents(t *testing.T) {
 				dec.accumulator = tc.accumu
 			}
 			for _, field := range tc.mesg.Fields {
-				if subField := field.SubFieldSubtitution(&tc.mesg); subField != nil {
+				if subField := field.SubFieldSubstitution(&tc.mesg); subField != nil {
 					dec.expandComponents(&tc.mesg, field.Value, field.BaseType, subField.Components)
 				} else {
 					dec.expandComponents(&tc.mesg, field.Value, field.BaseType, field.Components)

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -184,7 +184,7 @@ func (f Field) WithValue(v any) Field {
 }
 
 // SubFieldSubstitution returns any sub-field that can substitute the properties interpretation of the parent Field (Dynamic Field).
-func (f *Field) SubFieldSubtitution(mesgRef *Message) *SubField {
+func (f *Field) SubFieldSubstitution(mesgRef *Message) *SubField {
 	for i := range f.SubFields {
 		subField := &f.SubFields[i]
 		for j := range subField.Maps {

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -278,7 +278,7 @@ func TestFieldSubFieldSubtitution(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			subfield := tc.field.SubFieldSubtitution(&tc.mesg)
+			subfield := tc.field.SubFieldSubstitution(&tc.mesg)
 			if subfield != nil != tc.ok {
 				t.Fatalf("expected: %t, got: %t", tc.ok, subfield != nil)
 			}


### PR DESCRIPTION
Fix typo `SubFieldSubtitution` -> `SubFieldSubstitution`, with an `s`. Misspell didn't catch this.