### PR TITLE
fix: expand all valid subcomponents

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -805,7 +805,7 @@ func (d *Decoder) expandComponents(mesg *proto.Message, containingValue proto.Va
 		// e.g. speed (0) -> enhanced_speed (0).
 		val := vbits.Pull(component.Bits)
 		if val == 0 && len(components) > 1 {
-			break
+			continue
 		}
 
 		if component.Accumulate {

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -2144,6 +2144,19 @@ func TestExpandComponents(t *testing.T) {
 			},
 		},
 		{
+			name: "expand all non-zero component values if intermediate values are zero",
+			mesg: proto.Message{Num: mesgnum.Event, Fields: []proto.Field{
+				factory.CreateField(mesgnum.Event, fieldnum.EventEvent).WithValue(typedef.EventFrontGearChange),
+				factory.CreateField(mesgnum.Event, fieldnum.EventData).WithValue(uint32(0x00010002)),
+			}},
+			fieldsAfterExpansion: []proto.Field{
+				factory.CreateField(mesgnum.Event, fieldnum.EventEvent).WithValue(typedef.EventFrontGearChange),
+				factory.CreateField(mesgnum.Event, fieldnum.EventData).WithValue(uint32(0x00010002)),
+				{FieldBase: factory.CreateField(mesgnum.Event, fieldnum.EventRearGearNum).FieldBase, Value: proto.Uint8(2), IsExpandedField: true},
+				{FieldBase: factory.CreateField(mesgnum.Event, fieldnum.EventFrontGearNum).FieldBase, Value: proto.Uint8(1), IsExpandedField: true},
+			},
+		},
+		{
 			// Real world use case from "testdata/from_official_sdk/activity_poolswim_with_hr.csv"
 			// prior Hr message event_timestamp value: 3.6201171875 -> 3707
 			// event_timestamp_12:  "158|114|57|159|6|167|29|142|25|244|228|130"


### PR DESCRIPTION
Currently the expand components function will skip all subsequent subfields on the first zero subfield value encountered. This prevents certain valid fields from being expanded such as shifting event data which will commonly have zero values for teeth when there is no teeth information provided.

Replace the break when expanding components with continue to completely skip zero values but allow checking for potentially valid subfields.