### PR TITLE
chore: decoder make early break when containing value out of bits

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -787,12 +787,8 @@ func (d *Decoder) expandComponents(mesg *proto.Message, containingValue proto.Va
 		return
 	}
 
-	var componentField proto.Field
 	for i := range components {
 		component := &components[i]
-
-		componentField = d.options.factory.CreateField(mesg.Num, component.FieldNum)
-		componentField.IsExpandedField = true
 
 		// A component can only have max 32 bits value.
 		val, ok := vbits.Pull(component.Bits)
@@ -803,6 +799,9 @@ func (d *Decoder) expandComponents(mesg *proto.Message, containingValue proto.Va
 		if component.Accumulate {
 			val = d.accumulator.Accumulate(mesg.Num, component.FieldNum, val, component.Bits)
 		}
+
+		componentField := d.options.factory.CreateField(mesg.Num, component.FieldNum)
+		componentField.IsExpandedField = true
 
 		scaledValue := float64(val)/component.Scale - component.Offset
 		val = uint32((scaledValue + componentField.Offset) * componentField.Scale)


### PR DESCRIPTION
- We don't need to create a `componentField` if the `containingValue` is out of bits anyway.
- We no longer need to declare `componentField` outside the loop since it will never goes out of for-loop scope. It was declared that way due to performance issue at that time when our early implementation pass that variable as a pointer reference, causing it goes out of scope so escape analysis move it to the heap. Now, it's no longer an issue since we pass the `value` directly instead of the pointer of the `field`.