### PR TITLE
fix: decoder on handling bits value for component expansion

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -801,10 +801,8 @@ func (d *Decoder) expandComponents(mesg *proto.Message, containingValue proto.Va
 		componentField.IsExpandedField = true
 
 		// A component can only have max 32 bits value.
-		// If a field has only one component, expand it even if its value is zero
-		// e.g. speed (0) -> enhanced_speed (0).
-		val := vbits.Pull(component.Bits)
-		if val == 0 && len(components) > 1 {
+		val, ok := vbits.Pull(component.Bits)
+		if !ok {
 			break
 		}
 

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -2090,6 +2090,8 @@ func TestExpandComponents(t *testing.T) {
 				factory.CreateField(mesgnum.Event, fieldnum.EventData).WithValue(uint32(0x00000E08)),
 				{FieldBase: factory.CreateField(mesgnum.Event, fieldnum.EventRearGearNum).FieldBase, Value: proto.Uint8(uint8(0x08)), IsExpandedField: true},
 				{FieldBase: factory.CreateField(mesgnum.Event, fieldnum.EventRearGear).FieldBase, Value: proto.Uint8(uint8(0x0E)), IsExpandedField: true},
+				{FieldBase: factory.CreateField(mesgnum.Event, fieldnum.EventFrontGearNum).FieldBase, Value: proto.Uint8(uint8(0)), IsExpandedField: true},
+				{FieldBase: factory.CreateField(mesgnum.Event, fieldnum.EventFrontGear).FieldBase, Value: proto.Uint8(uint8(0)), IsExpandedField: true},
 			},
 		},
 		{


### PR DESCRIPTION
Related issue: #591

The new bits implementation allows us to expand only up to the amount of stored bits. This seems to match the behavior of the official SDK. 

This is the approach to ensure the correctness, create a FIT file containing these following data, then convert it into CSV using `FitCSVTool.jar` and `fitconv`, finally compare the resulting CSVs, they should contains the same expanded data.

1. message `record` -> field: `speed`, value: `uint16(1000)`, expanded into:
    - enhanced_speed: `uint32(1000)`

1. message `event` -> field: `gear_change_data`, value: `uint32(0x00000E08)`, expanded into:
    - rear_gear_num: `uint8z(0x08)`
    - rear_gear: `uint8z(0x0E)`
    - front_gear_num: `uint8z(0x0)`
    - front_gear: `uint8z(0x0)`

1. message `ant_tx` -> field: `mesg_data`, value: `[3]byte{1,2,3}`, expanded into:
    - channel_number: `uint8(1)`
    - data: `[]byte{2,3}`

1. message `raw_bbi` -> field: `data`, value: `[1]uint16{0x400F}`, expanded into:
    - time: `uint16(0xF)`
    - quality: `uint8(0x1)`
    - gap: `uint8(0x0)`
