### PR TITLE
chore: update dependabot schedule from monthly to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: monthly
+      interval: quarterly
     groups:
       gomod-bulk:
         patterns:
@@ -18,7 +18,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: quarterly
     groups:
       github-actions-bulk:
         patterns:


### PR DESCRIPTION
Dependabot exists to help us update dependencies this library uses to perform code generation so that we stay up to date with the latest version for potential bug-fixes, feature improvement or security. 

This development of this library is considered complete and we will release new version when Garmin release new FIT SDK. However, Garmin seems does not have exact timeline, the gap between version is quite big (it's been 6 months since latest version, v21.171). Another thing to mention is that Go release schedule is every 6 months, dependencies sometimes only updated when there is a language update. For those reasons, I think that we do not need to update our dependencies frequently (current: `monthly`), updating dependabot's schedule to `quarterly` is the sweet spot, not too frequent not too long, to maintain the heartbeat of this library.

Note: for security perspective, we have scorecard analysis running on monthly basis so we get notified and update it manually if necessary. 