### PR TITLE
pref: encoder reduce alloc on LRU by reusing old storage

### DIFF
--- a/encoder/lru_test.go
+++ b/encoder/lru_test.go
@@ -54,11 +54,6 @@ func TestLRU(t *testing.T) {
 	if len(l.bucket) != 0 {
 		t.Fatalf("expected lruBucket is %d, got: %d", 0, len(l.bucket))
 	}
-	for i := range l.items {
-		if l.items[i] != nil {
-			t.Fatalf("[%d] expected nil, got: %v", i, l.items[i])
-		}
-	}
 
 	l.ResetWithNewSize(10) // Only reslice
 	if len(l.items) != 10 {


### PR DESCRIPTION
I found some people encode into `bytes.Buffer` or `strings.Buffer` (instead of directly to an `*os.File` or other writers that support Seeker or WriterAt) which will make encoder to reiterate the encoding process twice (slow path), first is for calculating data size and the second is the actual write. During that process, LRU will reallocate twice since allocated storage created during the first iteration will be removed and reallocate again on the second iteration. So it makes me thinking, what why don't we just keep the old storage since LRU's item size is small  (the size of a message definition, max is 1537 bytes) and we can only have 16 items, keeping the old storage will benefit us more than do us harm.


Here is the benchmark for re-encode `triathlon_summary_last.fit` using `bytes.Buffer`
```js
goos: linux goarch: amd64 pkg: benchfit
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                           │   old.txt   │              new.txt               │
                           │   sec/op    │   sec/op     vs base               │
Encode/muktihari/fit_raw-4   10.91m ± 6%   10.03m ± 4%  -8.06% (p=0.001 n=10)
Encode/muktihari/fit-4       18.42m ± 7%   18.42m ± 3%       ~ (p=0.739 n=10)
geomean                      14.17m        13.59m       -4.11%

                           │   old.txt    │               new.txt                │
                           │     B/op     │     B/op      vs base                │
Encode/muktihari/fit_raw-4   15.83Ki ± 0%   11.80Ki ± 0%  -25.46% (p=0.000 n=10)
Encode/muktihari/fit-4       3.372Mi ± 0%   3.368Mi ± 0%   -0.13% (p=0.000 n=10)
geomean                      233.8Ki        201.7Ki       -13.72%

                           │   old.txt   │               new.txt               │
                           │  allocs/op  │  allocs/op   vs base                │
Encode/muktihari/fit_raw-4    80.00 ± 0%    46.00 ± 0%  -42.50% (p=0.000 n=10)
Encode/muktihari/fit-4       8.311k ± 0%   8.271k ± 0%   -0.48% (p=0.000 n=10)
geomean                       815.4         616.8       -24.35%

```