### PR TITLE
fix: checksum logic for file header's size 12

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -461,7 +461,10 @@ func (d *Decoder) decodeFileHeader() error {
 	if size != 12 && size != 14 { // current spec is either 12 or 14
 		return fmt.Errorf("file header size [%d] is invalid: %w", size, ErrNotFITFile)
 	}
-	_, _ = d.crc16.Write(b)
+
+	if d.options.shouldChecksum {
+		_, _ = d.crc16.Write(b)
+	}
 
 	rem := int(size - 1)
 	b, err = d.readBuffer.ReadN(rem)
@@ -487,22 +490,21 @@ func (d *Decoder) decodeFileHeader() error {
 		return fmt.Errorf("invalid data size: %w", ErrNotFITFile)
 	}
 
+	if d.options.shouldChecksum {
+		_, _ = d.crc16.Write(b[:11])
+	}
+
+	// If size is 12, checksum both file header and data together.
+	// If size is 14, checksum file header and data separately.
 	if size == 14 {
 		d.fileHeader.CRC = binary.LittleEndian.Uint16(b[11:13])
+		calculated := d.crc16.Sum16()
+		d.crc16.Reset() // Reset since checksuming file header for size 14 ends here.
+		if d.options.shouldChecksum && d.fileHeader.CRC != 0 && d.fileHeader.CRC != calculated {
+			return fmt.Errorf("expected file header's crc: %d, got: %d: %w",
+				d.fileHeader.CRC, calculated, ErrCRCChecksumMismatch)
+		}
 	}
-
-	if d.fileHeader.CRC == 0x0000 || !d.options.shouldChecksum { // do not need to check file header's crc integrity.
-		d.crc16.Reset()
-		return nil
-	}
-
-	_, _ = d.crc16.Write(b[:len(b)-2])
-	if d.crc16.Sum16() != d.fileHeader.CRC { // check file header integrity
-		return fmt.Errorf("expected file header's crc: %d, got: %d: %w",
-			d.fileHeader.CRC, d.crc16.Sum16(), ErrCRCChecksumMismatch)
-	}
-
-	d.crc16.Reset() // this hash will be re-used for calculating data integrity.
 
 	return nil
 }

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -68,15 +68,7 @@ func TestDecodeRealFiles(t *testing.T) {
 
 			_, err = dec.DecodeWithContext(context.Background())
 			if err != nil {
-				// NOTE: Doubts exist regarding the integrity of these files.
-				if info.Name() == "Settings.fit" || info.Name() == "WeightScaleMultiUser.fit" {
-					if errors.Is(err, ErrCRCChecksumMismatch) {
-						return nil
-					}
-				}
-
 				t.Errorf("filename: %s: %v", info.Name(), err)
-
 				return nil
 			}
 

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -240,7 +240,14 @@ func (e *Encoder) Encode(fit *proto.FIT) (err error) {
 	}
 	switch e.w.(type) {
 	case io.WriterAt, io.WriteSeeker:
-		err = e.encodeWithDirectUpdateStrategy(fit)
+		if fit.FileHeader.Size == 12 {
+			// When size is 12, we need to do checksum for both file header and data combined.
+			// Since we can only know file header's data size after calculating all messages,
+			// we can only use this strategy.
+			err = e.encodeWithEarlyCheckStrategy(fit)
+		} else {
+			err = e.encodeWithDirectUpdateStrategy(fit)
+		}
 	case io.Writer:
 		err = e.encodeWithEarlyCheckStrategy(fit)
 	default:
@@ -344,7 +351,8 @@ func (e *Encoder) encodeFileHeader(header *proto.FileHeader) error {
 
 	b, _ := header.MarshalAppend(e.buf[:0])
 
-	if header.Size != 14 {
+	if header.Size == 12 {
+		_, _ = e.crc16.Write(b[:header.Size]) // Checksum both file header and data together.
 		n, err := e.w.Write(b[:header.Size])
 		e.n += int64(n)
 		return err

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -432,6 +432,40 @@ func TestEncode(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("checksum should include file header if file header's size is 12", func(t *testing.T) {
+		fit := proto.FIT{
+			FileHeader: proto.FileHeader{
+				Size:            12,
+				ProtocolVersion: proto.V1,
+				ProfileVersion:  profile.Version,
+			},
+			Messages: []proto.Message{
+				{
+					Num: mesgnum.FileId,
+					Fields: []proto.Field{
+						factory.CreateField(mesgnum.FileId, fieldnum.FileIdManufacturer).WithValue(typedef.ManufacturerDevelopment.Uint16()),
+					},
+				},
+			},
+		}
+
+		w := &bufferAt{Buffer: new(bytes.Buffer)}
+		enc := New(w)
+		if err := enc.Encode(&fit); err != nil {
+			t.Fatalf("expected nil, got: %v", err)
+		}
+
+		checksumEncoded := binary.LittleEndian.Uint16(w.Bytes()[w.Len()-2:])
+
+		hasher := crc16.New()
+		hasher.Write(w.Bytes()[:w.Len()-2])
+		checksumCalculated := hasher.Sum16()
+
+		if checksumEncoded != checksumCalculated {
+			t.Fatalf("expected checksum: encoded: %d, calculated: %d", checksumEncoded, checksumCalculated)
+		}
+	})
 }
 
 func TestValidateMessages(t *testing.T) {

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -82,7 +82,7 @@ func FuzzDecodeEncodeRoundTrip(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, in []byte) {
 		r := bytes.NewReader(in)
-		dec := decoder.New(r, decoder.WithIgnoreChecksum())
+		dec := decoder.New(r)
 
 		buf := &bufferAt{new(bytes.Buffer)}
 		enc := encoder.New(buf,


### PR DESCRIPTION
I thought when `file header`'s size is 12 (legacy), only the `data` needs to be checksummed. But it turns out that both `file header` and `data` should be checksummed together. Now test decode for `Settings.fit` and `WeightScaleMultiUser.fit` has passed.

For encoding, since we can only know file header's data size after calculating all messages, we can only use `early check strategy`. CRC checksum can only be done sequentially in current implementation.