### PR TITLE
fix: checksum logic for EncodeWithContext

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -576,7 +576,11 @@ func (e *Encoder) EncodeWithContext(ctx context.Context, fit *proto.FIT) (err er
 	}
 	switch e.w.(type) {
 	case io.WriterAt, io.WriteSeeker:
-		err = e.encodeWithDirectUpdateStrategyWithContext(ctx, fit)
+		if fit.FileHeader.Size == 12 { // See `Encode` for details.
+			err = e.encodeWithEarlyCheckStrategyWithContext(ctx, fit)
+		} else {
+			err = e.encodeWithDirectUpdateStrategyWithContext(ctx, fit)
+		}
 	case io.Writer:
 		err = e.encodeWithEarlyCheckStrategyWithContext(ctx, fit)
 	default:

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -465,6 +465,30 @@ func TestEncode(t *testing.T) {
 		if checksumEncoded != checksumCalculated {
 			t.Fatalf("expected checksum: encoded: %d, calculated: %d", checksumEncoded, checksumCalculated)
 		}
+
+		fit.FileHeader = proto.FileHeader{
+			Size:            12,
+			ProtocolVersion: proto.V1,
+			ProfileVersion:  profile.Version,
+		}
+		fit.CRC = 0
+
+		w.Reset()
+		enc.Reset(w)
+
+		if err := enc.EncodeWithContext(context.Background(), &fit); err != nil {
+			t.Fatalf("encode with context: expected nil, got: %v", err)
+		}
+
+		checksumEncoded = binary.LittleEndian.Uint16(w.Bytes()[w.Len()-2:])
+
+		hasher.Reset()
+		hasher.Write(w.Bytes()[:w.Len()-2])
+		checksumCalculated = hasher.Sum16()
+
+		if checksumEncoded != checksumCalculated {
+			t.Fatalf("encode with context: expected checksum: encoded: %d, calculated: %d", checksumEncoded, checksumCalculated)
+		}
 	})
 }
 


### PR DESCRIPTION
I forgot to add this in #641.