### PR TITLE
perf: simplify makeBits for slice

### DIFF
--- a/decoder/bits_test.go
+++ b/decoder/bits_test.go
@@ -134,6 +134,78 @@ func TestMakeBits(t *testing.T) {
 			value:    proto.Value{},
 			expected: bits{}, ok: false,
 		},
+		{
+			value:    proto.SliceUint8(make([]byte, 256)),
+			expected: bits{store: [32]uint64{0}, size: 2048},
+			ok:       true,
+		},
+		{
+			value: func() proto.Value {
+				x := make([]byte, 256)
+				for i := range x {
+					x[i] = 255
+				}
+				return proto.SliceUint8(x)
+			}(),
+			expected: bits{
+				store: func() (x [32]uint64) {
+					for i := range x {
+						x[i] = math.MaxUint64
+					}
+					return
+				}(),
+				size: 2048,
+			},
+			ok: true,
+		},
+		{
+			value: func() proto.Value {
+				x := make([]byte, 255)
+				for i := range x {
+					x[i] = 255
+				}
+				return proto.SliceUint8(x)
+			}(),
+			expected: bits{
+				store: func() (x [32]uint64) {
+					for i := range x {
+						x[i] = math.MaxUint64
+					}
+					x[31] >>= 8
+					return
+				}(),
+				size: 2040,
+			},
+			ok: true,
+		},
+		{
+			value:    proto.SliceUint64(make([]uint64, 32)),
+			expected: bits{store: [32]uint64{0}, size: 2048},
+			ok:       true,
+		},
+		{
+			value:    proto.SliceUint16(append(make([]uint16, 4), 123)),
+			expected: bits{store: [32]uint64{0, 123, 0, 0}, size: 80},
+			ok:       true,
+		},
+		{
+			value: proto.SliceUint16([]uint16{1, 2, 3, 4, 5, 6, 7, 8}),
+			expected: bits{store: [32]uint64{
+				1 | (2 << 16) | (3 << 32) | (4 << 48),
+				5 | (6 << 16) | (7 << 32) | (8 << 48),
+			}, size: 128},
+			ok: true,
+		},
+		{
+			value: proto.SliceUint32([]uint32{1, 2, 3, 4, 5, 6, 7, 8}),
+			expected: bits{store: [32]uint64{
+				1 | (2 << 32),
+				3 | (4 << 32),
+				5 | (6 << 32),
+				7 | (8 << 32),
+			}, size: 256},
+			ok: true,
+		},
 	}
 
 	for i, tc := range tt {


### PR DESCRIPTION
This simplification reduce CPU instructions resulting performance boost on instantiating bits. The readability is arguably improved and correctness is still ensured.

How the performance boost is achieved?
1. The logic on `storeFromBits` is now simplified into 2 lines which consist only few instructions inside the loop, and now it's branch-less. The safety is guaranteed since we know the maximum value we are dealing with and it will never exceed it.
2. `storeFromBits` which now is renamed into `bitsFromSlice` is currently accepting pointer to `bits` instead of returning array ([32]uint64). Remove duffcopy when this (inlined) function is processed since we no longer create another big array, only duffcopy once on `makeBits` for `v` bits.

```c
goos: linux goarch: amd64 pkg: github.com/muktihari/fit/decoder
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
       │   old.txt    │               new.txt                │
       │    sec/op    │    sec/op     vs base                │
Bits-4   808.7n ± 15%   381.7n ± 12%  -52.80% (p=0.000 n=10)

       │  old.txt   │            new.txt             │
       │    B/op    │    B/op     vs base            │
Bits-4   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

       │  old.txt   │            new.txt             │
       │ allocs/op  │ allocs/op   vs base            │
Bits-4   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

```