### PR TITLE
fix: proto value unmarshal on not terminated strings

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -1028,6 +1028,8 @@ func strcount(b []byte) (size byte) {
 				size++
 			}
 			last = i + 1
+		} else if i == len(b)-1 { // case: string is not terminated
+			size++
 		}
 	}
 	return size

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -3071,3 +3071,9 @@ func BenchmarkDecodeMessageData(b *testing.B) {
 		cur = 0 // reset reader
 	}
 }
+
+func TestStrcount(t *testing.T) {
+	if v := strcount([]byte("Open\x00Water")); v != 2 {
+		t.Fatalf("expected: 2, got: %v", v)
+	}
+}

--- a/proto/value_unmarshal.go
+++ b/proto/value_unmarshal.go
@@ -208,6 +208,8 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 						size++
 					}
 					last = i + 1
+				} else if i == len(b)-1 { // case: string is not terminated
+					size++
 				}
 			}
 			last = 0
@@ -220,6 +222,10 @@ func UnmarshalValue(b []byte, arch byte, baseType basetype.BaseType, profileType
 						}
 					}
 					last = i + 1
+				} else if i == len(b)-1 { // case: string is not terminated
+					if s := utf8String(b[last : i+1]); len(s) > 0 {
+						vals = append(vals, s)
+					}
 				}
 			}
 			return SliceString(vals), nil

--- a/proto/value_unmarshal_test.go
+++ b/proto/value_unmarshal_test.go
@@ -181,6 +181,11 @@ func TestValueUnmarshalStringValue(t *testing.T) {
 		err   error
 	}{
 		{
+			in:    []byte("Walk or jog lightly."),
+			array: false,
+			out:   []string{"Walk or jog lightly."},
+		},
+		{
 			in:    []byte("Walk or jog lightly.\x00��\x00"),
 			array: false,
 			out:   []string{"Walk or jog lightly."},
@@ -194,6 +199,16 @@ func TestValueUnmarshalStringValue(t *testing.T) {
 			in:    []byte("Walk or jog lightly.\x00��\x00"),
 			array: true,
 			out:   []string{"Walk or jog lightly."},
+		},
+		{
+			in:    []byte("Open\x00Water\x00"),
+			array: true,
+			out:   []string{"Open", "Water"},
+		},
+		{
+			in:    []byte("Open\x00Water"),
+			array: true,
+			out:   []string{"Open", "Water"},
 		},
 	}
 


### PR DESCRIPTION
This is an edge case. We fix this in case if we encounter an array of string which does not terminated properly. And to ensure our logic consistent across single string and array of string.

We already have the ability to unmarshal string without utf8 null terminated if it's a single value:
```
"Open\x00" -> "Open"
"Open"     -> "Open"
```
However, when handling array value, we lost the last element if it does not end with zero

```
"Open\x00Water\x00" -> []string{"Open", "Water"}
"Open\x00Water"     -> []string{"Open"}           // <- We lose "Water"
```

This PR solve the issue:
```
"Open\x00Water" -> []string{"Open", "Water"}
```