### PR TITLE
refactor: PeekFileHeader now returns value instead of pointer

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -331,11 +331,11 @@ func (d *Decoder) discardMessages() (err error) {
 // PeekFileHeader decodes only up to FileHeader (first 12-14 bytes) without decoding the whole reader.
 //
 // If we choose to continue, Decode picks up where this left then continue decoding next messages instead of starting from zero.
-func (d *Decoder) PeekFileHeader() (*proto.FileHeader, error) {
+func (d *Decoder) PeekFileHeader() (proto.FileHeader, error) {
 	if d.err = d.decodeFileHeaderOnce(); d.err != nil {
-		return nil, fmt.Errorf("decode file header [byte pos: %d]: %w", d.n, d.err)
+		return proto.FileHeader{}, fmt.Errorf("decode file header [byte pos: %d]: %w", d.n, d.err)
 	}
-	return &d.fileHeader, nil
+	return d.fileHeader, nil
 }
 
 // PeekFileId decodes only up to FileId message without decoding the whole reader.

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -367,7 +367,7 @@ func TestPeekFileHeader(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if diff := cmp.Diff(*fileHeader, tc.fileHeader); diff != "" {
+			if diff := cmp.Diff(fileHeader, tc.fileHeader); diff != "" {
 				t.Fatal(diff)
 			}
 		})


### PR DESCRIPTION
Returning pointer was a mistake since the way we use proto.FileHeader is by value not by pointer. Moreover, returning pointer to `d.FileHeader` poses a risk of referencing the whole Decoder struct since it shares the same memory block. And also, if user changes the returning value, it will reflect the Decode's `fit` result. We can make a copy in the local variable and returning a pointer to it, but it will produce unnecessary allocation. So returning value is preferred.