### PR TITLE
refactor: proto.Validator is now a variable instead of a type

### DIFF
--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -485,8 +485,11 @@ func TestValidateMessages(t *testing.T) {
 			enc := New(nil)
 			// Protocol Version is now selected by selectProtocolVersion method as we allow dynamic protocol version
 			// based on FileHeader. This by pass it since we don't encode file header.
-			enc.protocolValidator.ProtocolVersion = tc.protocolVersion
-			err := enc.validateMessages(tc.messages)
+			fit := &proto.FIT{
+				FileHeader: proto.FileHeader{ProtocolVersion: tc.protocolVersion},
+				Messages:   tc.messages,
+			}
+			err := enc.validate(fit)
 			if !errors.Is(err, tc.err) {
 				t.Fatalf("expected error: %v, got: %v", tc.err, err)
 			}
@@ -982,7 +985,7 @@ func TestEncodeHeader(t *testing.T) {
 				t.Fatal(diff)
 			}
 
-			if enc.protocolValidator.ProtocolVersion != tc.protocolVersion {
+			if tc.header.ProtocolVersion != tc.protocolVersion {
 				t.Fatalf("expected protocol version: %v, got: %v",
 					tc.protocolVersion, enc.options.protocolVersion)
 			}
@@ -1697,7 +1700,6 @@ func TestReset(t *testing.T) {
 				cmpopts.IgnoreUnexported(writeSeeker{}),
 				cmp.FilterValues(func(x, y MessageValidator) bool { return true }, cmp.Ignore()),
 				cmp.FilterValues(func(x, y hash.Hash16) bool { return true }, cmp.Ignore()),
-				cmp.FilterValues(func(x, y *proto.Validator) bool { return true }, cmp.Ignore()),
 				cmp.FilterValues(func(x, y *lru) bool { return true }, cmp.Ignore()),
 			); diff != "" {
 				t.Fatal(diff)

--- a/encoder/stream.go
+++ b/encoder/stream.go
@@ -39,7 +39,7 @@ func (e *StreamEncoder) WriteMessage(mesg *proto.Message) error {
 		}
 		e.fileHeaderWritten = true
 	}
-	if err := e.enc.protocolValidator.ValidateMessage(mesg); err != nil {
+	if err := proto.Validator.ValidateMessage(mesg, e.fileHeader.ProtocolVersion); err != nil {
 		return fmt.Errorf("protocol validation: mesgNum: %d (%s): %w", mesg.Num, mesg.Num, err)
 	}
 	if err := e.enc.options.messageValidator.Validate(mesg); err != nil {

--- a/encoder/stream_test.go
+++ b/encoder/stream_test.go
@@ -222,7 +222,7 @@ func TestStreamEncoderUnhappyFlow(t *testing.T) {
 
 	// Protocol validation error
 	streamEnc, _ = NewStream(mockWriterAt{})
-	streamEnc.enc.protocolValidator.ProtocolVersion = proto.V1
+	streamEnc.fileHeader.ProtocolVersion = proto.V1
 	err = streamEnc.WriteMessage(&proto.Message{Fields: []proto.Field{
 		factory.CreateField(mesgnum.Record, fieldnum.RecordSpeed1S).WithValue(make([]uint8, 256)),
 	}, DeveloperFields: []proto.DeveloperField{{}}})

--- a/proto/validator.go
+++ b/proto/validator.go
@@ -12,17 +12,14 @@ import (
 
 const ErrProtocolViolation = errorString("protocol violation")
 
-// NewValidator creates protocol validator base on given version.
-func NewValidator(protocolVersion Version) *Validator {
-	return &Validator{ProtocolVersion: protocolVersion}
-}
-
 // Validator is protocol validator
-type Validator struct{ ProtocolVersion Version }
+var Validator validator
+
+type validator struct{}
 
 // ValidateMessageDefinition validates whether the message definition contains unsupported data for the targeted version.
-func (p *Validator) ValidateMessageDefinition(mesgDef *MessageDefinition) error {
-	if p.ProtocolVersion == V1 {
+func (validator) ValidateMessageDefinition(mesgDef *MessageDefinition, v Version) error {
+	if v == V1 {
 		if len(mesgDef.DeveloperFieldDefinitions) > 0 {
 			return fmt.Errorf("protocol version 1.0 do not support developer fields: %w", ErrProtocolViolation)
 		}
@@ -37,8 +34,8 @@ func (p *Validator) ValidateMessageDefinition(mesgDef *MessageDefinition) error 
 }
 
 // ValidateMessage validates whether the message contains unsupported data for the targeted version.
-func (p *Validator) ValidateMessage(mesg *Message) error {
-	if p.ProtocolVersion == V1 {
+func (validator) ValidateMessage(mesg *Message, v Version) error {
+	if v == V1 {
 		if len(mesg.DeveloperFields) > 0 {
 			return fmt.Errorf("protocol version 1.0 do not support developer fields: %w", ErrProtocolViolation)
 		}

--- a/proto/validator_test.go
+++ b/proto/validator_test.go
@@ -68,8 +68,7 @@ func TestValidateMessageDefinition(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			validator := proto.NewValidator(tc.protocolVersion)
-			err := validator.ValidateMessageDefinition(&tc.mesgDef)
+			err := proto.Validator.ValidateMessageDefinition(&tc.mesgDef, tc.protocolVersion)
 			if !errors.Is(err, tc.err) {
 				t.Fatalf("expected err: %v, git: %v", tc.err, err)
 			}
@@ -132,8 +131,7 @@ func TestValidateMessage(t *testing.T) {
 
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
-			v := proto.NewValidator(tc.protocolVersion)
-			err := v.ValidateMessage(&tc.mesg)
+			err := proto.Validator.ValidateMessage(&tc.mesg, tc.protocolVersion)
 			if !errors.Is(err, tc.err) {
 				t.Fatalf("expected error: %v, got: %v", tc.err, err)
 			}


### PR DESCRIPTION
Protocol validator is stateless, the only thing that it needs it to perform is the protocol version which we can pass it as a function parameter. Making it a single global variable is more make sense than having to instantiate it every time we need it, this will remove unnecessary allocation for each encoder instances users have created.