### PR TITLE
fix: allow reset on zero value decoder encoder

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -187,11 +187,7 @@ func WithReadBufferSize(size int) Option {
 // Note: Decoder already implements efficient io.Reader buffering, so there's no need to wrap 'r' using *bufio.Reader;
 // doing so will only reduce performance.
 func New(r io.Reader, opts ...Option) *Decoder {
-	d := &Decoder{
-		readBuffer:  new(readBuffer),
-		accumulator: NewAccumulator(),
-		crc16:       crc16.New(),
-	}
+	d := new(Decoder)
 	d.Reset(r, opts...)
 	return d
 }
@@ -201,6 +197,12 @@ func New(r io.Reader, opts ...Option) *Decoder {
 // It is similar to New() but it retains the underlying storage for use by
 // future decode to reduce memory allocs.
 func (d *Decoder) Reset(r io.Reader, opts ...Option) {
+	if d.readBuffer == nil {
+		d.readBuffer = new(readBuffer)
+		d.accumulator = NewAccumulator()
+		d.crc16 = crc16.New()
+	}
+
 	d.reset()
 	d.n = 0 // Must reset bytes counter since it's a full reset.
 

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -171,11 +171,7 @@ func WithWriteBufferSize(size int) Option {
 // doing so will only reduce performance. If you don't want the Encoder to buffer the writing, please direct the
 // Encoder to do so using WithWriteBufferSize(0).
 func New(w io.Writer, opts ...Option) *Encoder {
-	e := &Encoder{
-		crc16:           crc16.New(),
-		localMesgNumLRU: new(lru),
-		buf:             make([]byte, 0, 1536),
-	}
+	e := new(Encoder)
 	e.Reset(w, opts...)
 	return e
 }
@@ -184,6 +180,12 @@ func New(w io.Writer, opts ...Option) *Encoder {
 // default options so any options needs to be inputed again. It is similar to New()
 // but it retains the underlying storage for use by future encode to reduce memory allocs.
 func (e *Encoder) Reset(w io.Writer, opts ...Option) {
+	if e.buf == nil {
+		e.buf = make([]byte, 0, 1536)
+		e.crc16 = crc16.New()
+		e.localMesgNumLRU = new(lru)
+	}
+
 	e.n = 0
 	e.lastFileHeaderPos = 0
 


### PR DESCRIPTION
Previously , calling method Reset() on Decoder and Encoder causes panic if they are not instantiated using New(). This PR now allows users to call Reset on its zero value e.g.:

```go
var dec decoder.Decoder
dec.Reset(f) // -> now it is allowed instead of panic

dec := new(decoder.Decoder)
dec.Reset(f) // -> now it is allowed instead of panic
```

New() func is potentially being inlined by the compiler. We have the same pattern for listener and mesgdef's structs as well.