### PR TITLE
refactor!: make decoder accumulator 64 bit and un-export it

### DIFF
--- a/decoder/accumulator.go
+++ b/decoder/accumulator.go
@@ -9,18 +9,89 @@ import (
 	"github.com/muktihari/fit/proto"
 )
 
-// Accumulator is value accumulator.
-type Accumulator struct {
-	values []value // use slice over map since len(values) is relatively small
-}
-
-// NewAccumulator creates new accumulator.
-func NewAccumulator() *Accumulator {
-	return &Accumulator{}
+// accumulator is value accumulator.
+type accumulator struct {
+	values []accuValue // use slice over map since len(values) is relatively small
 }
 
 // Collect collects value, it will either append the value when not exist or replace existing one.
-func (a *Accumulator) Collect(mesgNum typedef.MesgNum, fieldNum byte, val uint32) {
+func (a *accumulator) Collect(mesgNum typedef.MesgNum, fieldNum byte, val proto.Value) {
+	switch val.Type() {
+	case proto.TypeInt8:
+		a.collect(mesgNum, fieldNum, uint64(val.Int8()))
+	case proto.TypeUint8:
+		a.collect(mesgNum, fieldNum, uint64(val.Uint8()))
+	case proto.TypeInt16:
+		a.collect(mesgNum, fieldNum, uint64(val.Int16()))
+	case proto.TypeUint16:
+		a.collect(mesgNum, fieldNum, uint64(val.Uint16()))
+	case proto.TypeInt32:
+		a.collect(mesgNum, fieldNum, uint64(val.Int32()))
+	case proto.TypeUint32:
+		a.collect(mesgNum, fieldNum, uint64(val.Uint32()))
+	case proto.TypeInt64:
+		a.collect(mesgNum, fieldNum, uint64(val.Int64()))
+	case proto.TypeUint64:
+		a.collect(mesgNum, fieldNum, uint64(val.Uint64()))
+	case proto.TypeFloat32:
+		a.collect(mesgNum, fieldNum, uint64(val.Float32()))
+	case proto.TypeFloat64:
+		a.collect(mesgNum, fieldNum, uint64(val.Float64()))
+	case proto.TypeSliceInt8:
+		vals := val.SliceInt8()
+		if n := len(vals); n > 0 {
+			a.collect(mesgNum, fieldNum, uint64(vals[n-1]))
+		}
+	case proto.TypeSliceUint8:
+		vals := val.SliceUint8()
+		if n := len(vals); n > 0 {
+			a.collect(mesgNum, fieldNum, uint64(vals[n-1]))
+		}
+	case proto.TypeSliceInt16:
+		vals := val.SliceInt16()
+		if n := len(vals); n > 0 {
+			a.collect(mesgNum, fieldNum, uint64(vals[n-1]))
+		}
+	case proto.TypeSliceUint16:
+		vals := val.SliceUint16()
+		if n := len(vals); n > 0 {
+			a.collect(mesgNum, fieldNum, uint64(vals[n-1]))
+		}
+	case proto.TypeSliceInt32:
+		vals := val.SliceInt32()
+		if n := len(vals); n > 0 {
+			a.collect(mesgNum, fieldNum, uint64(vals[n-1]))
+		}
+	case proto.TypeSliceUint32:
+		vals := val.SliceUint32()
+		if n := len(vals); n > 0 {
+			a.collect(mesgNum, fieldNum, uint64(vals[n-1]))
+		}
+	case proto.TypeSliceInt64:
+		vals := val.SliceInt64()
+		if n := len(vals); n > 0 {
+			a.collect(mesgNum, fieldNum, uint64(vals[n-1]))
+		}
+	case proto.TypeSliceUint64:
+		vals := val.SliceUint64()
+		if n := len(vals); n > 0 {
+			a.collect(mesgNum, fieldNum, uint64(vals[n-1]))
+		}
+	case proto.TypeSliceFloat32:
+		vals := val.SliceFloat32()
+		if n := len(vals); n > 0 {
+			a.collect(mesgNum, fieldNum, uint64(vals[n-1]))
+		}
+	case proto.TypeSliceFloat64:
+		vals := val.SliceFloat64()
+		if n := len(vals); n > 0 {
+			a.collect(mesgNum, fieldNum, uint64(vals[n-1]))
+		}
+	}
+}
+
+// collect collects uint64 value, it will either append the value when not exist or replace existing one.
+func (a *accumulator) collect(mesgNum typedef.MesgNum, fieldNum byte, val uint64) {
 	for i := range a.values {
 		av := &a.values[i]
 		if av.mesgNum == mesgNum && av.fieldNum == fieldNum {
@@ -29,7 +100,7 @@ func (a *Accumulator) Collect(mesgNum typedef.MesgNum, fieldNum byte, val uint32
 			return
 		}
 	}
-	a.values = append(a.values, value{
+	a.values = append(a.values, accuValue{
 		mesgNum:  mesgNum,
 		fieldNum: fieldNum,
 		value:    val,
@@ -37,95 +108,19 @@ func (a *Accumulator) Collect(mesgNum typedef.MesgNum, fieldNum byte, val uint32
 	})
 }
 
-// Collect collects value, it will either append the value when not exist or replace existing one.
-func (a *Accumulator) CollectValue(mesgNum typedef.MesgNum, fieldNum byte, val proto.Value) {
-	switch val.Type() {
-	case proto.TypeInt8:
-		a.Collect(mesgNum, fieldNum, uint32(val.Int8()))
-	case proto.TypeUint8:
-		a.Collect(mesgNum, fieldNum, uint32(val.Uint8()))
-	case proto.TypeInt16:
-		a.Collect(mesgNum, fieldNum, uint32(val.Int16()))
-	case proto.TypeUint16:
-		a.Collect(mesgNum, fieldNum, uint32(val.Uint16()))
-	case proto.TypeInt32:
-		a.Collect(mesgNum, fieldNum, uint32(val.Int32()))
-	case proto.TypeUint32:
-		a.Collect(mesgNum, fieldNum, uint32(val.Uint32()))
-	case proto.TypeInt64:
-		a.Collect(mesgNum, fieldNum, uint32(val.Int64()))
-	case proto.TypeUint64:
-		a.Collect(mesgNum, fieldNum, uint32(val.Uint64()))
-	case proto.TypeFloat32:
-		a.Collect(mesgNum, fieldNum, uint32(val.Float32()))
-	case proto.TypeFloat64:
-		a.Collect(mesgNum, fieldNum, uint32(val.Float64()))
-	case proto.TypeSliceInt8:
-		vals := val.SliceInt8()
-		if n := len(vals); n > 0 {
-			a.Collect(mesgNum, fieldNum, uint32(vals[n-1]))
-		}
-	case proto.TypeSliceUint8:
-		vals := val.SliceUint8()
-		if n := len(vals); n > 0 {
-			a.Collect(mesgNum, fieldNum, uint32(vals[n-1]))
-		}
-	case proto.TypeSliceInt16:
-		vals := val.SliceInt16()
-		if n := len(vals); n > 0 {
-			a.Collect(mesgNum, fieldNum, uint32(vals[n-1]))
-		}
-	case proto.TypeSliceUint16:
-		vals := val.SliceUint16()
-		if n := len(vals); n > 0 {
-			a.Collect(mesgNum, fieldNum, uint32(vals[n-1]))
-		}
-	case proto.TypeSliceInt32:
-		vals := val.SliceInt32()
-		if n := len(vals); n > 0 {
-			a.Collect(mesgNum, fieldNum, uint32(vals[n-1]))
-		}
-	case proto.TypeSliceUint32:
-		vals := val.SliceUint32()
-		if n := len(vals); n > 0 {
-			a.Collect(mesgNum, fieldNum, uint32(vals[n-1]))
-		}
-	case proto.TypeSliceInt64:
-		vals := val.SliceInt64()
-		if n := len(vals); n > 0 {
-			a.Collect(mesgNum, fieldNum, uint32(vals[n-1]))
-		}
-	case proto.TypeSliceUint64:
-		vals := val.SliceUint64()
-		if n := len(vals); n > 0 {
-			a.Collect(mesgNum, fieldNum, uint32(vals[n-1]))
-		}
-	case proto.TypeSliceFloat32:
-		vals := val.SliceFloat32()
-		if n := len(vals); n > 0 {
-			a.Collect(mesgNum, fieldNum, uint32(vals[n-1]))
-		}
-	case proto.TypeSliceFloat64:
-		vals := val.SliceFloat64()
-		if n := len(vals); n > 0 {
-			a.Collect(mesgNum, fieldNum, uint32(vals[n-1]))
-		}
-	}
-}
-
 // Accumulate calculates the accumulated value and update it accordingly. If targeted value
 // does not exist, it will be collected and the original value will be returned.
-func (a *Accumulator) Accumulate(mesgNum typedef.MesgNum, destFieldNum byte, val uint32, bits byte) uint32 {
+func (a *accumulator) Accumulate(mesgNum typedef.MesgNum, destFieldNum byte, val uint64, bits byte) uint64 {
 	for i := range a.values {
 		av := &a.values[i]
 		if av.mesgNum == mesgNum && av.fieldNum == destFieldNum {
-			var mask uint32 = (1 << bits) - 1
+			var mask uint64 = (1 << bits) - 1
 			av.value += (val - av.last) & mask
 			av.last = val
 			return av.value
 		}
 	}
-	a.values = append(a.values, value{
+	a.values = append(a.values, accuValue{
 		mesgNum:  mesgNum,
 		fieldNum: destFieldNum,
 		value:    val,
@@ -136,11 +131,11 @@ func (a *Accumulator) Accumulate(mesgNum typedef.MesgNum, destFieldNum byte, val
 
 // Reset resets the accumulator. It retains the underlying storage for use by
 // future use to reduce memory allocs.
-func (a *Accumulator) Reset() { a.values = a.values[:0] }
+func (a *accumulator) Reset() { a.values = a.values[:0] }
 
-type value struct {
+type accuValue struct {
 	mesgNum  typedef.MesgNum
 	fieldNum byte
-	last     uint32
-	value    uint32
+	last     uint64
+	value    uint64
 }

--- a/decoder/accumulator_test.go
+++ b/decoder/accumulator_test.go
@@ -19,8 +19,8 @@ func TestAccumulatorCollect(t *testing.T) {
 	type value struct {
 		mesgNum      typedef.MesgNum
 		destFieldNum byte
-		value        uint32
-		expected     uint32
+		value        uint64
+		expected     uint64
 	}
 
 	tt := []struct {
@@ -73,10 +73,10 @@ func TestAccumulatorCollect(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			accumu := NewAccumulator()
+			accumu := new(accumulator)
 			for i := range tc.collects {
 				val := &tc.collects[i]
-				accumu.Collect(val.mesgNum, val.destFieldNum, val.value)
+				accumu.collect(val.mesgNum, val.destFieldNum, val.value)
 			}
 			for i := range tc.toAccumulates {
 				val := &tc.toAccumulates[i]
@@ -92,36 +92,36 @@ func TestAccumulatorCollect(t *testing.T) {
 func TestAccumulatorCollectValue(t *testing.T) {
 	tt := []struct {
 		val               proto.Value
-		accumulatedValues []value
+		accumulatedValues []accuValue
 	}{
-		{val: proto.Int8(1), accumulatedValues: []value{{last: 1, value: 1}}},
-		{val: proto.Uint8(2), accumulatedValues: []value{{last: 2, value: 2}}},
-		{val: proto.Int16(3), accumulatedValues: []value{{last: 3, value: 3}}},
-		{val: proto.Uint16(4), accumulatedValues: []value{{last: 4, value: 4}}},
-		{val: proto.Int32(5), accumulatedValues: []value{{last: 5, value: 5}}},
-		{val: proto.Uint32(6), accumulatedValues: []value{{last: 6, value: 6}}},
-		{val: proto.Int64(7), accumulatedValues: []value{{last: 7, value: 7}}},
-		{val: proto.Uint64(8), accumulatedValues: []value{{last: 8, value: 8}}},
-		{val: proto.Float32(9), accumulatedValues: []value{{last: 9, value: 9}}},
-		{val: proto.Float64(10), accumulatedValues: []value{{last: 10, value: 10}}},
-		{val: proto.SliceInt8([]int8{1, 2}), accumulatedValues: []value{{last: 2, value: 2}}},
-		{val: proto.SliceUint8([]uint8{2, 3}), accumulatedValues: []value{{last: 3, value: 3}}},
-		{val: proto.SliceInt16([]int16{3, 4}), accumulatedValues: []value{{last: 4, value: 4}}},
-		{val: proto.SliceUint16([]uint16{4, 5}), accumulatedValues: []value{{last: 5, value: 5}}},
-		{val: proto.SliceInt32([]int32{5, 6}), accumulatedValues: []value{{last: 6, value: 6}}},
-		{val: proto.SliceUint32([]uint32{6, 7}), accumulatedValues: []value{{last: 7, value: 7}}},
-		{val: proto.SliceInt64([]int64{7, 8}), accumulatedValues: []value{{last: 8, value: 8}}},
-		{val: proto.SliceUint64([]uint64{8, 9}), accumulatedValues: []value{{last: 9, value: 9}}},
-		{val: proto.SliceFloat32([]float32{9, 10}), accumulatedValues: []value{{last: 10, value: 10}}},
-		{val: proto.SliceFloat64([]float64{10, 11}), accumulatedValues: []value{{last: 11, value: 11}}},
+		{val: proto.Int8(1), accumulatedValues: []accuValue{{last: 1, value: 1}}},
+		{val: proto.Uint8(2), accumulatedValues: []accuValue{{last: 2, value: 2}}},
+		{val: proto.Int16(3), accumulatedValues: []accuValue{{last: 3, value: 3}}},
+		{val: proto.Uint16(4), accumulatedValues: []accuValue{{last: 4, value: 4}}},
+		{val: proto.Int32(5), accumulatedValues: []accuValue{{last: 5, value: 5}}},
+		{val: proto.Uint32(6), accumulatedValues: []accuValue{{last: 6, value: 6}}},
+		{val: proto.Int64(7), accumulatedValues: []accuValue{{last: 7, value: 7}}},
+		{val: proto.Uint64(8), accumulatedValues: []accuValue{{last: 8, value: 8}}},
+		{val: proto.Float32(9), accumulatedValues: []accuValue{{last: 9, value: 9}}},
+		{val: proto.Float64(10), accumulatedValues: []accuValue{{last: 10, value: 10}}},
+		{val: proto.SliceInt8([]int8{1, 2}), accumulatedValues: []accuValue{{last: 2, value: 2}}},
+		{val: proto.SliceUint8([]uint8{2, 3}), accumulatedValues: []accuValue{{last: 3, value: 3}}},
+		{val: proto.SliceInt16([]int16{3, 4}), accumulatedValues: []accuValue{{last: 4, value: 4}}},
+		{val: proto.SliceUint16([]uint16{4, 5}), accumulatedValues: []accuValue{{last: 5, value: 5}}},
+		{val: proto.SliceInt32([]int32{5, 6}), accumulatedValues: []accuValue{{last: 6, value: 6}}},
+		{val: proto.SliceUint32([]uint32{6, 7}), accumulatedValues: []accuValue{{last: 7, value: 7}}},
+		{val: proto.SliceInt64([]int64{7, 8}), accumulatedValues: []accuValue{{last: 8, value: 8}}},
+		{val: proto.SliceUint64([]uint64{8, 9}), accumulatedValues: []accuValue{{last: 9, value: 9}}},
+		{val: proto.SliceFloat32([]float32{9, 10}), accumulatedValues: []accuValue{{last: 10, value: 10}}},
+		{val: proto.SliceFloat64([]float64{10, 11}), accumulatedValues: []accuValue{{last: 11, value: 11}}},
 	}
 
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("[%d] %v", i, tc.val.Any()), func(t *testing.T) {
-			accumu := NewAccumulator()
-			accumu.CollectValue(0, 0, tc.val)
+			accumu := new(accumulator)
+			accumu.Collect(0, 0, tc.val)
 			if diff := cmp.Diff(accumu.values, tc.accumulatedValues,
-				cmp.AllowUnexported(value{}),
+				cmp.AllowUnexported(accuValue{}),
 			); diff != "" {
 				t.Fatal(diff)
 			}
@@ -130,8 +130,8 @@ func TestAccumulatorCollectValue(t *testing.T) {
 }
 
 func TestAccumulatorReset(t *testing.T) {
-	accumu := NewAccumulator()
-	accumu.Collect(mesgnum.Record, fieldnum.RecordSpeed, 1000)
+	accumu := new(accumulator)
+	accumu.collect(mesgnum.Record, fieldnum.RecordSpeed, 1000)
 
 	if len(accumu.values) != 1 {
 		t.Fatalf("expected AccumulatedValues is 1, got: %d", len(accumu.values))

--- a/decoder/bits.go
+++ b/decoder/bits.go
@@ -94,7 +94,7 @@ func bitsFromSlice[S []E, E numeric](v *bits, s S, bitsize int) {
 //
 // We allow pulling bits value as long as the store's size is not zero.
 // Let's say we have 16 bits left in the store, but the caller asks for 32 bits, we return that remaining 16 bits.
-func (v *bits) Pull(bitsize byte) (val uint32, ok bool) {
+func (v *bits) Pull(bitsize byte) (val uint64, ok bool) {
 	if v.size == 0 {
 		return 0, false
 	}
@@ -103,9 +103,9 @@ func (v *bits) Pull(bitsize byte) (val uint32, ok bool) {
 	size := v.size - uint64(bitsize)
 	v.size = size &^ uint64(int64(size)>>63)
 
-	mask := uint64(1)<<bitsize - 1  // e.g. (1 << 8) - 1     = 255
-	val = uint32(v.store[0] & mask) // e.g. 0x27010E08 & 255 = 0x08
-	v.store[0] >>= bitsize          // e.g. 0x27010E08 >> 8  = 0x27010E
+	mask := uint64(1)<<bitsize - 1 // e.g. (1 << 8) - 1     = 255
+	val = v.store[0] & mask        // e.g. 0x27010E08 & 255 = 0x08
+	v.store[0] >>= bitsize         // e.g. 0x27010E08 >> 8  = 0x27010E
 
 	for i := 1; i < len(v.store); i++ {
 		if v.store[i] == 0 {

--- a/decoder/bits_test.go
+++ b/decoder/bits_test.go
@@ -224,7 +224,7 @@ func TestMakeBits(t *testing.T) {
 func TestBitsPull(t *testing.T) {
 	type pull struct {
 		bits  byte
-		value uint32
+		value uint64
 		vbits bits
 		ok    bool
 	}
@@ -282,12 +282,12 @@ func TestBitsPull(t *testing.T) {
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("[%d] %s", i, tc.name), func(t *testing.T) {
 			for j, p := range tc.pulls {
-				u32, ok := tc.vbits.Pull(p.bits)
+				value, ok := tc.vbits.Pull(p.bits)
 				if ok != p.ok {
 					t.Fatalf("[%d] expected ok: %v, got: %v", j, p.ok, ok)
 				}
-				if u32 != p.value {
-					t.Fatalf("[%d] expected value: %v, got: %v", j, p.value, u32)
+				if value != p.value {
+					t.Fatalf("[%d] expected value: %v, got: %v", j, p.value, value)
 				}
 				if tc.vbits != p.vbits {
 					t.Fatalf("[%d] expected bits:\n%v,\n got:\n%v", j, tc.vbits, p.vbits)

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -51,7 +51,7 @@ const (
 type Decoder struct {
 	readBuffer  *readBuffer // read from io.Reader with buffer without extra copying.
 	n           int64       // n is a read bytes counter, always moving forward, do not reset (except on full reset).
-	accumulator *Accumulator
+	accumulator *accumulator
 	crc16       hash.Hash16
 	err         error // Any error occurs during process.
 
@@ -199,7 +199,7 @@ func New(r io.Reader, opts ...Option) *Decoder {
 func (d *Decoder) Reset(r io.Reader, opts ...Option) {
 	if d.readBuffer == nil {
 		d.readBuffer = new(readBuffer)
-		d.accumulator = NewAccumulator()
+		d.accumulator = new(accumulator)
 		d.crc16 = crc16.New()
 	}
 
@@ -744,7 +744,7 @@ func (d *Decoder) decodeFields(mesgDef *proto.MessageDefinition, mesg *proto.Mes
 		}
 
 		if field.Accumulate && d.options.shouldExpandComponent {
-			d.accumulator.CollectValue(mesg.Num, field.Num, field.Value)
+			d.accumulator.Collect(mesg.Num, field.Num, field.Value)
 		}
 
 		mesg.Fields = append(mesg.Fields, field)
@@ -800,8 +800,8 @@ func (d *Decoder) expandComponents(mesg *proto.Message, containingValue proto.Va
 		componentField.IsExpandedField = true
 
 		scaledValue := float64(val)/component.Scale - component.Offset
-		val = uint32((scaledValue + componentField.Offset) * componentField.Scale)
-		value := convertUint32ToValue(val, componentField.BaseType)
+		val = uint64((scaledValue + componentField.Offset) * componentField.Scale)
+		value := convertUint64ToValue(val, componentField.BaseType)
 
 		// All components fields are appended, so it makes more sense to search from the last order.
 		// Our goal is to create new or update existing expanded field. However, there is an edge case
@@ -1033,9 +1033,9 @@ func strcount(b []byte) (size byte) {
 	return size
 }
 
-// convertUint32ToValue val into proto.Value of targeted baseType.
+// convertUint64ToValue val into proto.Value of targeted baseType.
 // If targeted baseType is not supported, it returns proto.Value{}.
-func convertUint32ToValue(val uint32, baseType basetype.BaseType) proto.Value {
+func convertUint64ToValue(val uint64, baseType basetype.BaseType) proto.Value {
 	switch baseType {
 	case basetype.Sint8:
 		return proto.Int8(int8(val))

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -1763,7 +1763,7 @@ func TestDecodeFields(t *testing.T) {
 		mesgdef           *proto.MessageDefinition
 		mesg              proto.Message
 		validateFn        func(mesg proto.Message) error
-		accumulatedValues []value
+		accumulatedValues []accuValue
 		err               error
 	}{
 		{
@@ -1812,7 +1812,7 @@ func TestDecodeFields(t *testing.T) {
 					},
 				},
 			},
-			accumulatedValues: []value{
+			accumulatedValues: []accuValue{
 				{
 					mesgNum:  mesgnum.Record,
 					fieldNum: fieldnum.RecordDistance,
@@ -1852,7 +1852,7 @@ func TestDecodeFields(t *testing.T) {
 					},
 				},
 			},
-			accumulatedValues: []value{
+			accumulatedValues: []accuValue{
 				{
 					mesgNum:  mesgnum.Hr,
 					fieldNum: fieldnum.HrEventTimestamp,
@@ -2095,7 +2095,7 @@ func TestDecodeFields(t *testing.T) {
 				return
 			}
 			if diff := cmp.Diff(dec.accumulator.values, tc.accumulatedValues,
-				cmp.AllowUnexported(value{}),
+				cmp.AllowUnexported(accuValue{}),
 			); diff != "" {
 				t.Fatal(diff)
 			}
@@ -2112,7 +2112,7 @@ func TestDecodeFields(t *testing.T) {
 func TestExpandComponents(t *testing.T) {
 	tt := []struct {
 		name                 string
-		accumu               *Accumulator
+		accumu               *accumulator
 		mesg                 proto.Message
 		fieldsAfterExpansion []proto.Field
 	}{
@@ -2214,7 +2214,7 @@ func TestExpandComponents(t *testing.T) {
 			// event_timestamp:     "4.654296875|4.8974609375|5.6552734375|6.609375|7.5283203125|8.3984375|9.23828125|10.044921875"
 			// event_timestamp raw: "4766       |5015        |5791        |6768    |7709        |8600     |9460      |10286"
 			name: "expand components: Hr mesg's event_timestamp_12",
-			accumu: &Accumulator{values: []value{
+			accumu: &accumulator{values: []accuValue{
 				// Prior Hr message
 				{mesgNum: mesgnum.Hr, fieldNum: fieldnum.HrEventTimestamp, value: 3707, last: 3707},
 			}},
@@ -2720,7 +2720,7 @@ func TestReset(t *testing.T) {
 			dec.Reset(buf, tc.opts...)
 
 			if diff := cmp.Diff(dec, tc.dec,
-				cmp.AllowUnexported(Accumulator{}),
+				cmp.AllowUnexported(accumulator{}),
 				cmp.AllowUnexported(options{}),
 				cmp.AllowUnexported(Decoder{}),
 				cmp.AllowUnexported(readBuffer{}),
@@ -2842,7 +2842,7 @@ func TestLogs(t *testing.T) {
 
 func TestConvertUint32ToValue(t *testing.T) {
 	tt := []struct {
-		value    uint32
+		value    uint64
 		baseType basetype.BaseType
 		expected proto.Value
 	}{
@@ -2905,7 +2905,7 @@ func TestConvertUint32ToValue(t *testing.T) {
 
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("[%d] %d -> %s", i, tc.value, tc.baseType), func(t *testing.T) {
-			val := convertUint32ToValue(tc.value, tc.baseType)
+			val := convertUint64ToValue(tc.value, tc.baseType)
 			if diff := cmp.Diff(val, tc.expected,
 				cmp.Transformer("Value", func(v proto.Value) any { return v.Any() }),
 			); diff != "" {


### PR DESCRIPTION
Garmin changed the C++ implementation of Accumulator from using `uint32` to `uint64` to support 64-bit value and they mark it as a fix in their v21.201 release. Even though I don't see any accumulated field or components listed in the `Profile.xlsx` file from having `uint64` value. It seems it is to support product profile (manufacturer specific), I don't know, let's support it as well is Garmin said so.

When I take a look of the implementation in other than C++, Java uses `long` since it does not have unsigned integer AFAIK, and Swift uses `Int64` since I believe this is due to convention to use signed integer. Python ans JS are obviously do not support it natively. So precision to `uint64` is not mandatory. But since C++ is closest language to Go, let's use `uint64`.

This is a refactor since Accumulator and its methods are exported, changing the method signature is a breaking change. I believe exporting it was a mistake since I don't think regular users will need it as it's  tightly coupled with component expansion on handling `bits` value and we don't export it. If we're going to break it, let's un-export it and make it private so if there is any future changes, we don't break user-space again. If users request to export it, let's ask them to copy the implementation to their code, because it's probably an edge-case if they need it.