### PR TITLE
perf: encoder reduce conversion step of message definition

### DIFF
--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -1086,10 +1086,6 @@ func TestEncodeMessage(t *testing.T) {
 			if (tc.mesg.Header & proto.DevDataMask) == proto.DevDataMask {
 				t.Fatalf("message header should not contain Developer Data Flag")
 			}
-
-			if enc.mesgDef.Architecture != tc.endianness {
-				t.Fatalf("expected endianness: %d, got: %d", tc.endianness, enc.mesgDef.Architecture)
-			}
 		})
 	}
 }
@@ -1389,7 +1385,7 @@ func TestCompressTimestampInHeader(t *testing.T) {
 	}
 }
 
-func TestNewMessageDefinition(t *testing.T) {
+func TestMarshalMessageDefinition(t *testing.T) {
 	tt := []struct {
 		name    string
 		mesg    *proto.Message
@@ -1556,16 +1552,9 @@ func TestNewMessageDefinition(t *testing.T) {
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
 			enc := New(nil)
 			enc.options.endianness = tc.arch
-			mesgDef := enc.newMessageDefinition(tc.mesg)
-			if diff := cmp.Diff(mesgDef, tc.mesgDef,
-				cmp.Transformer("DeveloperFieldDefinitions",
-					func(devFields []proto.DeveloperFieldDefinition) []proto.DeveloperFieldDefinition {
-						if len(devFields) == 0 {
-							return nil
-						}
-						return devFields
-					}),
-			); diff != "" {
+			mesgDef := enc.marshalMessageDefinition(tc.mesg)
+			expected, _ := tc.mesgDef.MarshalAppend(nil)
+			if diff := cmp.Diff(expected, mesgDef); diff != "" {
 				t.Fatal(diff)
 			}
 		})


### PR DESCRIPTION
Converting `message` into `message definition's bytes representation` is clear and straightforward, we don't need to convert `message` into `message definition` first then marshal it. The life of this intermediate representation, `message definition`, was too short. 

This change not only improve performance, but I believe it also improves the mental model required to maintain this code.

```c
goos: linux goarch: amd64 pkg: benchfit
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
                           │   old.txt   │              new.txt               │
                           │   sec/op    │   sec/op     vs base               │
Encode/muktihari/fit_raw-4   54.57m ± 2%   49.48m ± 1%  -9.33% (p=0.000 n=10)
Encode/muktihari/fit-4       103.9m ± 8%   101.5m ± 6%       ~ (p=0.063 n=10)
geomean                      75.31m        70.85m       -5.93%

                           │   old.txt    │               new.txt                │
                           │     B/op     │     B/op      vs base                │
Encode/muktihari/fit_raw-4   7.512Ki ± 0%   5.965Ki ± 0%  -20.60% (p=0.000 n=10)
Encode/muktihari/fit-4       32.82Mi ± 0%   32.82Mi ± 0%   -0.00% (p=0.000 n=10)
geomean                      502.4Ki        447.7Ki       -10.89%

                           │   old.txt   │               new.txt               │
                           │  allocs/op  │  allocs/op   vs base                │
Encode/muktihari/fit_raw-4    15.00 ± 0%    13.00 ± 0%  -13.33% (p=0.000 n=10)
Encode/muktihari/fit-4       100.0k ± 0%   100.0k ± 0%   -0.00% (p=0.000 n=10)
geomean                      1.225k        1.140k        -6.91%
```